### PR TITLE
Remove active sidebar border and hover states

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,8 +5,14 @@
     radial-gradient(900px 600px at -20% 90%, rgba(24,46,60,.6), transparent 60%),
     linear-gradient(180deg, #0f1b25 0%, #0d1620 40%, #10202a 100%);
 }
-.sb-item[aria-current="page"]{border-left:4px solid #06b6d4;padding-left:calc(.75rem - 4px);border-top-color:transparent;border-right-color:transparent;border-bottom-color:transparent;}
+.sb-item[aria-current="page"]{padding-left:.75rem;}
 .sb-item[aria-current="page"] .sb-label{color:#fff;font-weight:600;}
+.sb-item:focus,
+.sb-item:hover{
+  outline:none;
+  border-color:transparent !important;
+  background-color:transparent !important;
+}
 
 /* keep rows steady */
 .sb-item{ height:48px; min-height:48px; align-items:center; }


### PR DESCRIPTION
## Summary
- drop cyan border from active sidebar item
- disable sidebar link hover and focus styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5953d8acc8330afbcd66d727d00fd