### PR TITLE
Add unified filter popovers with apply/reset logic

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -1,0 +1,84 @@
+(function() {
+  const filters = document.querySelectorAll('.filter');
+  let openPanel = null;
+
+  filters.forEach(filter => {
+    const trigger = filter.querySelector('.filter-trigger');
+    const panel = filter.querySelector('.filter-panel');
+    const options = panel.querySelectorAll('input');
+    const applyBtn = panel.querySelector('.apply');
+    const cancelBtn = panel.querySelector('.cancel');
+    const labelSpan = trigger.querySelector('.filter-label');
+    const name = filter.dataset.name;
+    const defaultLabel = filter.dataset.default;
+    const isMulti = options[0] && options[0].type === 'checkbox';
+
+    function getSelected() {
+      return Array.from(options).filter(o => o.checked).map(o => o.value);
+    }
+
+    function updateButtons() {
+      const selected = getSelected();
+      applyBtn.disabled = selected.length === 0;
+      cancelBtn.textContent = selected.length ? 'Reset Ulang' : 'Batalkan';
+    }
+
+    function open() {
+      if (openPanel && openPanel !== panel) openPanel.classList.add('hidden');
+      const applied = filter.dataset.applied;
+      const appliedArr = applied ? applied.split(',') : [];
+      options.forEach(o => {
+        o.checked = appliedArr.includes(o.value);
+      });
+      updateButtons();
+      panel.classList.remove('hidden');
+      openPanel = panel;
+    }
+
+    function close() {
+      panel.classList.add('hidden');
+      openPanel = null;
+    }
+
+    trigger.addEventListener('click', () => {
+      panel.classList.contains('hidden') ? open() : close();
+    });
+
+    options.forEach(o => o.addEventListener('change', updateButtons));
+
+    applyBtn.addEventListener('click', () => {
+      const selected = getSelected();
+      filter.dataset.applied = selected.join(',');
+      if (isMulti) {
+        if (selected.length === 1) {
+          labelSpan.textContent = selected[0];
+        } else if (selected.length > 1) {
+          labelSpan.textContent = `${name} (${selected.length})`;
+        } else {
+          labelSpan.textContent = defaultLabel;
+        }
+      } else {
+        labelSpan.textContent = selected[0] || defaultLabel;
+      }
+      document.dispatchEvent(new CustomEvent('filter-change'));
+      close();
+    });
+
+    cancelBtn.addEventListener('click', () => {
+      if (cancelBtn.textContent === 'Batalkan') {
+        close();
+      } else {
+        options.forEach(o => {
+          o.checked = false;
+        });
+        updateButtons();
+      }
+    });
+
+    document.addEventListener('click', e => {
+      if (!filter.contains(e.target) && !panel.classList.contains('hidden')) {
+        close();
+      }
+    });
+  });
+})();

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -161,24 +161,91 @@
         </div>
 
         <!-- Filter Bar -->
-        <div class="flex items-center gap-3 mb-4">
-          <div class="relative">
-            <select class="appearance-none h-11 rounded-xl border border-slate-300 pl-10 pr-8 text-slate-700 bg-white w-[200px]">
-              <option>Semua Tanggal</option>
-              <option>Hari Ini</option>
-              <option>Minggu Ini</option>
-              <option>Bulan Ini</option>
-            </select>
-            <img src="img/icon/date-picker.svg" class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500"/>
+        <div class="flex items-center gap-3 mb-4" id="filterBar">
+          <!-- Date Filter -->
+          <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Semua Tanggal">
+            <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2">
+              <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
+              <span class="filter-label max-w-[120px] truncate">Semua Tanggal</span>
+            </button>
+            <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-52">
+              <div class="flex flex-col gap-2">
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="date" value="hari-ini">
+                  <span>Hari Ini</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="date" value="minggu-ini">
+                  <span>Minggu Ini</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="date" value="bulan-ini">
+                  <span>Bulan Ini</span>
+                </label>
+              </div>
+              <div class="flex justify-end gap-2 mt-4">
+                <button class="cancel px-3 py-1 rounded-lg border text-slate-600">Batalkan</button>
+                <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50" disabled>Terapkan</button>
+              </div>
+            </div>
           </div>
