### PR TITLE
Style akses cepat drawer checkboxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,11 +184,11 @@ function renderDrawer() {
       label.className = 'block cursor-pointer';
       label.innerHTML = `
         <input type="checkbox" data-id="${item.id}" class="sr-only peer" ${tempSelectedAkses.includes(item.id) ? 'checked' : ''}>
-        
-        <div class="flex items-center justify-between rounded-xl border border-slate-300 px-4 py-3 peer-checked:border-cyan-500">
-          <span class="text-slate-900 text-sm">${item.label}</span>
-          <span class="w-5 h-5 rounded-full border border-slate-300 grid place-items-center peer-checked:bg-cyan-500 peer-checked:border-cyan-500">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3 text-transparent peer-checked:text-white">
+
+        <div class="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm peer-checked:border-cyan-500 peer-checked:bg-cyan-50 peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-400">
+          <span class="text-base font-medium text-slate-900">${item.label}</span>
+          <span aria-hidden="true" class="flex-shrink-0 w-7 h-7 rounded-full border border-slate-300 grid place-items-center text-transparent transition peer-checked:border-cyan-500 peer-checked:bg-cyan-500 peer-checked:text-white">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4">
               <path d="M5 13l4 4L19 7" />
             </svg>
           </span>


### PR DESCRIPTION
## Summary
- restyle the Akses Cepat drawer selectors to use checkbox cards with a teal check indicator
- add hover and focus-visible feedback to the selector cards for better affordance

## Testing
- No automated tests (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c93063e43483309624b056bc87052a