### PR TITLE
Fix drawer overlay to avoid card text shift

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,15 +74,11 @@ function formatCurrency(num) {
 const drawer = document.getElementById('drawer');
 const openBtn = document.getElementById('ubahAksesBtn');
 const closeBtn = document.getElementById('drawerCloseBtn');
-const dashboardGrid = document.getElementById('dashboardGrid');
-const pendingSection = document.getElementById('pendingSection');
 
 function openDrawer() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
   drawer.classList.add('open');
-  dashboardGrid?.classList.replace('lg:grid-cols-3', 'lg:grid-cols-2');
-  pendingSection?.classList.replace('lg:col-span-1', 'lg:col-span-2');
   if (typeof window.sidebarCollapseForDrawer === 'function') {
     window.sidebarCollapseForDrawer();
   }
@@ -90,8 +86,6 @@ function openDrawer() {
 
 function closeDrawer() {
   drawer.classList.remove('open');
-  dashboardGrid?.classList.replace('lg:grid-cols-2', 'lg:grid-cols-3');
-  pendingSection?.classList.replace('lg:col-span-2', 'lg:col-span-1');
   if (typeof window.sidebarRestoreForDrawer === 'function') {
     window.sidebarRestoreForDrawer();
   }

--- a/styles.css
+++ b/styles.css
@@ -61,13 +61,21 @@
   z-index:50;
 }
 
-/* Drawer push panel */
+/* Drawer overlay panel */
 #drawer{
-  width:0;
+  position:fixed;
+  top:0;
+  right:0;
+  height:100%;
+  width:100%;
   max-width:480px;
-  transition:width .3s ease;
+  transform:translateX(100%);
+  transition:transform .3s ease;
+  z-index:60;
 }
-#drawer.open{ width:480px; }
+#drawer.open{
+  transform:translateX(0);
+}
 
 /* Disabled button appearance */
 button:disabled{

--- a/transfer.js
+++ b/transfer.js
@@ -476,8 +476,6 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.add('hidden');
     transferPane.classList.remove('hidden');
     drawer.classList.add('open');
-    cardGrid?.classList.remove('md:grid-cols-3');
-    cardGrid?.classList.add('md:grid-cols-2');
     if (typeof window.sidebarCollapseForDrawer === 'function') {
       window.sidebarCollapseForDrawer();
     }
@@ -490,8 +488,6 @@ document.addEventListener('DOMContentLoaded', () => {
     closeSheet();
     closeDestSheet();
     closeConfirmSheet();
-    cardGrid?.classList.remove('md:grid-cols-2');
-    cardGrid?.classList.add('md:grid-cols-3');
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
     }
@@ -501,8 +497,6 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.add('hidden');
     movePane.classList.remove('hidden');
     drawer.classList.add('open');
-    cardGrid?.classList.remove('md:grid-cols-3');
-    cardGrid?.classList.add('md:grid-cols-2');
     moveSourceBtn.textContent = 'Pilih sumber rekening';
     moveSourceBtn.classList.add('text-slate-500');
     moveDestBtn.textContent = 'Pilih rekening tujuan';


### PR DESCRIPTION
## Summary
- Convert drawer to a fixed overlay so opening it no longer pushes main content
- Simplify drawer logic by removing grid column toggles that caused card text to shift

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7825b8afc83309c3ea83add93abbc