### PR TITLE
Revert removal of hover and focus styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,6 +78,7 @@
     confirm.classList.toggle('text-slate-400', !enable);
     confirm.classList.toggle('bg-cyan-600', enable);
     confirm.classList.toggle('text-white', enable);
+    confirm.classList.toggle('hover:bg-cyan-700', enable);
   }
 
   trigger?.addEventListener('click', (e)=>{ e.preventDefault(); openPane(); });
@@ -204,6 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
     confirm.classList.toggle('text-slate-400', !enable);
     confirm.classList.toggle('bg-cyan-600', enable);
     confirm.classList.toggle('text-white', enable);
+    confirm.classList.toggle('hover:bg-cyan-700', enable);
   }
 
   function setMode(next) {
@@ -293,6 +295,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sheetChoose.classList.toggle('bg-cyan-600', enable);
     sheetChoose.classList.toggle('text-white', enable);
+    sheetChoose.classList.toggle('hover:bg-cyan-700', enable);
   }
 
   function openSheet() {
@@ -420,10 +423,10 @@ document.addEventListener("DOMContentLoaded", () => {
     if (idValid && rekValid && nominalValid) {
       confirmBtn.disabled = false;
       confirmBtn.classList.remove("bg-slate-200", "text-slate-400");
-      confirmBtn.classList.add("bg-cyan-600", "text-white");
+      confirmBtn.classList.add("bg-cyan-600", "text-white", "hover:bg-cyan-700");
     } else {
       confirmBtn.disabled = true;
-      confirmBtn.classList.remove("bg-cyan-600", "text-white");
+      confirmBtn.classList.remove("bg-cyan-600", "text-white", "hover:bg-cyan-700");
       confirmBtn.classList.add("bg-slate-200", "text-slate-400");
     }
   };
@@ -457,7 +460,7 @@ document.addEventListener("DOMContentLoaded", () => {
       rekeningLabel.classList.remove("text-slate-400");
       sheetChoose.disabled = false;
       sheetChoose.classList.remove("bg-slate-200", "text-slate-400", "cursor-not-allowed");
-      sheetChoose.classList.add("bg-cyan-600", "text-white");
+      sheetChoose.classList.add("bg-cyan-600", "text-white", "hover:bg-cyan-700");
       updateConfirmState();
     });
   });
@@ -601,7 +604,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // ubah tombol -> Verifikasi (disabled)
     btnPay.textContent = "Verifikasi";
     btnPay.disabled = true;
-    btnPay.classList.remove("bg-cyan-600", "text-white");
+    btnPay.classList.remove("bg-cyan-600", "hover:bg-cyan-700", "text-white");
     btnPay.classList.add("bg-slate-200", "text-slate-400", "cursor-not-allowed");
 
     // hapus note dengan ikon i di dalam sheet
@@ -626,11 +629,11 @@ document.addEventListener("DOMContentLoaded", () => {
       const filled = Array.from(inputs).every(i => i.value.trim() !== "");
       if (filled) {
         btnPay.disabled = false;
-        btnPay.classList.add("bg-cyan-600", "text-white");
+        btnPay.classList.add("bg-cyan-600", "hover:bg-cyan-700", "text-white");
         btnPay.classList.remove("bg-slate-200", "text-slate-400", "cursor-not-allowed");
       } else {
         btnPay.disabled = true;
-        btnPay.classList.remove("bg-cyan-600", "text-white");
+        btnPay.classList.remove("bg-cyan-600", "hover:bg-cyan-700", "text-white");
         btnPay.classList.add("bg-slate-200", "text-slate-400", "cursor-not-allowed");
       }
     });

--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Atur Persetujuan</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -153,7 +153,7 @@
             Transfer
             <span class="absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button class="px-4 py-2 text-slate-600">Beli &amp; Bayar</button>
+          <button class="px-4 py-2 text-slate-600 hover:text-slate-900">Beli &amp; Bayar</button>
         </div>
 
         <!-- Table -->
