### PR TITLE
fix: prevent sidebar flicker on load

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -1,4 +1,10 @@
 // sidebar.js — sidebar collapse + persistent state + safe navigation
+// Apply saved collapse state early to avoid width flicker on page load
+const STORAGE_KEY = 'ambis:sidebar-collapsed';
+let initialCollapsed = false;
+try { initialCollapsed = localStorage.getItem(STORAGE_KEY) === '1'; } catch {}
+if (initialCollapsed) document.documentElement.classList.add('sidebar-collapsed');
+
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   const btn     = document.getElementById('navToggle');
@@ -16,7 +22,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // --- Config
-  const STORAGE_KEY     = 'ambis:sidebar-collapsed';
   const EXPANDED_WIDTH  = 300;
   const COLLAPSED_WIDTH = 84;
   const ANIM_MS         = 250;
@@ -81,9 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // --- Restore saved state instantly (no flicker, handled by CSS + body class)
-  let saved = false;
-  try { saved = localStorage.getItem(STORAGE_KEY) === '1'; } catch {}
-  setCollapsed(saved, { persist: false, animate: false });
+  setCollapsed(initialCollapsed, { persist: false, animate: false });
 
   // --- Toggle button (with animation)
   btn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -15,23 +15,19 @@
 
 /* collapse behavior */
 #sidebar{ transition: width .25s ease; }
-#sidebar.collapsed{ width:84px !important; }
+#sidebar.collapsed,
+.sidebar-collapsed #sidebar{ width:84px !important; }
 
 /* keep labels in flow but don't animate width */
 .sb-label{
   display:inline-block; white-space:nowrap;
   transition: opacity .15s ease, margin .15s ease; /* no width transition */
 }
-#sidebar.collapsed .sb-label{
-  opacity:0; width:0; margin-left:0; overflow:hidden;
+#sidebar.collapsed .sb-label,
+.sidebar-collapsed #sidebar .sb-label{
+  opacity:0; width:0; margin-left:0; overflow:hidden; display:none;
 }
 
 /* center items when collapsed */
-#sidebar.collapsed .sb-item{ justify-content:center; padding-left:0; padding-right:0; gap:.5rem; }
-
-#sidebar.collapsed {
-  width: 84px !important;
-}
-#sidebar.collapsed .sb-label {
-  display: none;
-}
+#sidebar.collapsed .sb-item,
+.sidebar-collapsed #sidebar .sb-item{ justify-content:center; padding-left:0; padding-right:0; gap:.5rem; }


### PR DESCRIPTION
## Summary
- apply saved collapse state before DOMContentLoaded
- add global `.sidebar-collapsed` CSS to keep width and hide labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c14e42a2308330a4568edaa211eee6