### PR TITLE
Hide categories in collapsed sidebar and add distributor account

### DIFF
--- a/data/account.json
+++ b/data/account.json
@@ -18,5 +18,14 @@
       {"date": "10 September", "description": "Pembelian ATK", "amount": -500000},
       {"date": "11 September", "description": "Penjualan Produk", "amount": 2000000}
     ]
+  },
+  {
+    "id": 3,
+    "name": "Rekening Distributor",
+    "balance": 62000000,
+    "transactions": [
+      {"date": "9 September", "description": "Pembelian Barang", "amount": -1000000},
+      {"date": "8 September", "description": "Penjualan Produk", "amount": 5000000}
+    ]
   }
 ]

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,12 @@
   opacity:0; width:0; margin-left:0; overflow:hidden; display:none;
 }
 
+/* hide category headings when sidebar is collapsed */
+#sidebar.collapsed nav > p,
+.sidebar-collapsed #sidebar nav > p{
+  display:none;
+}
+
 /* center items when collapsed */
 #sidebar.collapsed .sb-item,
 .sidebar-collapsed #sidebar .sb-item{ justify-content:center; padding-left:0; padding-right:0; gap:.5rem; }


### PR DESCRIPTION
## Summary
- Hide UTAMA and ATUR headings when the sidebar is collapsed
- Add a Distributor account with Rp62.000.000,00 to sample account data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6db64f7d483309cba7a0f664096e6