### PR TITLE
Ensure minimum 16px font size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,3 +53,18 @@ button:disabled{
   cursor:not-allowed;
   opacity:1 !important;
 }
+
+/* Ensure minimum readable font size */
+html, body{
+  font-size:16px;
+}
+
+.text-xs,
+.text-sm,
+.text-\[11px\],
+.text-\[12px\],
+.text-\[13px\],
+.text-\[14px\],
+.text-\[15px\]{
+  font-size:16px !important;
+}


### PR DESCRIPTION
## Summary
- enforce 16px base font across all pages
- override smaller Tailwind text utilities to maintain readable minimum font size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae3a2bb083309c70a04f8429c9dc