### PR TITLE
Collapse sidebar when drawers open across pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,12 +82,18 @@ function openDrawer() {
   drawer.classList.add('open');
   dashboardGrid?.classList.replace('lg:grid-cols-3', 'lg:grid-cols-2');
   pendingSection?.classList.replace('lg:col-span-1', 'lg:col-span-2');
+  if (typeof window.sidebarCollapseForDrawer === 'function') {
+    window.sidebarCollapseForDrawer();
+  }
 }
 
 function closeDrawer() {
   drawer.classList.remove('open');
   dashboardGrid?.classList.replace('lg:grid-cols-2', 'lg:grid-cols-3');
   pendingSection?.classList.replace('lg:col-span-2', 'lg:col-span-1');
+  if (typeof window.sidebarRestoreForDrawer === 'function') {
+    window.sidebarRestoreForDrawer();
+  }
 }
 
 openBtn?.addEventListener('click', openDrawer);

--- a/sidebar.js
+++ b/sidebar.js
@@ -107,4 +107,14 @@ document.addEventListener('DOMContentLoaded', () => {
   // expose helper for other scripts
   window.sidebarSetCollapsed = (collapsed, opts = {}) => setCollapsed(collapsed, opts);
   window.isSidebarCollapsed = () => sidebar.classList.contains('collapsed');
+
+  // Helpers to temporarily collapse the sidebar when a drawer is open
+  let prevCollapsed = false;
+  window.sidebarCollapseForDrawer = () => {
+    prevCollapsed = sidebar.classList.contains('collapsed');
+    if (!prevCollapsed) setCollapsed(true, { persist: false });
+  };
+  window.sidebarRestoreForDrawer = () => {
+    if (!prevCollapsed) setCollapsed(false, { persist: false });
+  };
 });

--- a/transfer.js
+++ b/transfer.js
@@ -1,45 +1,28 @@
 // transfer.js - drawer logic for transfer page
 
 document.addEventListener('DOMContentLoaded', () => {
-  const openBtn = document.getElementById('openTransferDrawer');
-  const drawer = document.getElementById('drawer');
+  const openBtn  = document.getElementById('openTransferDrawer');
+  const drawer   = document.getElementById('drawer');
   const closeBtn = document.getElementById('drawerCloseBtn');
-  const sidebar = document.getElementById('sidebar');
-  let sidebarWasCollapsed = false;
-
-  function collapseSidebarForDrawer() {
-    if (!sidebar) return;
-    sidebarWasCollapsed = typeof window.isSidebarCollapsed === 'function'
-      ? window.isSidebarCollapsed()
-      : sidebar.classList.contains('collapsed');
-    if (!sidebarWasCollapsed) {
-      if (typeof window.sidebarSetCollapsed === 'function') {
-        window.sidebarSetCollapsed(true, { persist: false });
-      } else {
-        sidebar.classList.add('collapsed');
-      }
-    }
-  }
-
-  function restoreSidebar() {
-    if (!sidebar || sidebarWasCollapsed) return;
-    if (typeof window.sidebarSetCollapsed === 'function') {
-      window.sidebarSetCollapsed(false, { persist: false });
-    } else {
-      sidebar.classList.remove('collapsed');
-    }
-  }
 
   function openDrawer() {
     drawer.classList.add('open');
-    collapseSidebarForDrawer();
+    if (typeof window.sidebarCollapseForDrawer === 'function') {
+      window.sidebarCollapseForDrawer();
+    }
   }
 
   function closeDrawer() {
     drawer.classList.remove('open');
-    restoreSidebar();
+    if (typeof window.sidebarRestoreForDrawer === 'function') {
+      window.sidebarRestoreForDrawer();
+    }
   }
 
-  openBtn?.addEventListener('click', (e) => { e.preventDefault(); openDrawer(); });
+  openBtn?.addEventListener('click', (e) => {
+    e.preventDefault();
+    openDrawer();
+  });
   closeBtn?.addEventListener('click', closeDrawer);
 });
+


### PR DESCRIPTION
## Summary
- Add helper to sidebar.js to collapse/restore sidebar when a drawer opens or closes
- Use the helper in dashboard and transfer drawers so the sidebar shrinks on open and expands on close

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b8c1d0308330809e7e4fe1880a1f