### PR TITLE
Add circular backgrounds to transaction icons

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ function updateView() {
     tr.innerHTML = `
       <td class="px-4 py-3">
         <div class="flex items-center gap-2">
-          <img src="${iconSrc}" alt="" class="w-5 h-5">
+          <span class="w-10 h-10 rounded-full bg-emerald-100 border border-emerald-300 grid place-items-center">
+            <img src="${iconSrc}" alt="" class="w-6 h-6 object-contain">
+          </span>
           <span>${tx.description}</span>
         </div>
       </td>


### PR DESCRIPTION
## Summary
- style transaction list icons with rounded emerald backgrounds

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27736e0d88330bf10af107cc7f247