### PR TITLE
Add dynamic account selector and JSON-backed data

### DIFF
--- a/data/account.json
+++ b/data/account.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 1,
+    "name": "Rekening Utama",
+    "balance": 100000000000,
+    "transactions": [
+      {"date": "12 September", "description": "Ke BCA - PT Sinar Jaya Utama", "amount": -2000000},
+      {"date": "12 September", "description": "Dari BRI - PT Roti Manis Indonesia", "amount": 100000000},
+      {"date": "12 September", "description": "Ke BRI - PT Roti Manis Indonesia", "amount": -100000000},
+      {"date": "12 September", "description": "Dari BRI - PT Roti Manis Indonesia", "amount": 100000000}
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Rekening Operasional",
+    "balance": 50000000,
+    "transactions": [
+      {"date": "10 September", "description": "Pembelian ATK", "amount": -500000},
+      {"date": "11 September", "description": "Penjualan Produk", "amount": 2000000}
+    ]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -154,10 +154,7 @@
               </div>
 
               <div class="relative mb-3">
-                <select class="w-full h-[52px] text-base rounded-xl border border-slate-200 bg-white pl-3 pr-10 appearance-none">
-                  <option>Rekening Utama</option>
-                  <option>Rekening Operasional</option>
-                </select>
+                <select id="accountSelect" class="w-full h-[52px] text-base rounded-xl border border-slate-200 bg-white pl-3 pr-10 appearance-none"></select>
                 <svg class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-400" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
                   <path fill="currentColor" d="M7 10l5 5 5-5z"/>
                 </svg>
@@ -377,83 +374,7 @@
                     <th class="px-4 py-3"></th>
                   </tr>
                 </thead>
-                <tbody class="divide-y">
-                  <tr class="hover:bg-slate-50">
-                    <td class="px-4 py-3 flex items-center gap-2">
-                      <span class="w-10 h-10 rounded-full bg-rose-100 border border-rose-300 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/transfer-out.svg" alt="" class="w-6 h-6 object-contain">
-                      </span>
-                      Ke BCA - PT Sinar Jaya Utama
-                    </td>
-                    <td class="px-4 py-3"><span class="text-xs rounded border px-2 py-0.5">Rekening Utama</span></td>
-                    <td class="px-4 py-3">12 September</td>
-                    <td class="px-4 py-3">Rp2.000.000</td>
-                    <td class="px-4 py-3">
-                      <button class="w-6 h-6 border border-slate-200 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/detail.svg" alt="" class="w-3 h-3 object-contain">
-                      </button>
-                    </td>
-                  </tr>
-
-                  <tr class="hover:bg-slate-50">
-                    <td class="px-4 py-3 flex items-center gap-2">
-                      <span class="w-10 h-10 rounded-full bg-emerald-100 border border-emerald-300 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/transfer-in.svg" alt="" class="w-6 h-6 object-contain">
-                      </span>
-                      Dari BRI - PT Roti Manis Indonesia
-                    </td>
-                    <td class="px-4 py-3"><span class="text-xs rounded border px-2 py-0.5">Rekening Utama</span></td>
-                    <td class="px-4 py-3">12 September</td>
-                    <td class="px-4 py-3">Rp100.000.000</td>
-                    <td class="px-4 py-3">
-                      <button class="w-6 h-6 border border-slate-200 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/detail.svg" alt="" class="w-3 h-3 object-contain">
-                      </button>
-                    </td>
-                  </tr>
-
-                  <tr class="hover:bg-slate-50">
-                    <td class="px-4 py-3 flex items-center gap-2">
-                      <span class="w-10 h-10 rounded-full bg-rose-100 border border-rose-300 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/transfer-out.svg" alt="" class="w-6 h-6 object-contain">
-                      </span>
-                      Ke BRI - PT Roti Manis Indonesia
-                    </td>
-                    <td class="px-4 py-3"><span class="text-xs rounded border px-2 py-0.5">Rekening Utama</span></td>
-                    <td class="px-4 py-3">12 September</td>
-                    <td class="px-4 py-3">Rp100.000.000</td>
-                    <td class="px-4 py-3">
-                      <button class="w-6 h-6 border border-slate-200 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/detail.svg" alt="" class="w-3 h-3 object-contain">
-                      </button>
-                    </td>
-                  </tr>
-
-                  <tr class="hover:bg-slate-50">
-                    <td class="px-4 py-3 flex items-center gap-2">
-                      <span class="w-10 h-10 rounded-full bg-emerald-100 border border-emerald-300 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/transfer-in.svg" alt="" class="w-6 h-6 object-contain">
-                      </span>
-                      Dari BRI - PT Roti Manis Indonesia
-                    </td>
-                    <td class="px-4 py-3"><span class="text-xs rounded border px-2 py-0.5">Rekening Utama</span></td>
-                    <td class="px-4 py-3">12 September</td>
-                    <td class="px-4 py-3">Rp100.000.000</td>
-                    <td class="px-4 py-3">
-                      <button class="w-6 h-6 border border-slate-200 grid place-items-center">
-                        <!-- use your PNG icon -->
-                        <img src="img/dashboard/akses-cepat/detail.svg" alt="" class="w-3 h-3 object-contain">
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
+                <tbody id="transactionList" class="divide-y"></tbody>
               </table>
             </div>
           </div>
@@ -464,6 +385,7 @@
     <!-- ============ /MAIN ============ -->
   </div>
 
+  <script src="index.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+const accountSelect = document.getElementById('accountSelect');
+const balanceEl = document.getElementById('dashBalanceValue');
+const transactionListEl = document.getElementById('transactionList');
+
+let accounts = [];
+
+fetch('data/account.json')
+  .then((res) => res.json())
+  .then((data) => {
+    accounts = data;
+    populateSelect();
+    accountSelect.addEventListener('change', updateView);
+    updateView();
+  })
+  .catch((err) => {
+    console.error('Failed to load accounts', err);
+  });
+
+function populateSelect() {
+  accountSelect.innerHTML = '';
+  accounts.forEach((acc) => {
+    const opt = document.createElement('option');
+    opt.value = acc.id;
+    opt.textContent = acc.name;
+    if (acc.name === 'Rekening Utama') {
+      opt.selected = true;
+    }
+    accountSelect.appendChild(opt);
+  });
+}
+
+function updateView() {
+  const selectedId = parseInt(accountSelect.value, 10);
+  const account = accounts.find((a) => a.id === selectedId);
+  if (!account) return;
+
+  balanceEl.textContent = formatCurrency(account.balance);
+
+  transactionListEl.innerHTML = '';
+  account.transactions.forEach((tx) => {
+    const tr = document.createElement('tr');
+    tr.className = 'hover:bg-slate-50';
+    tr.innerHTML = `
+      <td class="px-4 py-3">${tx.description}</td>
+      <td class="px-4 py-3"><span class="text-xs rounded border px-2 py-0.5">${account.name}</span></td>
+      <td class="px-4 py-3">${tx.date}</td>
+      <td class="px-4 py-3">${formatCurrency(tx.amount)}</td>
+      <td class="px-4 py-3"></td>
+    `;
+    transactionListEl.appendChild(tr);
+  });
+}
+
+function formatCurrency(num) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+  }).format(num);
+}


### PR DESCRIPTION
## Summary
- load account list from `data/account.json`
- update balance card and transaction table when selecting an account

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_68c26f0d671c83308d3efac7f79184e6