### PR TITLE
feat: add account selection sheets

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -173,7 +173,7 @@
     <!-- ============ /MAIN ============ -->
 
     <!-- Drawer -->
-    <div id="drawer" class="h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-200">
+    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-200">
       <div class="flex items-center justify-between p-4 border-b">
         <h2 class="text-lg font-semibold">Transfer Saldo</h2>
         <button id="drawerCloseBtn" class="text-2xl leading-none">&times;</button>
@@ -181,11 +181,11 @@
       <div class="flex-1 overflow-y-auto p-4 space-y-4">
         <div>
           <label class="block text-sm mb-1">Sumber Rekening</label>
-          <button class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih sumber rekening</button>
+          <button id="sourceAccountBtn" class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih sumber rekening</button>
         </div>
         <div>
           <label class="block text-sm mb-1">Rekening Tujuan</label>
-          <button class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih rekening tujuan</button>
+          <button id="destinationAccountBtn" class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih rekening tujuan</button>
         </div>
         <div>
           <div class="flex items-center justify-between mb-1">
@@ -216,6 +216,21 @@
       </div>
       <div class="p-4 border-t">
         <button class="w-full rounded-xl bg-cyan-500 text-white py-3">Lanjut</button>
+      </div>
+
+      <!-- Bottom Sheet Overlay & Panel -->
+      <div id="sheetOverlay" class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity z-10"></div>
+      <div id="bottomSheet" class="absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform max-h-[80%] h-1/2 z-20 flex flex-col">
+        <div class="p-4 border-b">
+          <h3 id="sheetTitle" class="text-base font-semibold">Sumber Rekening</h3>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <ul id="sheetList" class="divide-y"></ul>
+        </div>
+        <div class="p-4 flex gap-3 border-t">
+          <button id="sheetCancel" class="flex-1 rounded-xl border py-3">Batalkan</button>
+          <button id="sheetChoose" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Pilih Rekening</button>
+        </div>
       </div>
     </div>
   </div>

--- a/transfer.js
+++ b/transfer.js
@@ -5,6 +5,98 @@ document.addEventListener('DOMContentLoaded', () => {
   const drawer   = document.getElementById('drawer');
   const closeBtn = document.getElementById('drawerCloseBtn');
 
+  // bottom sheet elements
+  const sourceBtn = document.getElementById('sourceAccountBtn');
+  const destBtn   = document.getElementById('destinationAccountBtn');
+  const sheetOverlay = document.getElementById('sheetOverlay');
+  const sheet       = document.getElementById('bottomSheet');
+  const sheetTitle  = document.getElementById('sheetTitle');
+  const sheetList   = document.getElementById('sheetList');
+  const sheetCancel = document.getElementById('sheetCancel');
+  const sheetChoose = document.getElementById('sheetChoose');
+
+  const accounts = [
+    { initial:'O', color:'bg-cyan-100 text-cyan-600', name:'Operasional', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
+    { initial:'D', color:'bg-orange-100 text-orange-600', name:'Distributor', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
+    { initial:'P', color:'bg-teal-100 text-teal-600', name:'Partnership', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
+    { initial:'A', color:'bg-purple-100 text-purple-600', name:'Admin', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
+    { initial:'B', color:'bg-red-100 text-red-600', name:'Bill', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' }
+  ];
+
+  let currentField = null;   // 'source' or 'dest'
+  let currentData  = [];
+  let selectedIndex = null;
+
+  function renderList(data) {
+    sheetList.innerHTML = data.map((acc, idx) => `
+      <li>
+        <button type="button" data-index="${idx}" class="sheet-item w-full flex items-center gap-3 px-4 py-3 text-left">
+          <div class="w-10 h-10 rounded-full ${acc.color} flex items-center justify-center font-semibold">${acc.initial}</div>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium">${acc.name}</p>
+            <p class="text-sm text-slate-500">${acc.company}</p>
+            <p class="text-sm text-slate-500">${acc.bank} - ${acc.number}</p>
+          </div>
+          <div class="text-sm font-medium whitespace-nowrap mr-2">${acc.balance}</div>
+          <span class="ml-2 w-5 h-5 rounded-full border border-slate-300 grid place-items-center">
+            <span class="radio-dot w-2 h-2 rounded-full bg-cyan-500 hidden"></span>
+          </span>
+        </button>
+      </li>`).join('');
+  }
+
+  function openSheet(field) {
+    currentField = field;
+    currentData = accounts; // same list for now
+    selectedIndex = null;
+    sheetTitle.textContent = field === 'source' ? 'Sumber Rekening' : 'Tujuan Rekening';
+    renderList(currentData);
+    sheetChoose.disabled = true;
+    sheetChoose.classList.add('opacity-50', 'cursor-not-allowed');
+    sheetOverlay.classList.remove('hidden');
+    requestAnimationFrame(() => {
+      sheetOverlay.classList.add('opacity-100');
+      sheet.classList.remove('translate-y-full');
+    });
+  }
+
+  function closeSheet() {
+    sheetOverlay.classList.remove('opacity-100');
+    sheet.classList.add('translate-y-full');
+    setTimeout(() => {
+      sheetOverlay.classList.add('hidden');
+    }, 200);
+  }
+
+  sheetList.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-index]');
+    if (!btn) return;
+    selectedIndex = btn.dataset.index;
+    sheetList.querySelectorAll('button[data-index]').forEach(b => {
+      b.classList.remove('bg-cyan-50','ring-2','ring-cyan-400');
+      b.querySelector('.radio-dot').classList.add('hidden');
+    });
+    btn.classList.add('bg-cyan-50','ring-2','ring-cyan-400');
+    btn.querySelector('.radio-dot').classList.remove('hidden');
+    sheetChoose.disabled = false;
+    sheetChoose.classList.remove('opacity-50','cursor-not-allowed');
+  });
+
+  sheetCancel?.addEventListener('click', closeSheet);
+  sheetOverlay?.addEventListener('click', closeSheet);
+
+  sheetChoose?.addEventListener('click', () => {
+    if (selectedIndex === null) return;
+    const acc = currentData[selectedIndex];
+    const target = currentField === 'source' ? sourceBtn : destBtn;
+    target.textContent = `${acc.name} - ${acc.number}`;
+    target.classList.remove('text-slate-500');
+    closeSheet();
+  });
+
+  sourceBtn?.addEventListener('click', () => openSheet('source'));
+  destBtn?.addEventListener('click', () => openSheet('dest'));
+
   function openDrawer() {
     drawer.classList.add('open');
     if (typeof window.sidebarCollapseForDrawer === 'function') {


### PR DESCRIPTION
## Summary
- add bottom sheet components inside transfer drawer to pick source or destination accounts
- implement JS logic for account selection with overlay dismiss and confirmation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c363a7660c83308ece4b04131bf13c