### PR TITLE
Make drawer push content instead of overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -61,20 +61,17 @@
   z-index:50;
 }
 
-/* Drawer overlay panel */
+/* Drawer panel that pushes main content instead of overlaying */
 #drawer{
-  position:fixed;
-  top:0;
-  right:0;
-  height:100%;
-  width:100%;
+  width:0;
   max-width:480px;
-  transform:translateX(100%);
-  transition:transform .3s ease;
-  z-index:60;
+  overflow:hidden;
+  transition:width .3s ease;
+  border-left-width:0;
 }
 #drawer.open{
-  transform:translateX(0);
+  width:100%;
+  border-left-width:1px;
 }
 
 /* Disabled button appearance */


### PR DESCRIPTION
## Summary
- Update drawer styling so it expands from the right and pushes the main content left

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c78552fd088330bd2211ccbdf27b9f