@@ -167,18 +167,18 @@
               </tr>
             </thead>
             <tbody class="divide-y">
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">Rp0 - 200.000.000</td>
                 <td class="px-4 py-3">2 Approver</td>
                 <td class="px-4 py-3 text-right">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Ubah</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Ubah</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">Rp200.000.001 - 500.000.000</td>
                 <td class="px-4 py-3">3 Approver</td>
                 <td class="px-4 py-3 text-right">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Ubah</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Ubah</button>
                 </td>
               </tr>
             </tbody>

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Batas Transaksi</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -158,7 +158,7 @@
           <p class="text-slate-500   mb-4">dari total batas transaksi Rp200.000.000</p>
 
           <!-- Button -->
-          <button class="w-full rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 flex items-center justify-center gap-2">
+          <button class="w-full rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 flex items-center justify-center gap-2 hover:bg-cyan-50">
             Ubah Batas Transaksi
             <img src="img/icon/batas-transaksi.svg" alt="" class="w-5 h-5"/>
           </button>

--- a/biller.html
+++ b/biller.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller-active.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Beli &amp; Bayar </h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -146,7 +146,7 @@
             <h2 class="font-semibold text-lg">Pilih Layanan</h2>
             <p class="text-slate-600">Akses catatan transaksi terkini melalui menu <span class="font-medium">Riwayat</span>.</p>
           </div>
-          <button class="h-9 px-4 rounded-lg border border-cyan-500 text-cyan-600 bg-white">Riwayat</button>
+          <button class="h-9 px-4 rounded-lg border border-cyan-500 text-cyan-600 bg-white hover:bg-cyan-50">Riwayat</button>
         </div>
 
         <!-- Listrik PLN -->
@@ -156,11 +156,11 @@
             <h3 class="font-medium">Listrik PLN</h3>
           </div>
           <div class="grid grid-cols-4 gap-4">
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-3">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-3">
               <img src="img/biller/pln.svg" class="w-6 h-6"/>
               Token Listrik
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-3">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-3">
               <img src="img/biller/pln.svg" class="w-6 h-6"/>
               Tagihan Listrik
             </button>
@@ -174,16 +174,16 @@
             <h3 class="font-medium">Internet</h3>
           </div>
           <div class="grid grid-cols-4 gap-4">
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-2">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-2">
               <img src="img/biller/indihome.svg" class="w-6 h-6"/> Indihome
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-2">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-2">
               <img src="img/biller/myrepublic.svg" class="w-6 h-6"/> My Republic
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-2">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-2">
               <img src="img/biller/cbn.png" class="w-6 h-6"/> CBN
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center gap-2">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center gap-2">
               <img src="img/biller/iconnet.png" class="w-6 h-6"/> Iconnet
             </button>
           </div>
@@ -196,16 +196,16 @@
             <h3 class="font-medium">BPJS</h3>
           </div>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center">
               <img src="img/biller/bpjs.svg" class="w-6 h-6 mr-2"/> BPJS Kesehatan keluarga
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center">
               <img src="img/biller/bpjs.svg" class="w-6 h-6 mr-2"/> BPJS Kesehatan Badan Usaha
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center">
               <img src="img/biller/jmo.svg" class="w-6 h-6 mr-2"/> BPJSTK Penerima Upah
             </button>
-            <button class="rounded-xl border border-slate-200 bg-white p-4 flex items-center">
+            <button class="rounded-xl border border-slate-200 bg-white p-4 hover:bg-slate-50 flex items-center">
               <img src="img/biller/jmo.svg" class="w-6 h-6 mr-2"/> BPJSTK Bukan Penerima Upah
             </button>
           </div>

--- a/index.html
+++ b/index.html
@@ -58,49 +58,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard-active.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -109,7 +109,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Ramero Carlo</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -150,7 +150,7 @@
                   <img class="w-6 h-6" src="img/dashboard/info-rek.svg" alt="">
                   <h3 class="text-[18px] font-semibold">Info Rekening</h3>
                 </div>
-                <button class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2">Lihat Semua</button>
+                <button class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2 hover:bg-cyan-100">Lihat Semua</button>
               </div>
 
               <div class="relative mb-3">
@@ -169,7 +169,7 @@
                   <img src="img/dashboard/card-bank.png" alt="Bank Logo" class="h-6">
                   <button id="dashBalanceToggle"
                           class="h-8 px-3 rounded-xl border border-slate-300/60 bg-white/90 text-slate-800
