### PR TITLE
Show transfer summary before confirmation

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -238,6 +238,12 @@
             </button>
           </div>
         </div>
+        <div id="summarySection" class="hidden text-sm space-y-2 pt-4 border-t border-slate-200">
+          <div class="flex justify-between"><span>Nominal</span><span id="summaryNominal">Rp0</span></div>
+          <div class="flex justify-between"><span>Biaya Transfer</span><span id="summaryFee">Rp0</span></div>
+          <hr class="border-slate-200"/>
+          <div class="flex justify-between font-semibold"><span>Total</span><span id="summaryTotal">Rp0</span></div>
+        </div>
       </div>
       <div class="p-4 border-t">
         <button id="confirmBtn" class="w-full rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Konfirmasi Transfer Saldo</button>

--- a/transfer.js
+++ b/transfer.js
@@ -19,6 +19,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const methodBtn = document.getElementById('methodBtn');
   const methodText = document.getElementById('methodText');
   const methodSection = document.getElementById('methodSection');
+  const summarySection = document.getElementById('summarySection');
+  const summaryNominal = document.getElementById('summaryNominal');
+  const summaryFee = document.getElementById('summaryFee');
+  const summaryTotal = document.getElementById('summaryTotal');
 
   // generic bottom sheet
   const sheetOverlay = document.getElementById('sheetOverlay');
@@ -264,6 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selectedMethod = m.name;
       selectedFee = m.fee;
       updateConfirmState();
+      updateSummary();
     }
     closeSheet();
   });
@@ -391,6 +396,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function updateSummary() {
+    if (methodSelected && amountValid) {
+      summaryNominal.textContent = 'Rp' + formatter.format(amountValue);
+      summaryFee.textContent = 'Rp' + formatter.format(selectedFee);
+      summaryTotal.textContent = 'Rp' + formatter.format(amountValue + selectedFee);
+      summarySection.classList.remove('hidden');
+    } else {
+      summarySection.classList.add('hidden');
+    }
+  }
+
   function updateMethodOptions() {
     const now = new Date();
     availableMethods = (amountValid && sourceSelected && destSelected)
@@ -405,6 +421,7 @@ document.addEventListener('DOMContentLoaded', () => {
     methodText.textContent = 'Pilih metode transfer';
     methodText.classList.add('text-slate-500');
     updateConfirmState();
+    updateSummary();
   }
 
   function updateMethodVisibility() {
@@ -421,6 +438,7 @@ document.addEventListener('DOMContentLoaded', () => {
       selectedMethod = '';
       selectedFee = 0;
       updateConfirmState();
+      updateSummary();
     }
   }
 


### PR DESCRIPTION
## Summary
- display transfer nominal, fee, and total after choosing a transfer method
- compute summary automatically based on amount and selected method

## Testing
- `node -c transfer.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a352fd3c833098120fbe591428d8