### PR TITLE
Prevent sidebar flicker on navigation

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Atur Persetujuan</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Batas Transaksi</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/biller.html
+++ b/biller.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Beli dan Bayar</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Dashboard</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Informasi Rekening</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/manajemen-pengguna.html
+++ b/manajemen-pengguna.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Manajemen Pengguna</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/mutasi.html
+++ b/mutasi.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Mutasi dan e-Statement</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Persetujuan Transaksi</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */

--- a/transfer.html
+++ b/transfer.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AMBIS — Transfer</title>
 
+  <script>
+    try {
+      if (localStorage.getItem('ambis:sidebar-collapsed') === '1') {
+        document.documentElement.classList.add('sidebar-collapsed');
+      }
+    } catch {}
+  </script>
+
   <!-- Tailwind + fonts -->
   <script>
     /* CDN JIT safelist: only classes toggled by local JS on this page */


### PR DESCRIPTION
## Summary
- Apply saved sidebar collapsed state before page rendering to avoid flicker.
- Embed localStorage check script in each page head for consistent collapsed view.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c150871c488330b8b7aa61a92f0ee6