### PR TITLE
feat: add flexible approval filters

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -5,13 +5,16 @@
   filters.forEach(filter => {
     const trigger = filter.querySelector('.filter-trigger');
     const panel = filter.querySelector('.filter-panel');
-    const options = panel.querySelectorAll('input');
+    const options = panel.querySelectorAll('input[type="radio"], input[type="checkbox"]');
     const applyBtn = panel.querySelector('.apply');
     const cancelBtn = panel.querySelector('.cancel');
     const labelSpan = trigger.querySelector('.filter-label');
     const name = filter.dataset.name;
     const defaultLabel = filter.dataset.default;
     const isMulti = options[0] && options[0].type === 'checkbox';
+    const isDate = filter.dataset.filter === 'date';
+    const customRange = isDate ? panel.querySelector('.custom-range') : null;
+    const customInputs = customRange ? customRange.querySelectorAll('input') : null;
 
     function getSelected() {
       return Array.from(options).filter(o => o.checked).map(o => o.value);
@@ -19,17 +22,45 @@
 
     function updateButtons() {
       const selected = getSelected();
-      applyBtn.disabled = selected.length === 0;
-      cancelBtn.textContent = selected.length ? 'Reset Ulang' : 'Batalkan';
+      if (isDate && selected[0] === 'custom') {
+        const filled = Array.from(customInputs || []).every(i => i.value);
+        applyBtn.disabled = !filled;
+      } else {
+        applyBtn.disabled = selected.length === 0;
+      }
+      const anyApplied = selected.length > 0 || Array.from(document.querySelectorAll('.filter')).some(f => f.dataset.applied);
+      cancelBtn.textContent = anyApplied ? 'Reset Ulang' : 'Batalkan';
     }
 
     function open() {
       if (openPanel && openPanel !== panel) openPanel.classList.add('hidden');
       const applied = filter.dataset.applied;
-      const appliedArr = applied ? applied.split(',') : [];
-      options.forEach(o => {
-        o.checked = appliedArr.includes(o.value);
-      });
+      if (isDate && applied && applied.startsWith('custom:')) {
+        const [start, end] = applied.slice(7).split('|');
+        const [sy, sm, sd] = start.split('-');
+        const [ey, em, ed] = end.split('-');
+        options.forEach(o => {
+          o.checked = o.value === 'custom';
+        });
+        if (customInputs) {
+          customRange.classList.remove('hidden');
+          customRange.querySelector('[data-field="start-day"]').value = sd;
+          customRange.querySelector('[data-field="start-month"]').value = sm;
+          customRange.querySelector('[data-field="start-year"]').value = sy;
+          customRange.querySelector('[data-field="end-day"]').value = ed;
+          customRange.querySelector('[data-field="end-month"]').value = em;
+          customRange.querySelector('[data-field="end-year"]').value = ey;
+        }
+      } else {
+        const appliedArr = applied ? applied.split(',') : [];
+        options.forEach(o => {
+          o.checked = appliedArr.includes(o.value);
+        });
+        if (customRange) {
+          customRange.classList.add('hidden');
+          (customInputs || []).forEach(i => i.value = '');
+        }
+      }
       updateButtons();
       panel.classList.remove('hidden');
       openPanel = panel;
@@ -44,21 +75,49 @@
       panel.classList.contains('hidden') ? open() : close();
     });
 
-    options.forEach(o => o.addEventListener('change', updateButtons));
+    options.forEach(o => o.addEventListener('change', () => {
+      if (isDate) {
+        if (o.value === 'custom' && o.checked) {
+          customRange.classList.remove('hidden');
+        } else if (o.value === 'custom' && !o.checked) {
+          customRange.classList.add('hidden');
+          (customInputs || []).forEach(i => i.value = '');
+        } else if (o.value !== 'custom') {
+          customRange.classList.add('hidden');
+          const customOption = Array.from(options).find(opt => opt.value === 'custom');
+          if (customOption) customOption.checked = false;
+          (customInputs || []).forEach(i => i.value = '');
+        }
+      }
+      updateButtons();
+    }));
 
     applyBtn.addEventListener('click', () => {
       const selected = getSelected();
-      filter.dataset.applied = selected.join(',');
-      if (isMulti) {
-        if (selected.length === 1) {
-          labelSpan.textContent = selected[0];
-        } else if (selected.length > 1) {
-          labelSpan.textContent = `${name} (${selected.length})`;
-        } else {
-          labelSpan.textContent = defaultLabel;
-        }
+      if (isDate && selected[0] === 'custom') {
+        const sd = customRange.querySelector('[data-field="start-day"]').value.padStart(2, '0');
+        const sm = customRange.querySelector('[data-field="start-month"]').value.padStart(2, '0');
+        const sy = customRange.querySelector('[data-field="start-year"]').value;
+        const ed = customRange.querySelector('[data-field="end-day"]').value.padStart(2, '0');
+        const em = customRange.querySelector('[data-field="end-month"]').value.padStart(2, '0');
+        const ey = customRange.querySelector('[data-field="end-year"]').value;
+        const startISO = `${sy}-${sm}-${sd}`;
+        const endISO = `${ey}-${em}-${ed}`;
+        filter.dataset.applied = `custom:${startISO}|${endISO}`;
+        labelSpan.textContent = `${sd}/${sm}/${sy} – ${ed}/${em}/${ey}`;
       } else {
-        labelSpan.textContent = selected[0] || defaultLabel;
+        filter.dataset.applied = selected.join(',');
+        if (isMulti) {
+          if (selected.length === 1) {
+            labelSpan.textContent = selected[0];
+          } else if (selected.length > 1) {
+            labelSpan.textContent = `${name} (${selected.length})`;
+          } else {
+            labelSpan.textContent = defaultLabel;
+          }
+        } else {
+          labelSpan.textContent = selected[0] || defaultLabel;
+        }
       }
       document.dispatchEvent(new CustomEvent('filter-change'));
       close();
@@ -68,10 +127,19 @@
       if (cancelBtn.textContent === 'Batalkan') {
         close();
       } else {
-        options.forEach(o => {
-          o.checked = false;
+        document.querySelectorAll('.filter').forEach(f => {
+          f.dataset.applied = '';
+          const span = f.querySelector('.filter-label');
+          span.textContent = f.dataset.default;
+          f.querySelectorAll('input').forEach(inp => {
+            if (inp.type === 'radio' || inp.type === 'checkbox') inp.checked = false;
+            else inp.value = '';
+          });
+          const cr = f.querySelector('.custom-range');
+          if (cr) cr.classList.add('hidden');
         });
-        updateButtons();
+        document.dispatchEvent(new CustomEvent('filter-change'));
+        close();
       }
     });
 

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -163,25 +163,47 @@
         <!-- Filter Bar -->
         <div class="flex items-center gap-3 mb-4" id="filterBar">
           <!-- Date Filter -->
-          <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Semua Tanggal">
+          <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
             <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
               <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
-              <span class="filter-label max-w-[120px] truncate">Semua Tanggal</span>
+              <span class="filter-label max-w-[120px] truncate">Tanggal</span>
             </button>
             <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-80">
               <div class="flex flex-col gap-4">
                 <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="hari-ini">
-                  <span>Hari Ini</span>
+                  <input type="radio" name="date" value="7 Hari Terakhir">
+                  <span>7 Hari Terakhir</span>
                 </label>
                 <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="minggu-ini">
-                  <span>Minggu Ini</span>
+                  <input type="radio" name="date" value="30 Hari Terakhir">
+                  <span>30 Hari Terakhir</span>
                 </label>
                 <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="bulan-ini">
-                  <span>Bulan Ini</span>
+                  <input type="radio" name="date" value="1 Tahun Terakhir">
+                  <span>1 Tahun Terakhir</span>
                 </label>
+                <label class="flex items-center gap-2">
+                  <input type="radio" name="date" value="custom">
+                  <span>Custom Rentang Tanggal</span>
+                </label>
+                <div class="custom-range hidden mt-2 space-y-2">
+                  <div class="flex items-center gap-2">
+                    <span class="w-24">Tanggal Awal</span>
+                    <input type="text" maxlength="2" class="w-10 h-9 border border-slate-300 rounded-lg text-center" placeholder="dd" data-field="start-day">
+                    <span>/</span>
+                    <input type="text" maxlength="2" class="w-10 h-9 border border-slate-300 rounded-lg text-center" placeholder="mm" data-field="start-month">
+                    <span>/</span>
+                    <input type="text" maxlength="4" class="w-14 h-9 border border-slate-300 rounded-lg text-center" placeholder="yyyy" data-field="start-year">
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <span class="w-24">Tanggal Akhir</span>
+                    <input type="text" maxlength="2" class="w-10 h-9 border border-slate-300 rounded-lg text-center" placeholder="dd" data-field="end-day">
+                    <span>/</span>
+                    <input type="text" maxlength="2" class="w-10 h-9 border border-slate-300 rounded-lg text-center" placeholder="mm" data-field="end-month">
+                    <span>/</span>
+                    <input type="text" maxlength="4" class="w-14 h-9 border border-slate-300 rounded-lg text-center" placeholder="yyyy" data-field="end-year">
+                  </div>
+                </div>
               </div>
               <div class="flex justify-end gap-2 mt-4">
                 <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -59,16 +59,23 @@ function render(tab) {
     const now = new Date();
     list = list.filter(item => {
       const d = parseDate(item.time);
-      if (filters.date === 'hari-ini') {
-        return d.toDateString() === now.toDateString();
-      }
-      if (filters.date === 'minggu-ini') {
+      if (filters.date === '7 Hari Terakhir') {
         const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
         return d >= weekAgo;
       }
-      if (filters.date === 'bulan-ini') {
+      if (filters.date === '30 Hari Terakhir') {
         const monthAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
         return d >= monthAgo;
+      }
+      if (filters.date === '1 Tahun Terakhir') {
+        const yearAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 365);
+        return d >= yearAgo;
+      }
+      if (filters.date.startsWith('custom:')) {
+        const [startStr, endStr] = filters.date.slice(7).split('|');
+        const start = new Date(startStr);
+        const end = new Date(endStr);
+        return d >= start && d <= end;
       }
       return true;
     });


### PR DESCRIPTION
## Summary
- expand transaction approval date filter with preset ranges and custom date range picker
- enable global filter reset and updated category handling

## Testing
- `node --check filters.js`
- `node --check persetujuan-transaksi.js`


------
https://chatgpt.com/codex/tasks/task_e_68c80e06c8e48330ac3ba8d544d988df