### PR TITLE
Refactor persetujuan tabs with isolated filters

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -1,8 +1,8 @@
 (function() {
-  const filters = document.querySelectorAll('.filter');
+  const allFilters = document.querySelectorAll('.filter');
   let openPanel = null;
 
-  filters.forEach(filter => {
+  allFilters.forEach(filter => {
     const trigger = filter.querySelector('.filter-trigger');
     const panel = filter.querySelector('.filter-panel');
     const options = panel.querySelectorAll('input[type="radio"], input[type="checkbox"]');
@@ -15,6 +15,13 @@
     const isDate = filter.dataset.filter === 'date';
     const customRange = isDate ? panel.querySelector('.custom-range') : null;
     const customInputs = customRange ? customRange.querySelectorAll('input') : null;
+    const groupEl = filter.closest('[data-filter-group]');
+    const groupId = groupEl ? groupEl.dataset.filterGroup || null : null;
+    const groupFilters = groupEl ? groupEl.querySelectorAll('.filter') : allFilters;
+
+    function emitChange() {
+      document.dispatchEvent(new CustomEvent('filter-change', { detail: { groupId } }));
+    }
 
     function getSelected() {
       return Array.from(options).filter(o => o.checked).map(o => o.value);
@@ -28,7 +35,7 @@
       } else {
         applyBtn.disabled = selected.length === 0;
       }
-      const anyApplied = selected.length > 0 || Array.from(document.querySelectorAll('.filter')).some(f => f.dataset.applied);
+      const anyApplied = selected.length > 0 || Array.from(groupFilters).some(f => f.dataset.applied);
       cancelBtn.textContent = anyApplied ? 'Reset Ulang' : 'Batalkan';
     }
 
@@ -98,29 +105,29 @@
 
     options.forEach(o => o.addEventListener('change', () => {
       if (isDate) {
-          if (o.value === 'custom' && o.checked) {
-            customRange.classList.remove('hidden');
-            if (customInputs && customInputs[0]._flatpickr) {
-              customInputs[0]._flatpickr.open();
-            }
-          } else if (o.value === 'custom' && !o.checked) {
-            customRange.classList.add('hidden');
-            (customInputs || []).forEach(i => {
-              i.value = '';
-              if (i._flatpickr) i._flatpickr.clear();
-            });
-          } else if (o.value !== 'custom') {
-            customRange.classList.add('hidden');
-            const customOption = Array.from(options).find(opt => opt.value === 'custom');
-            if (customOption) customOption.checked = false;
-            (customInputs || []).forEach(i => {
-              i.value = '';
-              if (i._flatpickr) i._flatpickr.clear();
-            });
+        if (o.value === 'custom' && o.checked) {
+          customRange.classList.remove('hidden');
+          if (customInputs && customInputs[0]._flatpickr) {
+            customInputs[0]._flatpickr.open();
           }
+        } else if (o.value === 'custom' && !o.checked) {
+          customRange.classList.add('hidden');
+          (customInputs || []).forEach(i => {
+            i.value = '';
+            if (i._flatpickr) i._flatpickr.clear();
+          });
+        } else if (o.value !== 'custom') {
+          customRange.classList.add('hidden');
+          const customOption = Array.from(options).find(opt => opt.value === 'custom');
+          if (customOption) customOption.checked = false;
+          (customInputs || []).forEach(i => {
+            i.value = '';
+            if (i._flatpickr) i._flatpickr.clear();
+          });
         }
-        updateButtons();
-      }));
+      }
+      updateButtons();
+    }));
 
     applyBtn.addEventListener('click', () => {
       const selected = getSelected();
@@ -147,7 +154,7 @@
           labelSpan.textContent = selected[0] || defaultLabel;
         }
       }
-      document.dispatchEvent(new CustomEvent('filter-change'));
+      emitChange();
       close();
     });
 
@@ -155,7 +162,7 @@
       if (cancelBtn.textContent === 'Batalkan') {
         close();
       } else {
-        document.querySelectorAll('.filter').forEach(f => {
+        Array.from(groupFilters).forEach(f => {
           f.dataset.applied = '';
           const span = f.querySelector('.filter-label');
           span.textContent = f.dataset.default;
@@ -169,7 +176,7 @@
           const cr = f.querySelector('.custom-range');
           if (cr) cr.classList.add('hidden');
         });
-        document.dispatchEvent(new CustomEvent('filter-change'));
+        emitChange();
         close();
       }
     });

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -144,133 +144,305 @@
 
         <!-- Tabs -->
         <div class="flex items-center gap-6 border-b border-slate-200 mb-6">
-          <button type="button" data-tab="butuh" class="tab-btn relative py-3 font-medium text-slate-900">
-            Butuh Persetujuan Anda
+          <button type="button" data-tab="transaksi" class="tab-btn relative py-3 font-semibold text-slate-900">
+            Transaksi
             <span class="tab-count ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button type="button" data-tab="menunggu" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
-            Menunggu Persetujuan
+          <button type="button" data-tab="batas" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
+            Batas Transaksi
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button type="button" data-tab="selesai" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
-            Selesai
+          <button type="button" data-tab="persetujuan" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
+            Atur Persetujuan
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
         </div>
 
-        <!-- Filter Bar -->
-        <div class="flex items-center gap-3 mb-4" id="filterBar">
-          <!-- Date Filter -->
-          <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
-            <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
-              <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
-              <span class="filter-label max-w-[120px] truncate">Tanggal</span>
-            </button>
-            <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
-              <div class="flex flex-col gap-4">
-                <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="7 Hari Terakhir">
-                  <span>7 Hari Terakhir</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="30 Hari Terakhir">
-                  <span>30 Hari Terakhir</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="1 Tahun Terakhir">
-                  <span>1 Tahun Terakhir</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="radio" name="date" value="custom">
-                  <span>Custom Rentang Tanggal</span>
-                </label>
-                <div class="custom-range">
-                  <div class="flex gap-2">
-                    <!-- Start Date -->
-                    <div class="flex flex-col w-[50%]">
-                      <span class="mb-1">Tanggal Awal</span>
-                      <input
-                        type="text"
-                        class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
-                        placeholder="DD/MM/YYYY"
-                        data-field="start"
-                        readonly
-                      />
-                    </div>
-                
-                    <!-- End Date -->
-                    <div class="flex flex-col w-[50%]">
-                      <span class="mb-1">Tanggal Akhir</span>
-                      <input
-                        type="text"
-                        class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
-                        placeholder="DD/MM/YYYY"
-                        data-field="end"
-                        readonly
-                      />
+        <!-- Tab Panels -->
+        <section class="tab-panel space-y-4" data-tab-panel="transaksi">
+          <div class="flex items-center gap-3" data-filter-group="transaksi">
+            <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Tanggal</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
+                <div class="flex flex-col gap-4">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-date" value="7 Hari Terakhir">
+                    <span>7 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-date" value="30 Hari Terakhir">
+                    <span>30 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-date" value="1 Tahun Terakhir">
+                    <span>1 Tahun Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-date" value="custom">
+                    <span>Custom Rentang Tanggal</span>
+                  </label>
+                  <div class="custom-range hidden">
+                    <div class="flex gap-2">
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Awal</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="start"
+                          readonly
+                        />
+                      </div>
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Akhir</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="end"
+                          readonly
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
-
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
               </div>
-              <div class="flex justify-end gap-2 mt-4">
-                <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
-                <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+            </div>
+            <div class="filter relative" data-filter="jenis" data-name="Jenis" data-default="Jenis">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/filter.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Jenis</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
+                <div class="flex flex-col gap-2">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-jenis" value="kredit">
+                    <span>Kredit</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="transaksi-jenis" value="debit">
+                    <span>Debit</span>
+                  </label>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
               </div>
             </div>
           </div>
-          <!-- Kategori -->
-          <div class="filter relative" data-filter="kategori" data-name="Kategori" data-default="Kategori">
-            <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
-              <img src="img/icon/filter.svg" class="w-5 h-5"/>
-              <span class="filter-label max-w-[120px] truncate">Kategori</span>
-            </button>
-            <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-80">
-              <div class="flex flex-col gap-2">
-                <label class="flex items-center gap-4">
-                  <input type="checkbox" value="Transaksi">
-                  <span>Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Manajemen Pengguna">
-                  <span>Manajemen Pengguna</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Batas Transaksi">
-                  <span>Batas Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Atur Persetujuan">
-                  <span>Atur Persetujuan</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Pengaturan Rekening">
-                  <span>Pengaturan Rekening</span>
-                </label>
+          <div class="overflow-x-auto rounded-xl border border-slate-200">
+            <table class="min-w-full">
+              <thead class="bg-slate-50 text-slate-600">
+                <tr>
+                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody class="divide-y" data-role="table-body"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="tab-panel space-y-4 hidden" data-tab-panel="batas">
+          <div class="flex items-center gap-3" data-filter-group="batas">
+            <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Tanggal</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
+                <div class="flex flex-col gap-4">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-date" value="7 Hari Terakhir">
+                    <span>7 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-date" value="30 Hari Terakhir">
+                    <span>30 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-date" value="1 Tahun Terakhir">
+                    <span>1 Tahun Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-date" value="custom">
+                    <span>Custom Rentang Tanggal</span>
+                  </label>
+                  <div class="custom-range hidden">
+                    <div class="flex gap-2">
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Awal</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="start"
+                          readonly
+                        />
+                      </div>
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Akhir</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="end"
+                          readonly
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
               </div>
-              <div class="flex justify-end gap-2 mt-4">
-                <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
-                <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50  w-full" disabled>Terapkan</button>
+            </div>
+            <div class="filter relative" data-filter="jenis" data-name="Jenis" data-default="Jenis">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/filter.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Jenis</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
+                <div class="flex flex-col gap-2">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-jenis" value="kredit">
+                    <span>Kredit</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="batas-jenis" value="debit">
+                    <span>Debit</span>
+                  </label>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
+          <div class="overflow-x-auto rounded-xl border border-slate-200">
+            <table class="min-w-full">
+              <thead class="bg-slate-50 text-slate-600">
+                <tr>
+                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody class="divide-y" data-role="table-body"></tbody>
+            </table>
+          </div>
+        </section>
 
-        <!-- Tabel -->
-        <div class="overflow-x-auto rounded-xl border border-slate-200">
-          <table class="min-w-full  ">
-            <thead class="bg-slate-50 text-slate-600">
-              <tr>
-                <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
-                <th class="text-left px-4 py-3 font-medium">Kategori</th>
-                <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
-                <th class="px-4 py-3"></th>
-              </tr>
-            </thead>
-            <tbody id="approvalBody" class="divide-y"></tbody>
-          </table>
-        </div>
+        <section class="tab-panel space-y-4 hidden" data-tab-panel="persetujuan">
+          <div class="flex items-center gap-3" data-filter-group="persetujuan">
+            <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Tanggal</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
+                <div class="flex flex-col gap-4">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-date" value="7 Hari Terakhir">
+                    <span>7 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-date" value="30 Hari Terakhir">
+                    <span>30 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-date" value="1 Tahun Terakhir">
+                    <span>1 Tahun Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-date" value="custom">
+                    <span>Custom Rentang Tanggal</span>
+                  </label>
+                  <div class="custom-range hidden">
+                    <div class="flex gap-2">
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Awal</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="start"
+                          readonly
+                        />
+                      </div>
+                      <div class="flex flex-col w-[50%]">
+                        <span class="mb-1">Tanggal Akhir</span>
+                        <input
+                          type="text"
+                          class="h-9 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="end"
+                          readonly
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
+              </div>
+            </div>
+            <div class="filter relative" data-filter="jenis" data-name="Jenis" data-default="Jenis">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
+                <img src="img/icon/filter.svg" class="w-5 h-5"/>
+                <span class="filter-label max-w-[120px] truncate">Jenis</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
+                <div class="flex flex-col gap-2">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-jenis" value="kredit">
+                    <span>Kredit</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="persetujuan-jenis" value="debit">
+                    <span>Debit</span>
+                  </label>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
+                  <button class="apply px-3 py-1 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-full" disabled>Terapkan</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="overflow-x-auto rounded-xl border border-slate-200">
+            <table class="min-w-full">
+              <thead class="bg-slate-50 text-slate-600">
+                <tr>
+                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody class="divide-y" data-role="table-body"></tbody>
+            </table>
+          </div>
+        </section>
       </div>
     </main>
     <!-- ============ /MAIN ============ -->

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -1,34 +1,27 @@
 const approvalsData = {
-  butuh: [
-    { time: '17 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '18 Agu 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance & Accounting' },
-    { time: '19 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
-    { time: '20 Agu 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan Transaksi - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '21 Agu 2025 • 20:10', category: 'Pengaturan Rekening', jenis: 'debit', description: 'Hapus Rekening - Operasional - Oleh Fajar Satria' },
-    { time: '22 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke Mandiri PT Aman Jaya - Rp100.000.000' },
-    { time: '23 Agu 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Nonaktifkan Pengguna - Budi Santoso - Admin' },
-    { time: '24 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Tambah Batas Transaksi - Dari Rp250.000.000 ke Rp300.000.000 - Oleh Bimo Purwoko' },
-    { time: '25 Agu 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Edit Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '26 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BRI PT Nusantara - Rp75.000.000' }
+  transaksi: [
+    { time: '17 Agu 2025 • 20:10', jenis: 'kredit', activity: 'Transfer Saldo', description: 'Ke BCA PT Queen Japan - Rp50.000.000' },
+    { time: '22 Agu 2025 • 20:10', jenis: 'kredit', activity: 'Transfer Saldo', description: 'Ke Mandiri PT Aman Jaya - Rp100.000.000' },
+    { time: '26 Agu 2025 • 20:10', jenis: 'kredit', activity: 'Transfer Saldo', description: 'Ke BRI PT Nusantara - Rp75.000.000' },
+    { time: '30 Sep 2025 • 20:10', jenis: 'kredit', activity: 'Transfer Saldo', description: 'Ke BNI PT Sejahtera - Rp90.000.000' },
+    { time: '02 Sep 2025 • 20:10', jenis: 'kredit', activity: 'Transfer Saldo', description: 'Ke BCA PT Queen Japan - Rp50.000.000' }
   ],
-  menunggu: [
-    { time: '01 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp60.000.000' },
-    { time: '10 Agu 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Siti Aisyah - Marketing' },
-    { time: '20 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
-    { time: '05 Sep 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '15 Sep 2025 • 20:10', category: 'Pengaturan Rekening', jenis: 'debit', description: 'Tambah Rekening - Operasional - Oleh Fajar Satria' },
-    { time: '30 Sep 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BNI PT Sejahtera - Rp90.000.000' }
+  batas: [
+    { time: '19 Agu 2025 • 20:10', jenis: 'debit', activity: 'Ubah Batas Transaksi', description: 'Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
+    { time: '24 Agu 2025 • 20:10', jenis: 'debit', activity: 'Tambah Batas Transaksi', description: 'Dari Rp250.000.000 ke Rp300.000.000 - Oleh Bimo Purwoko' },
+    { time: '20 Agu 2025 • 20:10', jenis: 'debit', activity: 'Ubah Batas Transaksi', description: 'Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
+    { time: '04 Sep 2025 • 20:10', jenis: 'debit', activity: 'Ubah Batas Transaksi', description: 'Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
   ],
-  selesai: [
-    { time: '02 Sep 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '03 Sep 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance' },
-    { time: '04 Sep 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
+  persetujuan: [
+    { time: '20 Agu 2025 • 20:10', jenis: 'debit', activity: 'Buat Persetujuan Transfer', description: 'Persetujuan Transfer - Oleh Fajar Satria' },
+    { time: '25 Agu 2025 • 20:10', jenis: 'debit', activity: 'Edit Persetujuan Transfer', description: 'Persetujuan Transfer - Oleh Fajar Satria' },
+    { time: '05 Sep 2025 • 20:10', jenis: 'debit', activity: 'Buat Persetujuan Transfer', description: 'Persetujuan Transfer - Oleh Fajar Satria' }
   ]
 };
 
 const tabButtons = document.querySelectorAll('.tab-btn');
-const tableBody = document.getElementById('approvalBody');
-let currentTab = 'butuh';
+const tabPanels = document.querySelectorAll('[data-tab-panel]');
+let activeTab = 'transaksi';
 
 function parseDate(str) {
   const months = {Jan:0, Feb:1, Mar:2, Apr:3, Mei:4, Jun:5, Jul:6, Agu:7, Sep:8, Okt:9, Nov:10, Des:11};
@@ -38,71 +31,91 @@ function parseDate(str) {
   return new Date(+year, months[mon], +day, +hour, +min);
 }
 
-function getFilters() {
-  const get = key => {
-    const el = document.querySelector(`.filter[data-filter="${key}"]`);
+function getFilters(tab) {
+  const group = document.querySelector(`[data-filter-group="${tab}"]`);
+  const read = key => {
+    const el = group ? group.querySelector(`.filter[data-filter="${key}"]`) : null;
     return el ? el.dataset.applied || '' : '';
   };
   return {
-    date: get('date'),
-    jenis: get('jenis'),
-    kategori: get('kategori')
+    date: read('date'),
+    jenis: read('jenis')
   };
 }
 
-function render(tab) {
-  currentTab = tab;
-  let list = approvalsData[tab];
-  const filters = getFilters();
+function filterByDate(list, value) {
+  if (!value) return list;
+  const now = new Date();
+  return list.filter(item => {
+    const d = parseDate(item.time);
+    if (value === '7 Hari Terakhir') {
+      const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+      return d >= weekAgo;
+    }
+    if (value === '30 Hari Terakhir') {
+      const monthAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+      return d >= monthAgo;
+    }
+    if (value === '1 Tahun Terakhir') {
+      const yearAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 365);
+      return d >= yearAgo;
+    }
+    if (value.startsWith('custom:')) {
+      const [startStr, endStr] = value.slice(7).split('|');
+      const start = new Date(startStr);
+      const end = new Date(endStr);
+      return d >= start && d <= end;
+    }
+    return true;
+  });
+}
 
-  if (filters.date) {
-    const now = new Date();
-    list = list.filter(item => {
-      const d = parseDate(item.time);
-      if (filters.date === '7 Hari Terakhir') {
-        const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
-        return d >= weekAgo;
-      }
-      if (filters.date === '30 Hari Terakhir') {
-        const monthAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-        return d >= monthAgo;
-      }
-      if (filters.date === '1 Tahun Terakhir') {
-        const yearAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 365);
-        return d >= yearAgo;
-      }
-      if (filters.date.startsWith('custom:')) {
-        const [startStr, endStr] = filters.date.slice(7).split('|');
-        const start = new Date(startStr);
-        const end = new Date(endStr);
-        return d >= start && d <= end;
-      }
-      return true;
-    });
-  }
+function render(tab) {
+  const panel = document.querySelector(`[data-tab-panel="${tab}"]`);
+  if (!panel) return;
+  const tbody = panel.querySelector('[data-role="table-body"]');
+  if (!tbody) return;
+
+  const filters = getFilters(tab);
+  let list = approvalsData[tab] ? [...approvalsData[tab]] : [];
+
+  list = filterByDate(list, filters.date);
 
   if (filters.jenis) {
     list = list.filter(item => item.jenis === filters.jenis);
   }
 
-  if (filters.kategori) {
-    const cats = filters.kategori.split(',');
-    list = list.filter(item => cats.includes(item.category));
+  tbody.innerHTML = '';
+
+  if (list.length === 0) {
+    const empty = document.createElement('tr');
+    empty.innerHTML = `
+      <td class="px-4 py-6 text-center text-slate-500" colspan="4">Tidak ada data pada rentang ini.</td>
+    `;
+    tbody.appendChild(empty);
+    return;
   }
 
-  tableBody.innerHTML = '';
   list.forEach(item => {
     const tr = document.createElement('tr');
     tr.className = 'hover:bg-slate-50';
+    const isCredit = item.jenis === 'kredit';
+    const badgeClass = isCredit ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700';
+    const jenisLabel = isCredit ? 'Kredit' : 'Debit';
     tr.innerHTML = `
       <td class="px-4 py-3">${item.time}</td>
-      <td class="px-4 py-3">${item.category}</td>
-      <td class="px-4 py-3">${item.description}</td>
       <td class="px-4 py-3">
+        <div class="flex items-center gap-2">
+          <span class="font-medium">${item.activity}</span>
+          <span class="text-xs font-semibold rounded-full px-2 py-0.5 ${badgeClass}">${jenisLabel}</span>
+        </div>
+      </td>
+      <td class="px-4 py-3">${item.description}</td>
+      <td class="px-4 py-3 text-right">
         <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
       </td>
     `;
-    tableBody.appendChild(tr);
+    tbody.appendChild(tr);
   });
 }
 
@@ -110,15 +123,19 @@ function updateCounts() {
   tabButtons.forEach(btn => {
     const tab = btn.dataset.tab;
     const countEl = btn.querySelector('.tab-count');
-    if (countEl) countEl.textContent = approvalsData[tab].length;
+    if (!countEl) return;
+    const total = approvalsData[tab] ? approvalsData[tab].length : 0;
+    countEl.textContent = total;
+    countEl.classList.toggle('hidden', total === 0);
   });
 }
 
 function setActive(tab) {
+  activeTab = tab;
   tabButtons.forEach(btn => {
     const isActive = btn.dataset.tab === tab;
     btn.classList.toggle('relative', isActive);
-    btn.classList.toggle('font-medium', isActive);
+    btn.classList.toggle('font-semibold', isActive);
     btn.classList.toggle('text-slate-900', isActive);
     btn.classList.toggle('text-slate-600', !isActive);
     btn.classList.toggle('hover:text-slate-900', !isActive);
@@ -127,18 +144,30 @@ function setActive(tab) {
       indicator.classList.toggle('hidden', !isActive);
     }
   });
+
+  tabPanels.forEach(panel => {
+    const isActive = panel.dataset.tabPanel === tab;
+    panel.classList.toggle('hidden', !isActive);
+  });
+
+  render(tab);
 }
 
 updateCounts();
-setActive('butuh');
-render('butuh');
+setActive(activeTab);
 
 tabButtons.forEach(btn => {
   btn.addEventListener('click', () => {
     const tab = btn.dataset.tab;
-    setActive(tab);
-    render(tab);
+    if (tab && tab !== activeTab) {
+      setActive(tab);
+    }
   });
 });
 
-document.addEventListener('filter-change', () => render(currentTab));
+document.addEventListener('filter-change', event => {
+  const groupId = event.detail ? event.detail.groupId : null;
+  if (!groupId || groupId === activeTab) {
+    render(activeTab);
+  }
+});


### PR DESCRIPTION
## Summary
- reorganize the persetujuan page into Transaction, Batas Transaksi, and Atur Persetujuan panels with their own filter bars and tables
- scope the shared filter component to operate per tab and emit targeted change events
- refresh the approvals rendering logic and mock data to match the new tabs and filter isolation rules

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9045a0a8083308b43d8f16b1f38b9