### PR TITLE
Adjust dashboard columns when drawer opens

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,9 +141,9 @@
         </div>
 
         <!-- Top widgets -->
-        <div class="grid lg:grid-cols-12 gap-4 items-stretch auto-rows-fr">
+        <div id="dashboardGrid" class="grid gap-4 items-stretch auto-rows-fr lg:grid-cols-3">
           <!-- rekening -->
-          <section class="lg:col-span-4">
+          <section class="lg:col-span-1">
             <div class="h-full rounded-2xl border border-slate-200 p-4 flex flex-col">
               <div class="flex items-center justify-between mb-4">
                 <div class="flex items-center gap-2">
@@ -198,7 +198,7 @@
           </section>
 
           <!-- Akses Cepat -->
-          <section class="lg:col-span-4">
+          <section class="lg:col-span-1">
             <div class="rounded-2xl border border-slate-200 p-4">
               <div class="flex items-center justify-between mb-3">
                 <div class="flex items-center gap-2">
@@ -214,7 +214,7 @@
           </section>
 
           <!-- Pending Aktivitas -->
-          <section class="lg:col-span-4">
+          <section class="lg:col-span-1">
             <div class="h-full rounded-2xl border border-slate-200 p-4 flex flex-col">
               <div class="flex items-center gap-2 mb-7">
                 <img class="w-6 h-6" src="img/dashboard/pending-aktivitas.svg" alt="">

--- a/index.js
+++ b/index.js
@@ -73,15 +73,18 @@ function formatCurrency(num) {
 const drawer = document.getElementById('drawer');
 const openBtn = document.getElementById('ubahAksesBtn');
 const closeBtn = document.getElementById('drawerCloseBtn');
+const dashboardGrid = document.getElementById('dashboardGrid');
 
 function openDrawer() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
   drawer.classList.add('open');
+  dashboardGrid?.classList.replace('lg:grid-cols-3', 'lg:grid-cols-2');
 }
 
 function closeDrawer() {
   drawer.classList.remove('open');
+  dashboardGrid?.classList.replace('lg:grid-cols-2', 'lg:grid-cols-3');
 }
 
 openBtn?.addEventListener('click', openDrawer);


### PR DESCRIPTION
## Summary
- Reduce dashboard grid to two columns when drawer is opened, restoring three columns when closed.
- Mark top widget grid with an ID for targeted layout adjustments.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c29f14d51c83309c277273958b4f95