### PR TITLE
feat: implement push drawer without overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,17 +383,16 @@
       </div>
     </main>
     <!-- ============ /MAIN ============ -->
-  </div>
 
-  <!-- Drawer overlay and panel -->
-  <div id="drawerOverlay" class="fixed inset-0 bg-black/50 opacity-0 pointer-events-none transition-opacity duration-300 z-40"></div>
-  <div id="drawer" class="fixed top-0 right-0 h-full w-full max-w-[480px] bg-white shadow-xl transform translate-x-full transition-transform duration-300 z-50 overflow-y-auto">
-    <div class="flex items-center justify-between p-4 border-b">
-      <h2 class="text-lg font-semibold">Riwayat</h2>
-      <button id="drawerCloseBtn" class="text-2xl leading-none">&times;</button>
-    </div>
-    <div class="p-4">
-      <p>drawer content</p>
+    <!-- Drawer -->
+    <div id="drawer" class="h-full bg-white shadow-xl overflow-y-auto flex-shrink-0">
+      <div class="flex items-center justify-between p-4 border-b">
+        <h2 class="text-lg font-semibold">Riwayat</h2>
+        <button id="drawerCloseBtn" class="text-2xl leading-none">&times;</button>
+      </div>
+      <div class="p-4">
+        <p>drawer content</p>
+      </div>
     </div>
   </div>
 

--- a/index.js
+++ b/index.js
@@ -71,22 +71,16 @@ function formatCurrency(num) {
 
 // Drawer logic for "Ubah Akses"
 const drawer = document.getElementById('drawer');
-const overlay = document.getElementById('drawerOverlay');
 const openBtn = document.getElementById('ubahAksesBtn');
 const closeBtn = document.getElementById('drawerCloseBtn');
 
 function openDrawer() {
-  drawer.classList.remove('translate-x-full');
-  overlay.classList.remove('opacity-0', 'pointer-events-none');
-  overlay.classList.add('opacity-100');
+  drawer.classList.add('open');
 }
 
 function closeDrawer() {
-  drawer.classList.add('translate-x-full');
-  overlay.classList.add('opacity-0', 'pointer-events-none');
-  overlay.classList.remove('opacity-100');
+  drawer.classList.remove('open');
 }
 
 openBtn?.addEventListener('click', openDrawer);
 closeBtn?.addEventListener('click', closeDrawer);
-overlay?.addEventListener('click', closeDrawer);

--- a/styles.css
+++ b/styles.css
@@ -31,3 +31,11 @@
 /* center items when collapsed */
 #sidebar.collapsed .sb-item,
 .sidebar-collapsed #sidebar .sb-item{ justify-content:center; padding-left:0; padding-right:0; gap:.5rem; }
+
+/* Drawer push panel */
+#drawer{
+  width:0;
+  max-width:480px;
+  transition:width .3s ease;
+}
+#drawer.open{ width:480px; }


### PR DESCRIPTION
## Summary
- replace overlay drawer with flex-based panel that pushes dashboard content
- animate drawer width for smooth transitions
- add JS control for drawer open and close

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_68c27d209adc8330a69ad82391135fd7