### PR TITLE
Prevent filter datepicker from closing when using the calendar

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -84,6 +84,11 @@
 
     function close() {
       panel.classList.add('hidden');
+      if (isDate && customInputs) {
+        Array.from(customInputs).forEach(inp => {
+          if (inp._flatpickr) inp._flatpickr.close();
+        });
+      }
       openPanel = null;
     }
 
@@ -170,7 +175,11 @@
     });
 
     document.addEventListener('click', e => {
-      if (!filter.contains(e.target) && !panel.classList.contains('hidden')) {
+      const interactedWithCalendar = isDate && customInputs && Array.from(customInputs).some(inp => {
+        const fp = inp._flatpickr;
+        return fp && fp.calendarContainer && fp.calendarContainer.contains(e.target);
+      });
+      if (!filter.contains(e.target) && !interactedWithCalendar && !panel.classList.contains('hidden')) {
         close();
       }
     });

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,7 @@
   border-radius:6px;
   white-space:nowrap;
   pointer-events:none;
-  z-index:50;
+  z-index:9999;
 }
 
 /* Drawer panel that pushes main content instead of overlaying */


### PR DESCRIPTION
## Summary
- keep the collapsed sidebar helper tooltip on top by raising its z-index
- stop filter panels from closing when clicking inside the flatpickr calendar and close the calendar when a panel is dismissed

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c8fb42c0288330aa690aed0a792288