### PR TITLE
feat: add bottom sheet for transfer method

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -232,9 +232,10 @@
           <p class="text-[16px] tracking-[.18em] text-slate-400 p-3 bg-slate-100 mb-4">METODE</p>
           <div>
             <label class="block text-sm mb-1">Metode Transfer</label>
-            <select id="methodSelect" class="w-full border rounded-xl px-3 py-3" disabled>
-              <option value="">Pilih metode transfer</option>
-            </select>
+            <button id="methodBtn" type="button" class="w-full border rounded-xl px-3 py-3 flex items-center justify-between opacity-50 cursor-not-allowed" disabled>
+              <span id="methodText" class="text-slate-500">Pilih metode transfer</span>
+              <span class="text-slate-400">▾</span>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace transfer method select with a button that opens a bottom sheet picker
- add data and logic to render transfer method options and update confirmation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check transfer.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3e6b3a6f083308709c299630c1f59