### PR TITLE
Keep drawer static while switching content

### DIFF
--- a/app.js
+++ b/app.js
@@ -772,24 +772,19 @@ setTimeout(() => {
       set("succTotal",   payload.total);
     }
 
-    // Slide out input drawer, slide in success drawer
-    const split = document.getElementById("deskSplit");
-    paneInput?.classList.replace("w-[520px]", "w-0");
-    split?.classList.remove("gap-6"); split?.classList.add("gap-0");
-
-    paneSucc?.classList.replace("w-0", "w-[520px]");
-    requestAnimationFrame(() => {
-      innerSucc?.classList.remove("opacity-0","translate-x-2");
-      innerSucc?.classList.add("opacity-100","translate-x-0");
-    });
+    // Swap input and success content without sliding the drawer
+    paneInput?.classList.add('hidden');
+    paneSucc?.classList.remove('hidden');
+    innerSucc?.classList.remove('opacity-0','translate-x-2');
+    innerSucc?.classList.add('opacity-100','translate-x-0');
 
     // Close handlers
     const closeSuccess = () => {
-      innerSucc?.classList.add("opacity-0","translate-x-2");
-      innerSucc?.classList.remove("opacity-100","translate-x-0");
+      innerSucc?.classList.add('opacity-0','translate-x-2');
+      innerSucc?.classList.remove('opacity-100','translate-x-0');
       setTimeout(() => {
-        paneSucc?.classList.replace("w-[520px]", "w-0");
-        split?.classList.remove("gap-0"); split?.classList.add("gap-6");
+        paneSucc?.classList.add('hidden');
+        paneInput?.classList.remove('hidden');
       }, 200);
     };
     document.getElementById("closeSuccessPane")?.addEventListener("click", closeSuccess, { once:true });
@@ -803,17 +798,16 @@ setTimeout(() => {
 
 /* ---------- RESET ACTIVE BUTTON ---------- */
 function closeSuccessDrawer() {
-  const split     = document.getElementById('deskSplit');
   const paneSucc  = document.getElementById('plnSuccessPane');
+  const paneInput = document.getElementById('plnPane');
   const innerSucc = document.getElementById('plnSuccessInner');
   const billTile  = document.getElementById('tilePlnBill');
 
   innerSucc.classList.add('opacity-0','translate-x-2');
   innerSucc.classList.remove('opacity-100','translate-x-0');
   setTimeout(() => {
-    paneSucc?.classList.replace('w-[520px]', 'w-0');
-    split?.classList.remove('gap-0'); 
-    split?.classList.add('gap-6');
+    paneSucc?.classList.add('hidden');
+    paneInput?.classList.remove('hidden');
 
     // reset Tagihan Listrik tile to inactive
     billTile?.classList.remove('ring-2','ring-cyan-400','border-cyan-300','bg-cyan-50');

--- a/styles.css
+++ b/styles.css
@@ -62,12 +62,12 @@
 }
 
 /* Drawer push panel */
-#drawer, #moveDrawer{
+#drawer{
   width:0;
   max-width:480px;
   transition:width .3s ease;
 }
-#drawer.open, #moveDrawer.open{ width:480px; }
+#drawer.open{ width:480px; }
 
 /* Disabled button appearance */
 button:disabled{

--- a/transfer.html
+++ b/transfer.html
@@ -174,11 +174,12 @@
 
     <!-- Drawer -->
     <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-200">
-      <div class="flex items-center justify-between p-4 border-b">
-        <h2 class="text-lg font-semibold">Transfer Saldo</h2>
-        <button id="drawerCloseBtn" class="text-2xl leading-none">&times;</button>
-      </div>
-      <div class="flex-1 overflow-y-auto p-4 space-y-4">
+      <div id="transferPane" class="h-full flex flex-col">
+        <div class="flex items-center justify-between p-4 border-b">
+          <h2 class="text-lg font-semibold">Transfer Saldo</h2>
+          <button id="drawerCloseBtn" class="text-2xl leading-none">&times;</button>
+        </div>
+        <div class="flex-1 overflow-y-auto p-4 space-y-4">
         <div>
           <label class="block text-sm mb-1">Sumber Rekening</label>
           <button id="sourceAccountBtn" class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih sumber rekening</button>
@@ -248,15 +249,15 @@
       <div class="p-4 border-t">
         <button id="confirmBtn" class="w-full rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Konfirmasi Transfer Saldo</button>
       </div>
-    </div>
-
-    <!-- Pemindahan Drawer -->
-    <div id="moveDrawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-200">
-      <div class="flex items-center justify-between p-4 border-b">
-        <h2 class="text-lg font-semibold">Pemindahan Saldo</h2>
-        <button id="moveDrawerCloseBtn" class="text-2xl leading-none">&times;</button>
       </div>
-      <div class="flex-1 overflow-y-auto p-4 space-y-4">
+
+      <!-- Move Pane -->
+      <div id="movePane" class="hidden h-full flex flex-col">
+        <div class="flex items-center justify-between p-4 border-b">
+          <h2 class="text-lg font-semibold">Pemindahan Saldo</h2>
+          <button id="moveDrawerCloseBtn" class="text-2xl leading-none">&times;</button>
+        </div>
+        <div class="flex-1 overflow-y-auto p-4 space-y-4">
         <div>
           <label class="block text-sm mb-1">Sumber Rekening</label>
           <button id="moveSourceBtn" class="w-full text-left border rounded-xl px-3 py-3 text-slate-500">Pilih sumber rekening</button>
@@ -299,8 +300,9 @@
         <button id="moveConfirmBtn" class="w-full rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Konfirmasi Pemindahan Saldo</button>
       </div>
     </div>
+  </div>
 
-    <!-- Bottom Sheet Overlay & Panel -->
+  <!-- Bottom Sheet Overlay & Panel -->
     <div id="sheetOverlay" class="hidden fixed inset-0 bg-black/20 opacity-0 transition-opacity z-10"></div>
     <div id="bottomSheet" class="fixed bottom-0 right-0 w-full max-w-[480px] bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform max-h-[80%] h-1/2 z-20 flex flex-col">
       <div class="p-4 border-b">

--- a/transfer.js
+++ b/transfer.js
@@ -3,6 +3,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const openBtn  = document.getElementById('openTransferDrawer');
   const drawer   = document.getElementById('drawer');
+  const transferPane = document.getElementById('transferPane');
+  const movePane = document.getElementById('movePane');
   const closeBtn = document.getElementById('drawerCloseBtn');
   const cardGrid = document.getElementById('cardGrid');
 
@@ -70,7 +72,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // move drawer elements
   const openMoveBtn = document.getElementById('openMoveDrawer');
-  const moveDrawer = document.getElementById('moveDrawer');
   const moveCloseBtn = document.getElementById('moveDrawerCloseBtn');
   const moveSourceBtn = document.getElementById('moveSourceBtn');
   const moveDestBtn = document.getElementById('moveDestBtn');
@@ -472,7 +473,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function openDrawer() {
-    closeMoveDrawerPanel();
+    movePane.classList.add('hidden');
+    transferPane.classList.remove('hidden');
     drawer.classList.add('open');
     cardGrid?.classList.remove('md:grid-cols-3');
     cardGrid?.classList.add('md:grid-cols-2');
@@ -482,6 +484,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function closeDrawer() {
+    transferPane.classList.add('hidden');
+    movePane.classList.add('hidden');
     drawer.classList.remove('open');
     closeSheet();
     closeDestSheet();
@@ -494,8 +498,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function openMoveDrawerPanel() {
-    closeDrawer();
-    moveDrawer.classList.add('open');
+    transferPane.classList.add('hidden');
+    movePane.classList.remove('hidden');
+    drawer.classList.add('open');
     cardGrid?.classList.remove('md:grid-cols-3');
     cardGrid?.classList.add('md:grid-cols-2');
     moveSourceBtn.textContent = 'Pilih sumber rekening';
@@ -522,18 +527,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function closeMoveDrawerPanel() {
-    moveDrawer.classList.remove('open');
-    closeSheet();
-    closeDestSheet();
-    closeConfirmSheet();
-    cardGrid?.classList.remove('md:grid-cols-2');
-    cardGrid?.classList.add('md:grid-cols-3');
-    if (typeof window.sidebarRestoreForDrawer === 'function') {
-      window.sidebarRestoreForDrawer();
-    }
-  }
-
   openBtn?.addEventListener('click', (e) => {
     e.preventDefault();
     openDrawer();
@@ -543,7 +536,7 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     openMoveDrawerPanel();
   });
-  moveCloseBtn?.addEventListener('click', closeMoveDrawerPanel);
+  moveCloseBtn?.addEventListener('click', closeDrawer);
 
   // helpers
   const formatter = new Intl.NumberFormat('id-ID');


### PR DESCRIPTION
## Summary
- Embed move balance form within primary drawer and toggle panes without closing the drawer
- Remove separate move drawer styles and keep single static drawer width
- Swap content for success drawers without sliding the container

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77928635c833083be92e2943c4dc9