-                                 text-base leading-none flex items-center gap-2">
+                                 text-base leading-none flex items-center gap-2 hover:bg-white">
                     <img src="img/dashboard/eye-off-fill.svg" alt="" class="w-4 h-4 object-contain">
                     Sembunyikan
                   </button>
@@ -205,7 +205,7 @@
                   <img class="w-6 h-6" src="img/dashboard/akses-cepat.svg" alt="">
                   <h3 class="text-[18px] font-semibold">Akses Cepat</h3>
                 </div>
-                <button id="ubahAksesBtn" class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2">Ubah Akses</button>
+                <button id="ubahAksesBtn" class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2 hover:bg-cyan-100">Ubah Akses</button>
               </div>
 
               <p class="text-slate-500 mb-3">Akses fitur transaksi yang Anda gunakan.</p>
@@ -223,10 +223,10 @@
 
               <!-- Tabs -->
               <div class="flex items-center gap-2">
-                <button id="tabButuh" class="flex-1 h-9 rounded-xl border bg-white font-medium">
+                <button id="tabButuh" class="flex-1 h-9 rounded-xl border bg-white hover:bg-slate-50 font-medium">
                   Butuh Persetujuan
                 </button>
-                <button id="tabMenunggu" class="flex-1 h-9 rounded-xl border bg-white">
+                <button id="tabMenunggu" class="flex-1 h-9 rounded-xl border bg-white hover:bg-slate-50">
                   Menunggu
                 </button>
               </div>
@@ -272,7 +272,7 @@
 
 
               <!-- Footer button pinned to bottom -->
-              <button class="mt-auto w-full h-11 rounded-xl border bg-white">
+              <button class="mt-auto w-full h-11 rounded-xl border bg-white hover:bg-slate-50">
                 Lihat Aktivitas
               </button>
             </div>
@@ -292,7 +292,7 @@
                   <p class="text-slate-500">Menampilkan mutasi terbaru di bawah ini.</p>
                 </div>
               </div>
