### PR TITLE
feat: improve transfer flow with categories and methods

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -200,22 +200,36 @@
           <label class="block text-sm mb-1">Nominal</label>
           <div class="relative">
             <span class="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">Rp</span>
-            <input type="text" placeholder="Masukkan nominal transfer" class="w-full border rounded-xl pl-8 pr-3 py-3" />
+            <input id="amountInput" type="text" placeholder="Masukkan nominal transfer" class="w-full border rounded-xl pl-8 pr-3 py-3" />
           </div>
         </div>
+
+        <!-- Metode Transfer (hidden until destination & nominal filled) -->
+        <div id="methodContainer" class="hidden">
+          <label class="block text-sm mb-1">Metode Transfer</label>
+          <select id="transferMethod" class="w-full border rounded-xl px-3 py-3" disabled>
+            <option value="">Pilih metode transfer</option>
+          </select>
+          <div id="feeBreakdown" class="hidden mt-2 text-sm space-y-1">
+            <div class="flex justify-between"><span>Nominal</span><span id="nominalDisplay">Rp0</span></div>
+            <div class="flex justify-between"><span>Biaya Transfer</span><span id="feeDisplay">Rp0</span></div>
+            <div class="flex justify-between font-semibold"><span>Total</span><span id="totalDisplay">Rp0</span></div>
+          </div>
+        </div>
+
         <p class="text-[11px] tracking-[.18em] text-slate-400 pt-4">DETAIL</p>
         <div>
           <label class="block text-sm mb-1">Kategori</label>
-          <button class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih kategori</button>
+          <button id="categoryBtn" class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih kategori</button>
         </div>
         <div>
           <label class="block text-sm mb-1">Catatan (Opsional)</label>
-          <textarea class="w-full border rounded-xl px-3 py-3" placeholder="Tulis catatan" maxlength="50"></textarea>
-          <div class="text-right text-xs text-slate-400">0/50</div>
+          <textarea id="noteInput" class="w-full border rounded-xl px-3 py-3" placeholder="Tulis catatan" maxlength="50"></textarea>
+          <div id="noteCounter" class="text-right text-xs text-slate-400">0/50</div>
         </div>
       </div>
       <div class="p-4 border-t">
-        <button class="w-full rounded-xl bg-cyan-500 text-white py-3">Lanjut</button>
+        <button id="confirmBtn" class="w-full rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Konfirmasi Transfer Saldo</button>
       </div>
 
       <!-- Bottom Sheet Overlay & Panel -->
@@ -283,6 +297,19 @@
         <div class="p-4 flex gap-3 border-t">
           <button id="destBack" class="flex-1 rounded-xl border py-3">Kembali</button>
           <button id="destProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Masukkan Detail Transfer</button>
+        </div>
+      </div>
+
+      <!-- Confirmation Bottom Sheet -->
+      <div id="confirmSheet" class="absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform h-full z-20 flex flex-col">
+        <div class="p-4 border-b">
+          <h3 class="text-base font-semibold">Konfirmasi Transfer Saldo</h3>
+          <p class="text-sm text-slate-600">Mohon pastikan data sudah sesuai</p>
+        </div>
+        <div id="confirmContent" class="flex-1 overflow-y-auto p-4 space-y-4"></div>
+        <div class="p-4 flex gap-3 border-t">
+          <button id="confirmBack" class="flex-1 rounded-xl border py-3">Batalkan</button>
+          <button id="confirmProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3">Lanjut Transfer Saldo</button>
         </div>
       </div>
     </div>

--- a/transfer.js
+++ b/transfer.js
@@ -5,9 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const drawer   = document.getElementById('drawer');
   const closeBtn = document.getElementById('drawerCloseBtn');
 
-  // bottom sheet elements
+  // buttons & inputs in form
   const sourceBtn = document.getElementById('sourceAccountBtn');
   const destBtn   = document.getElementById('destinationAccountBtn');
+  const categoryBtn = document.getElementById('categoryBtn');
+  const amountInput = document.getElementById('amountInput');
+  const methodContainer = document.getElementById('methodContainer');
+  const transferMethod = document.getElementById('transferMethod');
+  const feeBreakdown = document.getElementById('feeBreakdown');
+  const nominalDisplay = document.getElementById('nominalDisplay');
+  const feeDisplay = document.getElementById('feeDisplay');
+  const totalDisplay = document.getElementById('totalDisplay');
+  const confirmBtn = document.getElementById('confirmBtn');
+  const noteInput = document.getElementById('noteInput');
+  const noteCounter = document.getElementById('noteCounter');
+
+  // generic bottom sheet
   const sheetOverlay = document.getElementById('sheetOverlay');
   const sheet       = document.getElementById('bottomSheet');
   const sheetTitle  = document.getElementById('sheetTitle');