-          <div class="relative">
-            <select class="appearance-none h-11 rounded-xl border border-slate-300 pl-10 pr-8 text-slate-700 bg-white w-[200px]">
-              <option>Transaksi</option>
-              <option>Manajemen Pengguna</option>
-              <option>Batas Transaksi</option>
-              <option>Atur Persetujuan</option>
-            </select>
-            <img src="img/icon/filter.svg" class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500"/>
+          <!-- Jenis Transaksi -->
+          <div class="filter relative" data-filter="jenis" data-name="Jenis Transaksi" data-default="Semua Jenis">
+            <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2">
+              <img src="img/icon/filter.svg" class="w-5 h-5"/>
+              <span class="filter-label max-w-[120px] truncate">Semua Jenis</span>
+            </button>
+            <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-52">
+              <div class="flex flex-col gap-2">
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="jenis" value="kredit">
+                  <span>Kredit</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="jenis" value="debit">
+                  <span>Debit</span>
+                </label>
+              </div>
+              <div class="flex justify-end gap-2 mt-4">
+                <button class="cancel px-3 py-1 rounded-lg border text-slate-600">Batalkan</button>
+                <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50" disabled>Terapkan</button>
+              </div>
+            </div>
+          </div>
+          <!-- Kategori -->
+          <div class="filter relative" data-filter="kategori" data-name="Kategori" data-default="Kategori">
+            <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2">
+              <img src="img/icon/filter.svg" class="w-5 h-5"/>
+              <span class="filter-label max-w-[120px] truncate">Kategori</span>
+            </button>
+            <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-52">
+              <div class="flex flex-col gap-2">
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" value="Transaksi">
+                  <span>Transaksi</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" value="Manajemen Pengguna">
+                  <span>Manajemen Pengguna</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" value="Batas Transaksi">
+                  <span>Batas Transaksi</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" value="Atur Persetujuan">
+                  <span>Atur Persetujuan</span>
+                </label>
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" value="Pengaturan Rekening">
+                  <span>Pengaturan Rekening</span>
+                </label>
+              </div>
+              <div class="flex justify-end gap-2 mt-4">
+                <button class="cancel px-3 py-1 rounded-lg border text-slate-600">Batalkan</button>
+                <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50" disabled>Terapkan</button>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -201,6 +268,7 @@
     <!-- ============ /MAIN ============ -->
   </div>
 
