### PR TITLE
Fix quick access active icon visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     tailwind = window.tailwind || {};
     tailwind.config = {
       safelist: [
-        "opacity-0","opacity-100","peer-checked:opacity-100",
+        "opacity-0","opacity-100","peer-checked:opacity-100","peer-checked:[&_img]:opacity-100",
         "translate-y-0","translate-y-1",
         "ring-2","ring-cyan-400","bg-cyan-50","border-cyan-300",
         "text-slate-900","text-slate-400"

--- a/index.js
+++ b/index.js
@@ -185,10 +185,10 @@ function renderDrawer() {
       label.innerHTML = `
         <input type="checkbox" data-id="${item.id}" class="sr-only peer" ${tempSelectedAkses.includes(item.id) ? 'checked' : ''}>
 
-        <div class="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm peer-checked:bg-cyan-50 peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-400">
+        <div class="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm peer-checked:bg-cyan-50 peer-checked:[&_img]:opacity-100 peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-400">
           <span class="text-base font-medium text-slate-900">${item.label}</span>
           <span aria-hidden="true" class="flex-shrink-0 w-7 h-7 grid place-items-center">
-            <img src="img/dashboard/akses-cepat/aktif.svg" alt="" class="w-5 h-5 opacity-0 peer-checked:opacity-100">
+            <img src="img/dashboard/akses-cepat/aktif.svg" alt="" class="w-5 h-5 opacity-0">
           </span>
         </div>`;
       list.appendChild(label);


### PR DESCRIPTION
## Summary
- extend the dashboard Tailwind safelist to include the peer-checked selector that reveals the quick access active icon
- update the quick access drawer markup so the active icon opacity is controlled by the parent container and becomes visible when a checkbox is checked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c938dd95ac83308792cda95aa0082b