### PR TITLE
feat: add active sidebar states

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -101,8 +101,8 @@
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
+        <a href="atur-persetujuan.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/akses-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
       </nav>

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -96,8 +96,8 @@
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
+        <a href="batas-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/limit-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 

--- a/biller.html
+++ b/biller.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -79,8 +79,8 @@
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-            <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
+        <a href="biller.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+            <img class="block w-6 h-6" src="img/sidebar/biller-active.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 

--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
         <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <img class="w-6 h-6" src="img/sidebar/dashboard-active.svg" alt="">
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -58,13 +58,13 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
+        <a href="informasi-rekening.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/inforekening-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 

--- a/manajemen-pengguna.html
+++ b/manajemen-pengguna.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -91,8 +91,8 @@
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
+        <a href="manajemen-pengguna.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/user-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 

--- a/mutasi.html
+++ b/mutasi.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -84,8 +84,8 @@
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
+        <a href="mutasi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/mutasi-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -74,8 +74,8 @@
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
+        <a href="persetujuan-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/otorisasi-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 

--- a/styles.css
+++ b/styles.css
@@ -5,9 +5,8 @@
     radial-gradient(900px 600px at -20% 90%, rgba(24,46,60,.6), transparent 60%),
     linear-gradient(180deg, #0f1b25 0%, #0d1620 40%, #10202a 100%);
 }
-.sb-item[aria-current="page"] .sb-dot{opacity:1; transform:scale(1)}
-.sb-item[aria-current="page"] .sb-text{color:#d7f3f7}
-.sb-item[aria-current="page"]{background:rgba(0,163,174,.14); border-color:rgba(0,163,174,.35)}
+.sb-item[aria-current="page"]{border-left:4px solid #06b6d4;padding-left:calc(.75rem - 4px);border-top-color:transparent;border-right-color:transparent;border-bottom-color:transparent;}
+.sb-item[aria-current="page"] .sb-label{color:#fff;font-weight:600;}
 
 /* keep rows steady */
 .sb-item{ height:48px; min-height:48px; align-items:center; }

--- a/transfer.html
+++ b/transfer.html
@@ -59,9 +59,9 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
-          <span class="sb-label text-slate-400 text-[16px] text-white">Beranda</span>
+          <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
         <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
@@ -69,8 +69,8 @@
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
-          <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
+        <a href="transfer.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
+          <img class="w-6 h-6" src="img/sidebar/transfer-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 


### PR DESCRIPTION
## Summary
- highlight active sidebar links with cyan border-left
- show white, bold labels and swap to active icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c591d512388330ac6de1235f5ae047