### PR TITLE
Adjust transfer card layout when drawer opens

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -142,7 +142,7 @@
         <!-- ============ HEADER ============ -->
 
         <!-- Menu cards -->
-        <div class="grid md:grid-cols-3 gap-6">
+        <div id="cardGrid" class="grid md:grid-cols-3 gap-6">
           <!-- Transfer Saldo -->
           <div class="rounded-2xl border border-slate-200 p-6 flex flex-col">
             <h2 class="text-lg font-semibold mb-2">Transfer Saldo</h2>

--- a/transfer.js
+++ b/transfer.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const openBtn  = document.getElementById('openTransferDrawer');
   const drawer   = document.getElementById('drawer');
   const closeBtn = document.getElementById('drawerCloseBtn');
+  const cardGrid = document.getElementById('cardGrid');
 
   // buttons & inputs in form
   const sourceBtn = document.getElementById('sourceAccountBtn');
@@ -473,6 +474,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function openDrawer() {
     closeMoveDrawerPanel();
     drawer.classList.add('open');
+    cardGrid?.classList.remove('md:grid-cols-3');
+    cardGrid?.classList.add('md:grid-cols-2');
     if (typeof window.sidebarCollapseForDrawer === 'function') {
       window.sidebarCollapseForDrawer();
     }
@@ -483,6 +486,8 @@ document.addEventListener('DOMContentLoaded', () => {
     closeSheet();
     closeDestSheet();
     closeConfirmSheet();
+    cardGrid?.classList.remove('md:grid-cols-2');
+    cardGrid?.classList.add('md:grid-cols-3');
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
     }
@@ -491,6 +496,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function openMoveDrawerPanel() {
     closeDrawer();
     moveDrawer.classList.add('open');
+    cardGrid?.classList.remove('md:grid-cols-3');
+    cardGrid?.classList.add('md:grid-cols-2');
     moveSourceBtn.textContent = 'Pilih sumber rekening';
     moveSourceBtn.classList.add('text-slate-500');
     moveDestBtn.textContent = 'Pilih rekening tujuan';
@@ -520,6 +527,8 @@ document.addEventListener('DOMContentLoaded', () => {
     closeSheet();
     closeDestSheet();
     closeConfirmSheet();
+    cardGrid?.classList.remove('md:grid-cols-2');
+    cardGrid?.classList.add('md:grid-cols-3');
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
     }


### PR DESCRIPTION
## Summary
- Ensure Transfer and Pemindahan Saldo cards switch to a two-column grid when either drawer opens
- Add `cardGrid` identifier and update drawer logic to toggle between 2 and 3 columns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c77746182883309d9ccd0eaf028017