### PR TITLE
Limit transfer bottom sheet overlay to drawer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,30 @@
   border-left-width:1px;
 }
 
+/* Drawer overlays & sheets stay scoped within the drawer */
+#drawer .drawer-overlay,
+#drawer .drawer-sheet{
+  position:absolute;
+}
+
+#drawer .drawer-overlay{
+  inset:0;
+}
+
+#drawer .drawer-sheet{
+  left:0;
+  right:0;
+}
+
+#drawer .drawer-sheet--bottom{
+  bottom:0;
+}
+
+#drawer .drawer-sheet--full{
+  top:0;
+  bottom:0;
+}
+
 /* Disabled button appearance */
 button:disabled{
   background-color:#f5f5f5 !important;

--- a/transfer.html
+++ b/transfer.html
@@ -304,8 +304,8 @@
   </div>
 
   <!-- Bottom Sheet Overlay & Panel -->
-    <div id="sheetOverlay" class="hidden fixed inset-0 bg-black/20 opacity-0 transition-opacity z-10"></div>
-    <div id="bottomSheet" class="fixed bottom-0 right-0 w-full max-w-[480px] bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform  h-3/4 z-20 flex flex-col">
+    <div id="sheetOverlay" class="drawer-overlay hidden bg-black/20 opacity-0 transition-opacity z-10"></div>
+    <div id="bottomSheet" class="drawer-sheet drawer-sheet--bottom w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform h-3/4 z-20 flex flex-col">
       <div class="p-4 border-b">
         <h3 id="sheetTitle" class="text-base font-semibold">Sumber Rekening</h3>
       </div>
@@ -319,7 +319,7 @@
     </div>
 
     <!-- Destination Account Bottom Sheet -->
-    <div id="destSheet" class="fixed inset-y-0 right-0 w-full max-w-[480px] bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform z-20 flex flex-col">
+    <div id="destSheet" class="drawer-sheet drawer-sheet--full w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform z-20 flex flex-col">
       <div class="p-4 border-b">
         <h3 class="text-base font-semibold">Daftar Rekening Tujuan</h3>
       </div>
@@ -379,7 +379,7 @@
     </div>
 
     <!-- Confirmation Bottom Sheet -->
-    <div id="confirmSheet" class="fixed inset-y-0 right-0 w-full max-w-[480px] bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform z-20 flex flex-col">
+    <div id="confirmSheet" class="drawer-sheet drawer-sheet--full w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform z-20 flex flex-col">
       <div class="p-6 text-center border-b relative">
         <h3 class="text-base font-semibold">Konfirmasi Transfer Saldo</h3>
       </div>


### PR DESCRIPTION
## Summary
- add drawer-scoped utility classes so overlays and sheets respect the drawer bounds
- update the transfer bottom sheets to use the new classes instead of viewport-wide positioning

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cbb67967b883309524d799a397fe80