+  <script src="filters.js"></script>
   <script src="persetujuan-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -1,36 +1,88 @@
 const approvalsData = {
   butuh: [
-    { time: '17 Agu 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '18 Agu 2024 • 20:10', category: 'Manajemen Pengguna', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance & Accounting' },
-    { time: '19 Agu 2024 • 20:10', category: 'Batas Transaksi', description: 'Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
-    { time: '20 Agu 2024 • 20:10', category: 'Atur Persetujuan', description: 'Buat Persetujuan Transaksi - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '21 Agu 2024 • 20:10', category: 'Pengaturan Rekening', description: 'Hapus Rekening - Operasional - Oleh Fajar Satria' },
-    { time: '22 Agu 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke Mandiri PT Aman Jaya - Rp100.000.000' },
-    { time: '23 Agu 2024 • 20:10', category: 'Manajemen Pengguna', description: 'Nonaktifkan Pengguna - Budi Santoso - Admin' },
-    { time: '24 Agu 2024 • 20:10', category: 'Batas Transaksi', description: 'Tambah Batas Transaksi - Dari Rp250.000.000 ke Rp300.000.000 - Oleh Bimo Purwoko' },
-    { time: '25 Agu 2024 • 20:10', category: 'Atur Persetujuan', description: 'Edit Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '26 Agu 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke BRI PT Nusantara - Rp75.000.000' }
+    { time: '17 Agu 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
+    { time: '18 Agu 2024 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance & Accounting' },
+    { time: '19 Agu 2024 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
+    { time: '20 Agu 2024 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan Transaksi - Persetujuan Transfer - Oleh Fajar Satria' },
+    { time: '21 Agu 2024 • 20:10', category: 'Pengaturan Rekening', jenis: 'debit', description: 'Hapus Rekening - Operasional - Oleh Fajar Satria' },
+    { time: '22 Agu 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke Mandiri PT Aman Jaya - Rp100.000.000' },
+    { time: '23 Agu 2024 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Nonaktifkan Pengguna - Budi Santoso - Admin' },
+    { time: '24 Agu 2024 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Tambah Batas Transaksi - Dari Rp250.000.000 ke Rp300.000.000 - Oleh Bimo Purwoko' },
+    { time: '25 Agu 2024 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Edit Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
+    { time: '26 Agu 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BRI PT Nusantara - Rp75.000.000' }
   ],
   menunggu: [
-    { time: '27 Agu 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp60.000.000' },
-    { time: '28 Agu 2024 • 20:10', category: 'Manajemen Pengguna', description: 'Penambahan Pengguna Baru - Siti Aisyah - Marketing' },
-    { time: '29 Agu 2024 • 20:10', category: 'Batas Transaksi', description: 'Ubah Batas Transaksi - Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
-    { time: '30 Agu 2024 • 20:10', category: 'Atur Persetujuan', description: 'Buat Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '31 Agu 2024 • 20:10', category: 'Pengaturan Rekening', description: 'Tambah Rekening - Operasional - Oleh Fajar Satria' },
-    { time: '01 Sep 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke BNI PT Sejahtera - Rp90.000.000' }
+    { time: '27 Agu 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp60.000.000' },
+    { time: '28 Agu 2024 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Siti Aisyah - Marketing' },
+    { time: '29 Agu 2024 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
+    { time: '30 Agu 2024 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
+    { time: '31 Agu 2024 • 20:10', category: 'Pengaturan Rekening', jenis: 'debit', description: 'Tambah Rekening - Operasional - Oleh Fajar Satria' },
+    { time: '01 Sep 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BNI PT Sejahtera - Rp90.000.000' }
   ],
   selesai: [
-    { time: '02 Sep 2024 • 20:10', category: 'Transaksi', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '03 Sep 2024 • 20:10', category: 'Manajemen Pengguna', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance' },
-    { time: '04 Sep 2024 • 20:10', category: 'Batas Transaksi', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
+    { time: '02 Sep 2024 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
+    { time: '03 Sep 2024 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance' },
+    { time: '04 Sep 2024 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
   ]
 };
 
 const tabButtons = document.querySelectorAll('.tab-btn');
 const tableBody = document.getElementById('approvalBody');
+let currentTab = 'butuh';
+
+function parseDate(str) {
+  const months = {Jan:0, Feb:1, Mar:2, Apr:3, Mei:4, Jun:5, Jul:6, Agu:7, Sep:8, Okt:9, Nov:10, Des:11};
+  const [datePart, timePart] = str.split('•').map(s => s.trim());
+  const [day, mon, year] = datePart.split(' ');
+  const [hour, min] = timePart.split(':');
+  return new Date(+year, months[mon], +day, +hour, +min);
+}
+
+function getFilters() {
+  const get = key => {
+    const el = document.querySelector(`.filter[data-filter="${key}"]`);
+    return el ? el.dataset.applied || '' : '';
+  };
+  return {
+    date: get('date'),
+    jenis: get('jenis'),
+    kategori: get('kategori')
+  };
+}
 
 function render(tab) {
-  const list = approvalsData[tab];
+  currentTab = tab;
+  let list = approvalsData[tab];
+  const filters = getFilters();
+
+  if (filters.date) {
+    const now = new Date();
+    list = list.filter(item => {
+      const d = parseDate(item.time);
+      if (filters.date === 'hari-ini') {
+        return d.toDateString() === now.toDateString();
+      }
+      if (filters.date === 'minggu-ini') {
+        const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+        return d >= weekAgo;
+      }
+      if (filters.date === 'bulan-ini') {
+        const monthAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+        return d >= monthAgo;
+      }
+      return true;
+    });
+  }
+
+  if (filters.jenis) {
+    list = list.filter(item => item.jenis === filters.jenis);
+  }
+
+  if (filters.kategori) {
+    const cats = filters.kategori.split(',');
+    list = list.filter(item => cats.includes(item.category));
+  }
+
   tableBody.innerHTML = '';
   list.forEach(item => {
     const tr = document.createElement('tr');
@@ -81,3 +133,5 @@ tabButtons.forEach(btn => {
     render(tab);
   });
 });
+
+document.addEventListener('filter-change', () => render(currentTab));


### PR DESCRIPTION
## Summary
- Replace select elements with popover filters for date range, transaction type, and category
- Add reusable `filters.js` to handle default, selection, and applied states
- Apply filter selections to approval table

## Testing
- `node --check filters.js`
- `node --check persetujuan-transaksi.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d683a10c8330b8c6b30b2cb8ece3