### PR TITLE
Add internal transfer drawer with validation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,12 @@
   transition:width .3s ease;
 }
 #drawer.open{ width:480px; }
+#moveDrawer{
+  width:0;
+  max-width:480px;
+  transition:width .3s ease;
+}
+#moveDrawer.open{ width:480px; }
 
 /* Disabled button appearance */
 button:disabled{

--- a/transfer.html
+++ b/transfer.html
@@ -161,7 +161,7 @@
             <p class="text-slate-500 mb-6">
               Antar rekening GIRO Anda yang didaftarkan di Amar Bank Bisnis
             </p>
-            <button class="mt-auto w-full py-3 rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2 hover:bg-cyan-50">
+            <button id="openMoveDrawer" class="mt-auto w-full py-3 rounded-xl border border-cyan-500 text-cyan-600 font-medium flex items-center justify-center gap-2 hover:bg-cyan-50">
               Pemindahan Saldo
               <img src="img/icon/pindah-saldo.svg" alt="" class="w-5 h-5">
             </button>
@@ -375,8 +375,54 @@
           <button id="confirmBack" class="flex-1 rounded-xl border py-3">Batalkan</button>
           <button id="confirmProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Lanjut Transfer Saldo</button>
         </div>
+  </div>
+  </div>
+  <!-- Pemindahan Saldo Drawer -->
+  <div id="moveDrawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-200">
+    <div class="flex items-center justify-between p-4 border-b">
+      <h2 class="text-lg font-semibold">Pemindahan Saldo</h2>
+      <button id="moveDrawerCloseBtn" class="text-2xl leading-none">&times;</button>
+    </div>
+    <div class="flex-1 overflow-y-auto p-4 space-y-4">
+      <div>
+        <label class="block text-sm mb-1">Sumber Rekening</label>
+        <select id="moveSourceAccount" class="w-full border rounded-xl px-3 py-3"></select>
+        <p id="moveSourceError" class="text-sm text-red-500 hidden"></p>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Rekening Tujuan</label>
+        <div id="moveDestAccount" class="w-full border rounded-xl px-3 py-3 bg-slate-50"></div>
+        <p id="moveDestError" class="text-sm text-red-500 hidden"></p>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Nominal</label>
+        <input id="moveAmount" type="number" placeholder="Masukkan nominal" class="w-full border rounded-xl px-3 py-3" />
+        <p id="moveAmountError" class="text-sm text-red-500 hidden"></p>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Kategori</label>
+        <select id="moveCategory" class="w-full border rounded-xl px-3 py-3">
+          <option value="">Pilih kategori</option>
+          <option value="Tagihan">Tagihan</option>
+          <option value="Pembayaran">Pembayaran</option>
+          <option value="Transportasi">Transportasi</option>
+          <option value="Pemindahan Dana">Pemindahan Dana</option>
+          <option value="Investasi">Investasi</option>
+          <option value="Lainnya">Lainnya</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Catatan (Opsional)</label>
+        <textarea id="moveNote" class="w-full border rounded-xl px-3 py-3" placeholder="Tulis catatan" maxlength="50"></textarea>
+        <div id="moveNoteCounter" class="text-right text-xs text-slate-400">0/50</div>
+        <p id="moveNoteError" class="text-sm text-red-500 hidden"></p>
       </div>
     </div>
+    <div class="p-4 border-t">
+      <button id="moveContinue" class="w-full rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Lanjutkan</button>
+    </div>
+  </div>
+
   </div>
 
   <script src="transfer.js"></script>

--- a/transfer.js
+++ b/transfer.js
@@ -74,6 +74,121 @@ document.addEventListener('DOMContentLoaded', () => {
   ];
 
 
+  // Pemindahan Saldo drawer elements
+  const moveOpenBtn = document.getElementById('openMoveDrawer');
+  const moveDrawer = document.getElementById('moveDrawer');
+  const moveCloseBtn = document.getElementById('moveDrawerCloseBtn');
+  const moveSourceSelect = document.getElementById('moveSourceAccount');
+  const moveDestAccount = document.getElementById('moveDestAccount');
+  const moveAmountInput = document.getElementById('moveAmount');
+  const moveCategorySelect = document.getElementById('moveCategory');
+  const moveNoteInput = document.getElementById('moveNote');
+  const moveNoteCounter = document.getElementById('moveNoteCounter');
+  const moveContinueBtn = document.getElementById('moveContinue');
+  const moveSourceError = document.getElementById('moveSourceError');
+  const moveDestError = document.getElementById('moveDestError');
+  const moveAmountError = document.getElementById('moveAmountError');
+  const moveNoteError = document.getElementById('moveNoteError');
+
+  let sourceAccount = 0;
+  let destinationAccount = 1;
+  let amount = 0;
+  let category = '';
+  let note = '';
+
+  accounts.forEach((acc, idx) => {
+    const opt = document.createElement('option');
+    opt.value = idx;
+    opt.textContent = `${acc.name} - ${acc.number}`;
+    moveSourceSelect?.appendChild(opt);
+  });
+
+  function updateMoveAccounts() {
+    moveSourceSelect.value = sourceAccount;
+    const dest = accounts[destinationAccount];
+    moveDestAccount.textContent = `${dest.name} - ${dest.number}`;
+  }
+  updateMoveAccounts();
+  validateMove();
+
+  function openMoveDrawer() {
+    moveDrawer.classList.add('open');
+    if (typeof window.sidebarCollapseForDrawer === 'function') {
+      window.sidebarCollapseForDrawer();
+    }
+  }
+
+  function closeMoveDrawer() {
+    moveDrawer.classList.remove('open');
+    if (typeof window.sidebarRestoreForDrawer === 'function') {
+      window.sidebarRestoreForDrawer();
+    }
+  }
+
+  moveOpenBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    openMoveDrawer();
+  });
+  moveCloseBtn?.addEventListener('click', closeMoveDrawer);
+
+  moveSourceSelect?.addEventListener('change', e => {
+    sourceAccount = parseInt(e.target.value);
+    destinationAccount = sourceAccount === 0 ? 1 : 0;
+    updateMoveAccounts();
+    validateMove();
+  });
+
+  moveAmountInput?.addEventListener('input', e => {
+    amount = parseFloat(e.target.value);
+    validateMove();
+  });
+
+  moveCategorySelect?.addEventListener('change', e => {
+    category = e.target.value;
+  });
+
+  moveNoteInput?.addEventListener('input', e => {
+    note = e.target.value;
+    moveNoteCounter.textContent = `${note.length}/50`;
+    validateMove();
+  });
+
+  function validateMove() {
+    let valid = true;
+    if (isNaN(amount) || amount <= 0) {
+      moveAmountError.textContent = 'Nominal harus lebih dari 0';
+      moveAmountError.classList.remove('hidden');
+      valid = false;
+    } else {
+      moveAmountError.classList.add('hidden');
+    }
+
+    if (sourceAccount === destinationAccount) {
+      const msg = 'Sumber dan tujuan tidak boleh sama';
+      moveSourceError.textContent = msg;
+      moveDestError.textContent = msg;
+      moveSourceError.classList.remove('hidden');
+      moveDestError.classList.remove('hidden');
+      valid = false;
+    } else {
+      moveSourceError.classList.add('hidden');
+      moveDestError.classList.add('hidden');
+    }
+
+    if (note.length > 50) {
+      moveNoteError.textContent = 'Maksimal 50 karakter';
+      moveNoteError.classList.remove('hidden');
+      valid = false;
+    } else {
+      moveNoteError.classList.add('hidden');
+    }
+
+    moveContinueBtn.disabled = !valid;
+    moveContinueBtn.classList.toggle('opacity-50', !valid);
+    moveContinueBtn.classList.toggle('cursor-not-allowed', !valid);
+  }
+
+
   function isBusinessDay(date) {
     const day = date.getDay();
     return day >= 1 && day <= 5; // Monday-Friday


### PR DESCRIPTION
## Summary
- add Pemindahan Saldo drawer with form fields and inline errors
- auto-switch destination account and validate amount, account, and note
- keep continue button disabled until form is valid

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check transfer.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6c77e652c8330b36a4670f9d5f7c8