### PR TITLE
Handle OTP expired state messaging

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -451,9 +451,10 @@
             Silakan login &amp; cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi.
           </p>
           <p id="otpCountdown" class="text-sm text-slate-500 text-center">
-            Sesi akan berakhir dalam <span id="otpTimer" class="text-cyan-500 font-semibold">00:30</span>
+            <span id="otpCountdownMessage">Sesi akan berakhir dalam</span>
+            <span id="otpTimer" class="text-cyan-500 font-semibold">00:30</span>
           </p>
-          <button id="otpResendBtn" type="button" class="hidden mt-2 mx-auto px-4 py-2 rounded-xl border border-cyan-500 text-cyan-600 text-sm font-medium">
+          <button id="otpResendBtn" type="button" class="hidden mt-2 mx-auto px-4 py-2 rounded-xl border border-slate-300 text-slate-700 text-sm font-medium hover:bg-slate-50">
             Kirim Ulang Kode Verifikasi
           </button>
         </div>

--- a/transfer.js
+++ b/transfer.js
@@ -74,8 +74,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const otpSection = document.getElementById('otpSection');
   const otpInputs = otpSection ? Array.from(otpSection.querySelectorAll('.otp-input')) : [];
   const otpCountdown = document.getElementById('otpCountdown');
+  const otpCountdownMessage = document.getElementById('otpCountdownMessage');
   const otpTimerEl = document.getElementById('otpTimer');
   const otpResendBtn = document.getElementById('otpResendBtn');
+  const otpCountdownDefaultMessage = otpCountdownMessage?.textContent?.trim() || 'Sesi akan berakhir dalam';
+  const OTP_EXPIRED_MESSAGE = 'Sesi Anda telah berakhir.';
 
   // move drawer elements
   const openMoveBtn = document.getElementById('openMoveDrawer');
@@ -320,6 +323,24 @@ document.addEventListener('DOMContentLoaded', () => {
     return `${mins}:${secs}`;
   }
 
+  function showOtpCountdownDefaultMessage() {
+    if (otpCountdownMessage) {
+      otpCountdownMessage.textContent = otpCountdownDefaultMessage;
+    }
+    if (otpTimerEl) {
+      otpTimerEl.classList.remove('hidden');
+    }
+  }
+
+  function showOtpExpiredMessage() {
+    if (otpCountdownMessage) {
+      otpCountdownMessage.textContent = OTP_EXPIRED_MESSAGE;
+    }
+    if (otpTimerEl) {
+      otpTimerEl.classList.add('hidden');
+    }
+  }
+
   function updateOtpCountdownDisplay() {
     if (!otpTimerEl) return;
     otpTimerEl.textContent = formatOtpTime(otpTimeLeft);
@@ -350,6 +371,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function startOtpTimer() {
     otpCountdown?.classList.remove('hidden');
+    showOtpCountdownDefaultMessage();
     otpResendBtn?.classList.add('hidden');
     otpTimeLeft = 30;
     updateOtpCountdownDisplay();
@@ -360,7 +382,7 @@ document.addEventListener('DOMContentLoaded', () => {
         otpTimeLeft = 0;
         updateOtpCountdownDisplay();
         clearOtpTimer();
-        otpCountdown?.classList.add('hidden');
+        showOtpExpiredMessage();
         otpResendBtn?.classList.remove('hidden');
         setConfirmProceedEnabled(false);
         return;
@@ -380,6 +402,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (otpCountdown) {
       otpCountdown.classList.remove('hidden');
     }
+    showOtpCountdownDefaultMessage();
     if (otpResendBtn) {
       otpResendBtn.classList.add('hidden');
     }


### PR DESCRIPTION
## Summary
- update the OTP countdown markup so the message can change on expiry and restyle the resend action as a secondary button
- adjust the OTP timer logic to show the expired message, hide the timer, and re-enable the resend action when the countdown completes

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68cbd351ab508330afe0f8543afb89ab