### PR TITLE
Fix sidebar toggle after flicker patch

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -62,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sidebar.classList.toggle('collapsed', collapsed);
     document.body.classList.toggle('sidebar-collapsed', collapsed);
+    document.documentElement.classList.toggle('sidebar-collapsed', collapsed);
     applyWidth(collapsed);
 
     if (label) label.textContent = collapsed ? 'Perbesar Navigasi' : 'Perkecil Navigasi';


### PR DESCRIPTION
## Summary
- Synchronize sidebar collapse state with the `<html>` element so the toggle button works even with early flicker-prevention class.

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c152bb075c8330b2f7fc93b5749550