@@ -31,6 +44,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const destBack    = document.getElementById('destBack');
   const destProceed = document.getElementById('destProceed');
 
+  // confirmation sheet
+  const confirmSheet = document.getElementById('confirmSheet');
+  const confirmContent = document.getElementById('confirmContent');
+  const confirmBack = document.getElementById('confirmBack');
+  const confirmProceed = document.getElementById('confirmProceed');
+
+  // data
   const accounts = [
     { initial:'O', color:'bg-cyan-100 text-cyan-600', name:'Operasional', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
     { initial:'D', color:'bg-orange-100 text-orange-600', name:'Distributor', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' },
@@ -39,38 +59,70 @@ document.addEventListener('DOMContentLoaded', () => {
     { initial:'B', color:'bg-red-100 text-red-600', name:'Bill', company:'PT ABC Indonesia', bank:'Amar Indonesia', number:'000967895483', balance:'Rp3.000.000.000,00' }
   ];
 
-  let currentData  = [];
+  const categories = ['Tagihan','Pembayaran','Transportasi','Pemindahan Dana','Investasi','Lainnya'];
+
+  const transferMethodsData = [
+    { name:'BI Fast', fee:2500, min:0, max:250000000 },
+    { name:'RTGS', fee:25000, min:100000000, max:Infinity },
+    { name:'SKN/LLG', fee:2900, min:0, max:500000000 },
+    { name:'Online Transfer', fee:6500, min:0, max:25000000 }
+  ];
+
+  // state
+  let currentData = [];
   let selectedIndex = null;
   let selectedBank = '';
   let accountNumber = '';
   let accountOwner = '';
   let saveBeneficiary = false;
+  let sourceSelected = false;
+  let destSelected = false;
+  let amountValue = 0;
+  let amountValid = false;
+  let methodSelected = false;
+  let categorySelected = false;
+  let selectedCategory = '';
+  let currentSheetType = 'source';
 
-  function renderList(data) {
-    sheetList.innerHTML = data.map((acc, idx) => `
-      <li>
-        <button type="button" data-index="${idx}" class="sheet-item w-full flex items-center gap-3 px-4 py-3 text-left">
-          <div class="w-10 h-10 rounded-full ${acc.color} flex items-center justify-center font-semibold">${acc.initial}</div>
-          <div class="flex-1 min-w-0">
-            <p class="font-medium">${acc.name}</p>
-            <p class="text-sm text-slate-500">${acc.company}</p>
-            <p class="text-sm text-slate-500">${acc.bank} - ${acc.number}</p>
-          </div>
-          <div class="text-sm font-medium whitespace-nowrap mr-2">${acc.balance}</div>
-          <span class="ml-2 w-5 h-5 rounded-full border border-slate-300 grid place-items-center">
-            <span class="radio-dot w-2 h-2 rounded-full bg-cyan-500 hidden"></span>
-          </span>
-        </button>
-      </li>`).join('');
+  function renderList(data, type) {
+    if (type === 'source') {
+      sheetList.innerHTML = data.map((acc, idx) => `
+        <li>
+          <button type="button" data-index="${idx}" class="sheet-item w-full flex items-center gap-3 px-4 py-3 text-left">
+            <div class="w-10 h-10 rounded-full ${acc.color} flex items-center justify-center font-semibold">${acc.initial}</div>
+            <div class="flex-1 min-w-0">
+              <p class="font-medium">${acc.name}</p>
+              <p class="text-sm text-slate-500">${acc.company}</p>
+              <p class="text-sm text-slate-500">${acc.bank} - ${acc.number}</p>
+            </div>
+            <div class="text-sm font-medium whitespace-nowrap mr-2">${acc.balance}</div>
+            <span class="ml-2 w-5 h-5 rounded-full border border-slate-300 grid place-items-center">
+              <span class="radio-dot w-2 h-2 rounded-full bg-cyan-500 hidden"></span>
+            </span>
+          </button>
+        </li>`).join('');
+    } else if (type === 'category') {
+      sheetList.innerHTML = data.map((cat, idx) => `
+        <li>
+          <button type="button" data-index="${idx}" class="sheet-item w-full flex items-center justify-between px-4 py-3 text-left">
+            <span>${cat}</span>
+            <span class="ml-2 w-5 h-5 rounded-full border border-slate-300 grid place-items-center">
+              <span class="radio-dot w-2 h-2 rounded-full bg-cyan-500 hidden"></span>
+            </span>
+          </button>
+        </li>`).join('');
+    }
   }
 
-  function openSheet() {
-    currentData = accounts; // same list for now
+  function openSheet(type = 'source') {
+    currentSheetType = type;
     selectedIndex = null;
-    sheetTitle.textContent = 'Sumber Rekening';
-    renderList(currentData);
+    currentData = type === 'source' ? accounts : categories;
+    sheetTitle.textContent = type === 'source' ? 'Sumber Rekening' : 'Kategori';
+    sheetChoose.textContent = type === 'source' ? 'Pilih Rekening' : 'Pilih';
+    renderList(currentData, type);
     sheetChoose.disabled = true;
-    sheetChoose.classList.add('opacity-50', 'cursor-not-allowed');
+    sheetChoose.classList.add('opacity-50','cursor-not-allowed');
     sheetOverlay.classList.remove('hidden');
     requestAnimationFrame(() => {
       sheetOverlay.classList.add('opacity-100');
@@ -97,7 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
     aliasInput.value = '';
     aliasCounter.textContent = '0/15';
     destProceed.disabled = true;
-    destProceed.classList.add('opacity-50', 'cursor-not-allowed');
+    destProceed.classList.add('opacity-50','cursor-not-allowed');
     saveCheckbox.checked = false;
     selectedBank = '';
     accountNumber = '';
@@ -122,6 +174,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 200);
   }
 
+  function closeConfirmSheet() {
+    confirmSheet.classList.add('translate-y-full');
+    sheetOverlay.classList.remove('opacity-100');
+    setTimeout(() => {
+      sheetOverlay.classList.add('hidden');
+    }, 200);
+  }
+
   sheetList.addEventListener('click', (e) => {
     const btn = e.target.closest('button[data-index]');
     if (!btn) return;
@@ -140,21 +200,32 @@ document.addEventListener('DOMContentLoaded', () => {
   sheetOverlay?.addEventListener('click', () => {
     closeSheet();
     closeDestSheet();
+    closeConfirmSheet();
   });
 
   sheetChoose?.addEventListener('click', () => {
     if (selectedIndex === null) return;
-    const acc = currentData[selectedIndex];
-    sourceBtn.textContent = `${acc.name} - ${acc.number}`;
-    sourceBtn.classList.remove('text-slate-500');
+    if (currentSheetType === 'source') {
+      const acc = currentData[selectedIndex];
+      sourceBtn.textContent = `${acc.name} - ${acc.number}`;
+      sourceBtn.classList.remove('text-slate-500');
+      sourceSelected = true;
+    } else if (currentSheetType === 'category') {
+      selectedCategory = currentData[selectedIndex];
+      categoryBtn.textContent = selectedCategory;
+      categoryBtn.classList.remove('text-slate-500');
+      categorySelected = true;
+    }
+    updateConfirmState();
     closeSheet();
   });
 
-  sourceBtn?.addEventListener('click', () => openSheet());
+  sourceBtn?.addEventListener('click', () => openSheet('source'));
+  categoryBtn?.addEventListener('click', () => openSheet('category'));
   destBtn?.addEventListener('click', openDestSheet);
 
   destNumber?.addEventListener('input', (e) => {
-    e.target.value = e.target.value.replace(/\D/g, '');
+    e.target.value = e.target.value.replace(/\D/g,'');
   });
 
   checkAccount?.addEventListener('click', () => {
@@ -167,7 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ownerField.classList.remove('hidden');
     saveContainer.classList.remove('hidden');
     destProceed.disabled = false;
-    destProceed.classList.remove('opacity-50', 'cursor-not-allowed');
+    destProceed.classList.remove('opacity-50','cursor-not-allowed');
   });
 
   saveCheckbox?.addEventListener('change', (e) => {
@@ -177,7 +248,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   aliasInput?.addEventListener('input', (e) => {
     if (e.target.value.length > 15) {
-      e.target.value = e.target.value.slice(0, 15);
+      e.target.value = e.target.value.slice(0,15);
     }
     aliasCounter.textContent = `${e.target.value.length}/15`;
   });
@@ -186,7 +257,10 @@ document.addEventListener('DOMContentLoaded', () => {
   destProceed?.addEventListener('click', () => {
     destBtn.textContent = `${selectedBank} - ${accountNumber} - ${accountOwner}`;
     destBtn.classList.remove('text-slate-500');
+    destSelected = true;
     closeDestSheet();
+    checkMethodVisibility();
+    updateConfirmState();
   });
 
   function openDrawer() {
@@ -208,5 +282,118 @@ document.addEventListener('DOMContentLoaded', () => {
     openDrawer();
   });
   closeBtn?.addEventListener('click', closeDrawer);
+
+  // helpers
+  const formatter = new Intl.NumberFormat('id-ID');
+  const dailyLimit = 200000000;
+
+  function checkMethodVisibility() {
+    if (destSelected && amountValid) {
+      methodContainer.classList.remove('hidden');
+      updateMethodOptions();
+    } else {
+      methodContainer.classList.add('hidden');
+      transferMethod.value = '';
+      feeBreakdown.classList.add('hidden');
+      methodSelected = false;
+    }
+  }
+
+  function updateMethodOptions() {
+    const validMethods = transferMethodsData.filter(m => amountValue >= m.min && amountValue <= m.max);
+    transferMethod.innerHTML = '<option value="">Pilih metode transfer</option>' +
+      validMethods.map(m => `<option value="${m.name}" data-fee="${m.fee}">${m.name}</option>`).join('');
+    transferMethod.disabled = validMethods.length === 0;
+  }
+
+  function updateConfirmState() {
+    if (sourceSelected && destSelected && amountValid && categorySelected && methodSelected) {
+      confirmBtn.disabled = false;
+      confirmBtn.classList.remove('opacity-50','cursor-not-allowed');
+    } else {
+      confirmBtn.disabled = true;
+      confirmBtn.classList.add('opacity-50','cursor-not-allowed');
+    }
+  }
+
+  amountInput?.addEventListener('input', (e) => {
+    const raw = e.target.value.replace(/\D/g,'');
+    e.target.value = raw ? formatter.format(raw) : '';
+    amountValue = parseInt(raw) || 0;
+    amountValid = amountValue > 0 && amountValue <= dailyLimit;
+    checkMethodVisibility();
+    updateConfirmState();
+  });
+
+  transferMethod?.addEventListener('change', (e) => {
+    if (e.target.value) {
+      const fee = parseInt(e.target.selectedOptions[0].dataset.fee);
+      nominalDisplay.textContent = 'Rp' + formatter.format(amountValue);
+      feeDisplay.textContent = 'Rp' + formatter.format(fee);
+      totalDisplay.textContent = 'Rp' + formatter.format(amountValue + fee);
+      feeBreakdown.classList.remove('hidden');
+      methodSelected = true;
+    } else {
+      feeBreakdown.classList.add('hidden');
+      methodSelected = false;
+    }
+    updateConfirmState();
+  });
+
+  noteInput?.addEventListener('input', (e) => {
+    if (e.target.value.length > 50) {
+      e.target.value = e.target.value.slice(0,50);
+    }
+    noteCounter.textContent = `${e.target.value.length}/50`;
+  });
+
+  confirmBtn?.addEventListener('click', () => {
+    const fee = parseInt(transferMethod.selectedOptions[0].dataset.fee);
+    const total = amountValue + fee;
+    const ref = Math.floor(100000000 + Math.random()*900000000);
+    const now = new Date();
+    const dateStr = now.toLocaleDateString('id-ID', {day:'numeric', month:'long', year:'numeric'});
+    const timeStr = now.toLocaleTimeString('id-ID', {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+    const noteVal = noteInput.value || '-';
+    confirmContent.innerHTML = `
+      <div class="space-y-4">
+        <div>
+          <p class="font-semibold mb-1">Transfer Saldo</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between"><span class="text-slate-600">Sumber</span><span>${sourceBtn.textContent}</span></div>
+            <div class="flex justify-between"><span class="text-slate-600">Tujuan</span><span>${destBtn.textContent}</span></div>
+          </div>
+        </div>
+        <div>
+          <p class="font-semibold mb-1">Total Transaksi</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between"><span>Nominal</span><span>Rp${formatter.format(amountValue)}</span></div>
+            <div class="flex justify-between"><span>Biaya Transfer</span><span>Rp${formatter.format(fee)}</span></div>
+            <div class="flex justify-between font-semibold"><span>Total</span><span>Rp${formatter.format(total)}</span></div>
+          </div>
+        </div>
+        <div>
+          <p class="font-semibold mb-1">Detail Transaksi</p>
+          <div class="space-y-2 text-sm">
+            <div class="flex justify-between"><span>Metode Transfer</span><span>${transferMethod.value}</span></div>
+            <div class="flex justify-between"><span>Nomor Referensi</span><span>${ref}</span></div>
+            <div class="flex justify-between"><span>Tanggal dan Waktu</span><span>${dateStr} ${timeStr}</span></div>
+            <div class="flex justify-between"><span>Kategori</span><span>${selectedCategory}</span></div>
+            <div class="flex justify-between"><span>Catatan</span><span>${noteVal}</span></div>
+          </div>
+        </div>
+      </div>`;
+    sheetOverlay.classList.remove('hidden');
+    requestAnimationFrame(() => {
+      sheetOverlay.classList.add('opacity-100');
+      confirmSheet.classList.remove('translate-y-full');
+    });
+  });
+
+  confirmBack?.addEventListener('click', closeConfirmSheet);
+  confirmProceed?.addEventListener('click', () => {
+    alert('Transfer diproses (dummy).');
+    closeConfirmSheet();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add selectable categories and notes to transfer form
- show transfer methods based on amount with fee & total calculation
- add confirmation preview bottom sheet before final transfer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bd58ef148330a6e35f14d1370e7c