### PR TITLE
Align approvals tabs with mock data

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -144,24 +144,26 @@
 
         <!-- Tabs -->
         <div class="flex items-center gap-6 border-b border-slate-200 mb-6">
-          <button type="button" data-tab="transaksi" class="tab-btn relative py-3 font-semibold text-slate-900">
+          <button type="button" data-tab="butuh" class="tab-btn relative py-3 font-semibold text-slate-900">
             Butuh Persetujuan
             <span class="tab-count ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button type="button" data-tab="batas" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
+          <button type="button" data-tab="menunggu" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
             Menunggu Persetujuan
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
-          <button type="button" data-tab="persetujuan" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
+          <button type="button" data-tab="selesai" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
             Selesai
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
         </div>
 
         <!-- Tab Panels -->
-        <section class="tab-panel space-y-4" data-tab-panel="transaksi">
-          <div class="flex items-center gap-3" data-filter-group="transaksi">
+        <section class="tab-panel space-y-4" data-tab-panel="butuh">
+          <div class="flex items-center gap-3" data-filter-group="butuh">
             <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
               <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
                 <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
@@ -170,19 +172,19 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
                 <div class="flex flex-col gap-4">
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="transaksi-date" value="7 Hari Terakhir">
+                    <input type="radio" name="butuh-date" value="7 Hari Terakhir">
                     <span>7 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="transaksi-date" value="30 Hari Terakhir">
+                    <input type="radio" name="butuh-date" value="30 Hari Terakhir">
                     <span>30 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="transaksi-date" value="1 Tahun Terakhir">
+                    <input type="radio" name="butuh-date" value="1 Tahun Terakhir">
                     <span>1 Tahun Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="transaksi-date" value="custom">
+                    <input type="radio" name="butuh-date" value="custom">
                     <span>Custom Rentang Tanggal</span>
                   </label>
                   <div class="custom-range hidden">
@@ -266,8 +268,8 @@
           </div>
         </section>
 
-        <section class="tab-panel space-y-4 hidden" data-tab-panel="batas">
-          <div class="flex items-center gap-3" data-filter-group="batas">
+        <section class="tab-panel space-y-4 hidden" data-tab-panel="menunggu">
+          <div class="flex items-center gap-3" data-filter-group="menunggu">
             <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
               <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
                 <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
@@ -276,19 +278,19 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
                 <div class="flex flex-col gap-4">
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-date" value="7 Hari Terakhir">
+                    <input type="radio" name="menunggu-date" value="7 Hari Terakhir">
                     <span>7 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-date" value="30 Hari Terakhir">
+                    <input type="radio" name="menunggu-date" value="30 Hari Terakhir">
                     <span>30 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-date" value="1 Tahun Terakhir">
+                    <input type="radio" name="menunggu-date" value="1 Tahun Terakhir">
                     <span>1 Tahun Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-date" value="custom">
+                    <input type="radio" name="menunggu-date" value="custom">
                     <span>Custom Rentang Tanggal</span>
                   </label>
                   <div class="custom-range hidden">
@@ -330,11 +332,11 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
                 <div class="flex flex-col gap-2">
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-Kategori" value="kredit">
+                    <input type="radio" name="menunggu-Kategori" value="kredit">
                     <span>Kredit</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="batas-Kategori" value="debit">
+                    <input type="radio" name="menunggu-Kategori" value="debit">
                     <span>Debit</span>
                   </label>
                 </div>
@@ -360,8 +362,8 @@
           </div>
         </section>
 
-        <section class="tab-panel space-y-4 hidden" data-tab-panel="persetujuan">
-          <div class="flex items-center gap-3" data-filter-group="persetujuan">
+        <section class="tab-panel space-y-4 hidden" data-tab-panel="selesai">
+          <div class="flex items-center gap-3" data-filter-group="selesai">
             <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Tanggal">
               <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2 w-64">
                 <img src="img/icon/date-picker.svg" class="w-5 h-5"/>
@@ -370,19 +372,19 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[400px]">
                 <div class="flex flex-col gap-4">
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-date" value="7 Hari Terakhir">
+                    <input type="radio" name="selesai-date" value="7 Hari Terakhir">
                     <span>7 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-date" value="30 Hari Terakhir">
+                    <input type="radio" name="selesai-date" value="30 Hari Terakhir">
                     <span>30 Hari Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-date" value="1 Tahun Terakhir">
+                    <input type="radio" name="selesai-date" value="1 Tahun Terakhir">
                     <span>1 Tahun Terakhir</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-date" value="custom">
+                    <input type="radio" name="selesai-date" value="custom">
                     <span>Custom Rentang Tanggal</span>
                   </label>
                   <div class="custom-range hidden">
@@ -424,11 +426,11 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
                 <div class="flex flex-col gap-2">
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-Kategori" value="kredit">
+                    <input type="radio" name="selesai-Kategori" value="kredit">
                     <span>Kredit</span>
                   </label>
                   <label class="flex items-center gap-2">
-                    <input type="radio" name="persetujuan-Kategori" value="debit">
+                    <input type="radio" name="selesai-Kategori" value="debit">
                     <span>Debit</span>
                   </label>
                 </div>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -1,6 +1,5 @@
 const approvalsData = {
-  butuh: 
-  [
+  butuh: [
     { time: '17 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
     { time: '18 Agu 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance & Accounting' },
     { time: '19 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
@@ -12,8 +11,7 @@ const approvalsData = {
     { time: '25 Agu 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Edit Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' },
     { time: '26 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BRI PT Nusantara - Rp75.000.000' }
   ],
-  menunggu: 
-  [
+  menunggu: [
     { time: '01 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp60.000.000' },
     { time: '10 Agu 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Siti Aisyah - Marketing' },
     { time: '20 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
@@ -21,17 +19,16 @@ const approvalsData = {
     { time: '15 Sep 2025 • 20:10', category: 'Pengaturan Rekening', jenis: 'debit', description: 'Tambah Rekening - Operasional - Oleh Fajar Satria' },
     { time: '30 Sep 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BNI PT Sejahtera - Rp90.000.000' }
   ],
-  Selesai: 
-  [
+  selesai: [
     { time: '02 Sep 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
     { time: '03 Sep 2025 • 20:10', category: 'Manajemen Pengguna', jenis: 'debit', description: 'Penambahan Pengguna Baru - Fajar Satria - Finance' },
-    { time: '04 Sep 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000
+    { time: '04 Sep 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
   ]
 };
 
 const tabButtons = document.querySelectorAll('.tab-btn');
 const tabPanels = document.querySelectorAll('[data-tab-panel]');
-let activeTab = 'transaksi';
+let activeTab = 'butuh';
 
 const monthMap = {
   Jan: 0,


### PR DESCRIPTION
## Summary
- align the approvals tabs, filter groups, and counters to the butuh/menunggu/selesai structure
- update the approvals dataset to use the provided mock entries and default to the butuh tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c91d50ece483308713a2cf06b1156c