### PR TITLE
Update approval tabs and table labels

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -145,16 +145,16 @@
         <!-- Tabs -->
         <div class="flex items-center gap-6 border-b border-slate-200 mb-6">
           <button type="button" data-tab="transaksi" class="tab-btn relative py-3 font-semibold text-slate-900">
-            Transaksi
+            Butuh Persetujuan
             <span class="tab-count ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
           <button type="button" data-tab="batas" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
-            Batas Transaksi
+            Menunggu Persetujuan
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
           <button type="button" data-tab="persetujuan" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
-            Atur Persetujuan
+            Selesai
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
         </div>
@@ -256,7 +256,7 @@
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
-                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Kategori</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
                   <th class="px-4 py-3"></th>
                 </tr>
@@ -350,7 +350,7 @@
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
-                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Kategori</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
                   <th class="px-4 py-3"></th>
                 </tr>
@@ -444,7 +444,7 @@
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
-                  <th class="text-left px-4 py-3 font-medium">Aktivitas</th>
+                  <th class="text-left px-4 py-3 font-medium">Kategori</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
                   <th class="px-4 py-3"></th>
                 </tr>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -133,25 +133,13 @@ function render(tab) {
   list.forEach(item => {
     const tr = document.createElement('tr');
     tr.className = 'hover:bg-slate-50';
-    const jenisLabel = item.jenis === 'kredit' ? 'Kredit' : item.jenis === 'debit' ? 'Debit' : '';
-    const badgeClass = item.jenis === 'kredit'
-      ? 'bg-emerald-100 text-emerald-700'
-      : item.jenis === 'debit'
-        ? 'bg-rose-100 text-rose-700'
-        : '';
-    const badge = jenisLabel
-      ? `<span class="text-xs font-semibold rounded-full px-2 py-0.5 ${badgeClass}">${jenisLabel}</span>`
-      : '';
-    const activity = item.activity || item.category || '-';
+    const category = item.category || item.activity || '-';
     const description = item.description || '';
 
     tr.innerHTML = `
       <td class="px-4 py-3">${item.time || '-'}</td>
       <td class="px-4 py-3">
-        <div class="flex items-center gap-2">
-          <span class="font-medium">${activity}</span>
-          ${badge}
-        </div>
+        <span class="font-medium">${category}</span>
       </td>
       <td class="px-4 py-3">${description}</td>
       <td class="px-4 py-3 text-right">


### PR DESCRIPTION
## Summary
- rename the approval tabs to "Butuh Persetujuan", "Menunggu Persetujuan", and "Selesai" while leaving the data attributes untouched
- retitle the approval tables' second column to "Kategori" and display the category text without the jenis badge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c918c49d988330a8af6863c143d246