### PR TITLE
Hide duplicate account on balance move and add sidebar tooltips

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -101,7 +101,11 @@ document.addEventListener('DOMContentLoaded', () => {
       e.stopPropagation(); // don’t toggle
     });
     const lbl = a.querySelector('.sb-label');
-    if (lbl && !a.title) a.title = lbl.textContent.trim();
+    const text = lbl?.textContent.trim();
+    if (text) {
+      if (!a.title) a.title = text;
+      a.setAttribute('data-label', text);
+    }
   });
 
   // expose helper for other scripts

--- a/styles.css
+++ b/styles.css
@@ -15,11 +15,11 @@
 }
 
 /* keep rows steady */
-.sb-item{ height:48px; min-height:48px; align-items:center; }
+.sb-item{ height:48px; min-height:48px; align-items:center; position:relative; }
 .sb-item img{ display:block; } /* no baseline jitter */
 
 /* collapse behavior */
-#sidebar{ transition: width .25s ease; }
+#sidebar{ transition: width .25s ease; overflow:visible; }
 #sidebar.collapsed,
 .sidebar-collapsed #sidebar{ width:84px !important; }
 
@@ -42,6 +42,24 @@
 /* center items when collapsed */
 #sidebar.collapsed .sb-item,
 .sidebar-collapsed #sidebar .sb-item{ justify-content:center; padding-left:0; padding-right:0; gap:.5rem; }
+
+/* Tooltip helper when sidebar is collapsed */
+#sidebar.collapsed .sb-item:hover::after,
+.sidebar-collapsed #sidebar .sb-item:hover::after{
+  content: attr(data-label);
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left:8px;
+  background-color: rgba(15,27,37,.9);
+  color:#fff;
+  padding:4px 8px;
+  border-radius:6px;
+  white-space:nowrap;
+  pointer-events:none;
+  z-index:50;
+}
 
 /* Drawer push panel */
 #drawer, #moveDrawer{

--- a/transfer.js
+++ b/transfer.js
@@ -207,7 +207,13 @@ document.addEventListener('DOMContentLoaded', () => {
   function openMoveDestSheet() {
     currentSheetType = 'moveDest';
     selectedIndex = null;
-    currentData = accounts;
+    // If a source account has been selected, exclude it from destination list
+    if (moveSourceSelected) {
+      const sourceName = moveSourceBtn.textContent.split(' - ')[0];
+      currentData = accounts.filter(acc => acc.name !== sourceName);
+    } else {
+      currentData = accounts;
+    }
     sheetTitle.textContent = 'Rekening Tujuan';
     sheetChoose.textContent = 'Pilih Rekening';
     renderList(currentData);


### PR DESCRIPTION
## Summary
- Exclude selected source account from destination options when moving balance.
- Show helper text for sidebar icons when collapsed using data attributes and CSS tooltips.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dfb66dfc83309248d7093ef49504