-              <button class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2">Lihat Semua</button>
+              <button class="rounded-xl border border-cyan-500 text-cyan-500 px-4 py-2 hover:bg-cyan-100">Lihat Semua</button>
             </div>
 
             <div class="overflow-x-auto">

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function updateView() {
   transactionListEl.innerHTML = '';
   account.transactions.forEach((tx) => {
     const tr = document.createElement('tr');
-    tr.className = "";
+    tr.className = 'hover:bg-slate-50';
     const iconSrc = tx.amount < 0
       ? 'img/dashboard/akses-cepat/transfer-out.svg'
       : 'img/dashboard/akses-cepat/transfer-in.svg';
@@ -133,7 +133,7 @@ function renderQuickAccess() {
     const item = aksesItems.find((i) => i.id === id);
     if (!item) return;
     const btn = document.createElement('button');
-    btn.className = 'w-full h-[130px] rounded-[18px] border border-slate-200 bg-white  transition flex flex-col items-center justify-center gap-3';
+    btn.className = 'w-full h-[130px] rounded-[18px] border border-slate-200 bg-white hover:bg-slate-50 transition flex flex-col items-center justify-center gap-3';
     btn.innerHTML = `
       <span class="w-12 h-12 rounded-full bg-slate-100 border border-slate-200 grid place-items-center">
         <img src="${item.icon}" alt="" class="w-6 h-6 object-contain">

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -58,49 +58,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -109,7 +109,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -126,12 +126,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Informasi Rekening</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -154,7 +154,7 @@
               Tampilkan Semua Saldo
               <img src="img/icon/tampilkan-saldo.svg" alt="" class="w-6 h-6"/>
             </button>
-            <button class="px-4 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center gap-2">
               Tambah Rekening
               <span class="text-xl">+</span>
             </button>
@@ -177,10 +177,10 @@
             <p class="mt-2 text-slate-500">Saldo Aktif</p>
             <p>Rp••••</p>
             <div class="flex gap-2 mt-4">
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Mutasi Rekening <img src="img/icon/transfer-mutasi.svg" alt="" class="w-5 h-5"/>
               </button>
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Transfer <img src="img/icon/transfer.svg" alt="" class="w-5 h-5"/>
               </button>
             </div>
@@ -200,10 +200,10 @@
             <p class="mt-2  text-slate-500">Saldo Aktif</p>
             <p>Rp••••</p>
             <div class="flex gap-2 mt-4">
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Mutasi Rekening <img src="img/icon/transfer-mutasi.svg" alt="" class="w-5 h-5"/>
               </button>
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Transfer <img src="img/icon/transfer.svg" alt="" class="w-5 h-5"/>
               </button>
             </div>
@@ -223,10 +223,10 @@
             <p class="mt-2  text-slate-500">Saldo Aktif</p>
             <p>Rp••••</p>
             <div class="flex gap-2 mt-4">
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Mutasi Rekening <img src="img/icon/transfer-mutasi.svg" alt="" class="w-5 h-5"/>
               </button>
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Transfer <img src="img/icon/transfer.svg" alt="" class="w-5 h-5"/>
               </button>
             </div>
@@ -246,10 +246,10 @@
             <p class="mt-2  text-slate-500">Saldo Aktif</p>
             <p>Rp••••</p>
             <div class="flex gap-2 mt-4">
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Mutasi Rekening <img src="img/icon/transfer-mutasi.svg" alt="" class="w-5 h-5"/>
               </button>
-              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 flex items-center justify-center gap-1">
+              <button class="flex-1 px-3 py-2 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 flex items-center justify-center gap-1">
                 Transfer <img src="img/icon/transfer.svg" alt="" class="w-5 h-5"/>
               </button>
             </div>

--- a/manajemen-pengguna.html
+++ b/manajemen-pengguna.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Manajemen Pengguna</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -146,7 +146,7 @@
             <h2 class="font-semibold text-lg">Atur Pengguna</h2>
             <p class="text-slate-500  ">Kelola hak akses dan peran pengguna untuk memastikan keamanan dan efisiensi penggunaan sistem.</p>
           </div>
-          <button class="h-11 px-4 rounded-xl border border-cyan-500 text-cyan-600 bg-white flex items-center gap-2">
+          <button class="h-11 px-4 rounded-xl border border-cyan-500 text-cyan-600 bg-white hover:bg-cyan-50 flex items-center gap-2">
             <span class="text-xl font-bold">+</span> Tambah Pengguna Baru
           </button>
         </div>
@@ -157,9 +157,9 @@
             Semua
             <span class="absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button class="py-3 text-slate-600">Aktif</button>
-          <button class="py-3 text-slate-600">Non Aktif</button>
-          <button class="py-3 text-slate-600 flex items-center gap-1">
+          <button class="py-3 text-slate-600 hover:text-slate-900">Aktif</button>
+          <button class="py-3 text-slate-600 hover:text-slate-900">Non Aktif</button>
+          <button class="py-3 text-slate-600 hover:text-slate-900 flex items-center gap-1">
             KYC <span class="text-xs bg-red-500 text-white rounded-full px-1.5 py-0.5">1</span>
           </button>
         </div>
@@ -177,59 +177,59 @@
             </thead>
             <tbody class="divide-y">
               <!-- Row -->
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">A</span>
                   Arthur Taylor
                 </td>
                 <td class="px-4 py-3">arthur@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">Aktif</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">S</span>
                   Sophia Williams
                 </td>
                 <td class="px-4 py-3">sophia@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">Aktif</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">M</span>
                   Matthew Johnson
                 </td>
                 <td class="px-4 py-3">matthew@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">Aktif</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">J</span>
                   James Brown
                 </td>
                 <td class="px-4 py-3">james@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">Aktif</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">W</span>
                   Wong Fei Hung
                 </td>
                 <td class="px-4 py-3">wong@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-red-100 text-red-700 text-xs">Non Aktif</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3 flex items-center gap-3">
                   <span class="w-8 h-8 rounded-full bg-slate-200 grid place-items-center text-slate-600">W</span>
                   Wei Chen
                 </td>
                 <td class="px-4 py-3">wei@saranapancing.com</td>
                 <td class="px-4 py-3"><span class="px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-700 text-xs">KYC</span></td>
-                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button></td>
+                <td class="px-4 py-3"><button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button></td>
               </tr>
             </tbody>
           </table>

--- a/mutasi.html
+++ b/mutasi.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -128,12 +128,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Mutasi Rekening &amp; e-Statement </h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -154,7 +154,7 @@
             </div>
             <p class="text-slate-500  ">Nomor Rekening</p>
             <p class="font-bold text-slate-900 tracking-wide mb-4">0009 6789 5439</p>
-            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2">Pilih Rekening</button>
+            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
           </div>
 
           <!-- Distributor -->
@@ -165,7 +165,7 @@
             </div>
             <p class="text-slate-500  ">Nomor Rekening</p>
             <p class="font-bold text-slate-900 tracking-wide mb-4">0009 6789 5439</p>
-            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2">Pilih Rekening</button>
+            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
           </div>
 
           <!-- Partnership -->
@@ -176,7 +176,7 @@
             </div>
             <p class="text-slate-500  ">Nomor Rekening</p>
             <p class="font-bold text-slate-900 tracking-wide mb-4">0009 6789 5439</p>
-            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2">Pilih Rekening</button>
+            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
           </div>
 
           <!-- Admin -->
@@ -187,7 +187,7 @@
             </div>
             <p class="text-slate-500  ">Nomor Rekening</p>
             <p class="font-bold text-slate-900 tracking-wide mb-4">0009 6789 5439</p>
-            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2">Pilih Rekening</button>
+            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
           </div>
 
           <!-- Bill -->
@@ -198,7 +198,7 @@
             </div>
             <p class="text-slate-500  ">Nomor Rekening</p>
             <p class="font-bold text-slate-900 tracking-wide mb-4">0009 6789 5439</p>
-            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2">Pilih Rekening</button>
+            <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
           </div>
         </div>
       </div>

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Menunggu Persetujuan</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -148,8 +148,8 @@
             <span class="ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">5</span>
             <span class="absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button class="py-3 text-slate-600">Menunggu Persetujuan</button>
-          <button class="py-3 text-slate-600">Selesai</button>
+          <button class="py-3 text-slate-600 hover:text-slate-900">Menunggu Persetujuan</button>
+          <button class="py-3 text-slate-600 hover:text-slate-900">Selesai</button>
         </div>
 
         <!-- Filter Bar -->
@@ -186,44 +186,44 @@
               </tr>
             </thead>
             <tbody class="divide-y">
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">17 Agu 2024 • 20:10</td>
                 <td class="px-4 py-3">Transaksi</td>
                 <td class="px-4 py-3">Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000</td>
                 <td class="px-4 py-3">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">18 Agu 2024 • 20:10</td>
                 <td class="px-4 py-3">Manajemen Pengguna</td>
                 <td class="px-4 py-3">Penambahan Pengguna Baru - Fajar Satria - Finance &amp; Accounting</td>
                 <td class="px-4 py-3">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">19 Agu 2024 • 20:10</td>
                 <td class="px-4 py-3">Batas Transaksi</td>
                 <td class="px-4 py-3">Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko</td>
                 <td class="px-4 py-3">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">20 Agu 2024 • 20:10</td>
                 <td class="px-4 py-3">Atur Persetujuan</td>
                 <td class="px-4 py-3">Buat Persetujuan Transaksi - Persetujuan Transfer - Oleh Fajar Satria</td>
                 <td class="px-4 py-3">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="hover:bg-slate-50">
                 <td class="px-4 py-3">21 Agu 2024 • 20:10</td>
                 <td class="px-4 py-3">Pengaturan Rekening</td>
                 <td class="px-4 py-3">Hapus Rekening - Operasional - Oleh Fajar Satria</td>
                 <td class="px-4 py-3">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600">Detail</button>
+                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
                 </td>
               </tr>
             </tbody>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,12 @@
 }
 .sb-item[aria-current="page"]{padding-left:.75rem;}
 .sb-item[aria-current="page"] .sb-label{color:#fff;font-weight:600;}
+.sb-item:focus,
+.sb-item:hover{
+  outline:none;
+  border-color:transparent !important;
+  background-color:transparent !important;
+}
 
 /* keep rows steady */
 .sb-item{ height:48px; min-height:48px; align-items:center; }
@@ -46,16 +52,4 @@ button:disabled{
   border-color:transparent !important;
   cursor:not-allowed;
   opacity:1 !important;
-}
-/* Remove focus and hover styles globally */
-*:hover,
-*:focus,
-*:focus-visible,
-*:focus-within {
-  outline: none !important;
-  box-shadow: none !important;
-  background-color: inherit !important;
-  color: inherit !important;
-  border-color: inherit !important;
-  text-decoration: none !important;
 }

--- a/transfer.html
+++ b/transfer.html
@@ -59,49 +59,49 @@
       <nav class="mt-8 px-4 pb-28">
         <p class="px-2 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">UTAMA</p>
 
-        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="index.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/dashboard.svg" alt="">
           <span class="sb-label text-slate-400 text-[16px]">Beranda</span>
         </a>
 
-        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="informasi-rekening.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/inforekening.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Informasi Rekening</span>
         </a>
 
-        <a href="transfer.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="transfer.html" aria-current="page" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/transfer-active.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Transfer</span>
         </a>
 
-        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="persetujuan-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/otorisasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Persetujuan Transaksi</span>
         </a>
 
-        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="biller.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
             <img class="block w-6 h-6" src="img/sidebar/biller.svg" alt="">
           <span class="sb-label text-[16px] font-medium">Beli &amp; Bayar</span>
         </a>
 
-        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="mutasi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/mutasi.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Mutasi &amp; e-Statement</span>
         </a>
 
         <p class="px-2 mt-7 text-[11px] tracking-[.18em] text-slate-400/80 mb-3">ATUR</p>
 
-        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="manajemen-pengguna.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/user.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Manajemen Pengguna</span>
         </a>
 
-        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="batas-transaksi.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/limit.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Batas Transaksi</span>
         </a>
 
-        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent transition">
+        <a href="atur-persetujuan.html" class="sb-item group flex items-center gap-3 px-3 py-3 rounded-xl border border-transparent hover:border-slate-700/60 hover:bg-white/[.03] transition">
           <img class="w-6 h-6" src="img/sidebar/akses.svg" alt="">
           <span class="sb-label sb-text text-[16px]">Atur Persetujuan</span>
         </a>
@@ -110,7 +110,7 @@
       <div class="absolute left-0 right-0 bottom-0 border-t border-white/10 px-6 py-4 flex items-center justify-between">
         <span id="collapseLabel" class="sb-label text-slate-300">Perkecil Navigasi</span>
         <button id="navToggle" aria-expanded="true"
-                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5">
+                class="w-6 h-6 grid place-items-center rounded-md border border-white/15 bg-white/5 hover:bg-white/10">
           <img id="collapseIcon" src="img/shrink.svg" alt="" class="w-4 h-4">
         </button>
       </div>
@@ -127,12 +127,12 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Transfer</h1>
           </div>
           <div class="flex items-center gap-2">
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Bantuan</span>
             </button>
-            <button class="px-4 py-2 rounded-xl border text-base bg-white flex items-center gap-2">
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/keluar.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>
@@ -149,7 +149,7 @@
             <p class="text-slate-500 mb-6">
               Ke rekening sesama Amar Bank ataupun bank lainnya
             </p>
-            <button id="openTransferDrawer" class="mt-auto w-full h-[60px] rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2">
+            <button id="openTransferDrawer" class="mt-auto w-full h-[60px] rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2 hover:bg-cyan-50">
               Transfer Saldo
               <img src="img/icon/transfer.svg" alt="" class="w-5 h-5">
             </button>
@@ -161,7 +161,7 @@
             <p class="text-slate-500 mb-6">
               Antar rekening GIRO Anda yang didaftarkan di Amar Bank Bisnis
             </p>
-            <button class="mt-auto w-full h-[60px] rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2">
+            <button class="mt-auto w-full h-[60px] rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2 hover:bg-cyan-50">
               Pemindahan Saldo
               <img src="img/icon/pindah-saldo.svg" alt="" class="w-5 h-5">
             </button>
@@ -215,12 +215,12 @@
             <span class="text-slate-400">▾</span>
           </button>
           <ul id="categoryList" class="hidden absolute left-0 right-0 mt-1 bg-white rounded-xl border shadow divide-y z-10">
-            <li><button type="button" data-value="Tagihan" class="w-full text-left px-4 py-4 border-b-0">Tagihan</button></li>
-            <li><button type="button" data-value="Pembayaran" class="w-full text-left px-4 py-4 border-b-0">Pembayaran</button></li>
-            <li><button type="button" data-value="Transportasi" class="w-full text-left px-4 py-4 border-b-0">Transportasi</button></li>
-            <li><button type="button" data-value="Pemindahan Dana" class="w-full text-left px-4 py-4 border-b-0">Pemindahan Dana</button></li>
-            <li><button type="button" data-value="Investasi" class="w-full text-left px-4 py-4 border-b-0">Investasi</button></li>
-            <li><button type="button" data-value="Lainnya" class="w-full text-left px-4 py-4 border-b-0">Lainnya</button></li>
+            <li><button type="button" data-value="Tagihan" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Tagihan</button></li>
+            <li><button type="button" data-value="Pembayaran" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Pembayaran</button></li>
+            <li><button type="button" data-value="Transportasi" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Transportasi</button></li>
+            <li><button type="button" data-value="Pemindahan Dana" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Pemindahan Dana</button></li>
+            <li><button type="button" data-value="Investasi" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Investasi</button></li>
+            <li><button type="button" data-value="Lainnya" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Lainnya</button></li>
           </ul>
         </div>
         <div>
@@ -271,16 +271,16 @@
               <span class="text-slate-400">▾</span>
             </button>
             <ul id="bankList" class="hidden absolute left-0 right-0 mt-1 bg-white rounded-xl border shadow divide-y z-10">
-              <li><button type="button" data-value="BCA" class="w-full text-left px-4 py-4 border-b-0">BCA</button></li>
-              <li><button type="button" data-value="BNI" class="w-full text-left px-4 py-4 border-b-0">BNI</button></li>
-              <li><button type="button" data-value="BRI" class="w-full text-left px-4 py-4 border-b-0">BRI</button></li>
-              <li><button type="button" data-value="Mandiri" class="w-full text-left px-4 py-4 border-b-0">Mandiri</button></li>
-              <li><button type="button" data-value="CIMB Niaga" class="w-full text-left px-4 py-4 border-b-0">CIMB Niaga</button></li>
-              <li><button type="button" data-value="Permata" class="w-full text-left px-4 py-4 border-b-0">Permata</button></li>
-              <li><button type="button" data-value="BTN" class="w-full text-left px-4 py-4 border-b-0">BTN</button></li>
-              <li><button type="button" data-value="Bank Danamon" class="w-full text-left px-4 py-4 border-b-0">Bank Danamon</button></li>
-              <li><button type="button" data-value="Maybank" class="w-full text-left px-4 py-4 border-b-0">Maybank</button></li>
-              <li><button type="button" data-value="OCBC NISP" class="w-full text-left px-4 py-4 border-b-0">OCBC NISP</button></li>
+              <li><button type="button" data-value="BCA" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">BCA</button></li>
+              <li><button type="button" data-value="BNI" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">BNI</button></li>
+              <li><button type="button" data-value="BRI" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">BRI</button></li>
+              <li><button type="button" data-value="Mandiri" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Mandiri</button></li>
+              <li><button type="button" data-value="CIMB Niaga" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">CIMB Niaga</button></li>
+              <li><button type="button" data-value="Permata" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Permata</button></li>
+              <li><button type="button" data-value="BTN" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">BTN</button></li>
+              <li><button type="button" data-value="Bank Danamon" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Bank Danamon</button></li>
+              <li><button type="button" data-value="Maybank" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">Maybank</button></li>
+              <li><button type="button" data-value="OCBC NISP" class="w-full text-left px-4 py-4 hover:bg-slate-50 border-b-0">OCBC NISP</button></li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- restore hover and focus interaction styling across all pages by reverting earlier removal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59eaefe188330bbbb266e8b284e0f