### PR TITLE
Revamp transfer confirmation bottom sheet UI

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -459,88 +459,116 @@
 
     <!-- Confirmation Bottom Sheet -->
     <div id="confirmSheet" class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
-      <div class="relative p-4 text-center border-b">
-        <h3 class="text-base font-semibold">Konfirmasi Transfer Saldo</h3>
+      <div class="relative px-4 pt-6 pb-4 text-center border-b">
+        <h3 class="text-lg font-semibold">Konfirmasi Pemindahan Saldo</h3>
         <button id="confirmClose" type="button" class="absolute top-6 right-6 text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup lembar bawah">&times;</button>
       </div>
       <div class="flex-1 overflow-y-auto">
-        <div>
-           <div id="accountInfo" class="flex p-3 rounded-xl bg-sky-100 border border-slate-200  m-4 text-slate-600">
-            <img class="w-6 h-6 mr-2" src="img/icon/info-2.svg" alt="">
-            <span>Mohon pastikan data sudah sesuai</span>
+        <div class="px-4 py-6 space-y-6">
+          <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+            <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi" />
+            <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
           </div>
-          <p class="font-semibold mx-4 mb-4">Transfer Saldo</p>
-          <div class="bg-[#F2F9FF] border rounded-xl mx-4 mb-4 border-sky-200">
-            <div class="flex gap-3 p-6 items-center">
-              <div class="w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center text-slate-800">
-                <span class="font-medium">O</span>
+
+          <section class="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+            <div class="px-6 pt-6 pb-2">
+              <p class="text-xs font-semibold tracking-[.2em] text-slate-500 uppercase">Transfer Saldo</p>
+            </div>
+            <div class="px-6 pb-6 space-y-6">
+              <div class="flex items-start gap-4">
+                <div id="confirmSourceBadge" class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-600 grid place-items-center font-semibold text-base">O</div>
+                <div class="min-w-0 space-y-1">
+                  <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Sumber</p>
+                  <p id="sheetSource" class="text-base font-semibold text-slate-900 leading-snug truncate">-</p>
+                  <p id="sheetSourceCompany" class="text-sm text-slate-500 leading-snug truncate"></p>
+                  <p id="sheetSourceDetail" class="text-sm text-slate-500 leading-snug break-words"></p>
+                </div>
               </div>
-              <div class="min-w-0">
-                <p class="text-slate-900 mb-1">Sumber</p>
-                <p id="sheetSource" class="font-medium truncate"></p>
+              <div class="flex flex-col items-center gap-2 text-slate-300">
+                <span class="h-8 border-l border-dashed"></span>
+                <span class="inline-flex w-8 h-8 items-center justify-center rounded-full border border-dashed text-slate-400">↓</span>
+                <span class="h-8 border-l border-dashed"></span>
+              </div>
+              <div class="flex items-start gap-4">
+                <div id="confirmDestinationBadge" class="w-10 h-10 rounded-full bg-amber-100 text-amber-600 grid place-items-center font-semibold text-base">D</div>
+                <div class="min-w-0 space-y-1">
+                  <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Tujuan</p>
+                  <p id="sheetDestination" class="text-base font-semibold text-slate-900 leading-snug truncate">-</p>
+                  <p id="sheetDestinationCompany" class="text-sm text-slate-500 leading-snug truncate"></p>
+                  <p id="sheetDestinationDetail" class="text-sm text-slate-500 leading-snug break-words"></p>
+                </div>
               </div>
             </div>
-            <div class="border-t border-sky-200"></div>
-            <div class="flex">
-              <span></span>
-              <hr class="my-4 border-gray-300">
+          </section>
+
+          <section class="rounded-2xl border border-slate-200 overflow-hidden">
+            <div class="px-6 py-3 bg-slate-50">
+              <p class="text-xs font-semibold tracking-[.2em] text-slate-500">TOTAL TRANSAKSI</p>
             </div>
-            <div class="flex gap-3 p-6 items-center">
-              <div class="w-10 h-10 rounded-full bg-amber-200 flex items-center justify-center text-slate-600">
-                <span class="font-medium">D</span>
+            <div class="px-6 py-4 space-y-3">
+              <div class="flex justify-between text-sm text-slate-600">
+                <span>Nominal</span>
+                <span id="sheetNominal" class="text-right text-slate-900 font-medium">Rp0</span>
               </div>
-              <div class="min-w-0">
-                <p class="text-xs text-slate-500 mb-1">Tujuan</p>
-                <p id="sheetDestination" class="font-medium truncate"></p>
+              <div class="flex justify-between text-sm text-slate-600">
+                <span>Total</span>
+                <span id="sheetTotal" class="text-right text-slate-900 font-semibold">Rp0</span>
               </div>
             </div>
+          </section>
+
+          <section class="rounded-2xl border border-slate-200 overflow-hidden">
+            <div class="px-6 py-3 bg-slate-50">
+              <p class="text-xs font-semibold tracking-[.2em] text-slate-500">DETAIL TRANSAKSI</p>
+            </div>
+            <div class="px-6 py-4 space-y-3 text-sm text-slate-600">
+              <div class="flex justify-between gap-6">
+                <span>Nomor Referensi</span>
+                <span id="sheetRef" class="text-right text-slate-900 font-medium break-words">-</span>
+              </div>
+              <div class="flex justify-between gap-6">
+                <span>Tanggal dan Waktu</span>
+                <span id="sheetDate" class="text-right text-slate-900 font-medium break-words">-</span>
+              </div>
+              <div class="flex justify-between gap-6">
+                <span>Kategori</span>
+                <span id="sheetCategory" class="text-right text-slate-900 font-medium break-words">-</span>
+              </div>
+              <div class="flex justify-between gap-6">
+                <span>Catatan</span>
+                <span id="sheetNote" class="text-right text-slate-900 font-medium break-words">-</span>
+              </div>
+            </div>
+          </section>
+
+          <div id="otpSection" class="hidden rounded-2xl border border-slate-200 bg-white px-6 py-5 shadow-sm space-y-4">
+            <h4 class="text-lg font-semibold text-slate-900 text-center">Masukkan kode verifikasi</h4>
+            <div class="grid grid-cols-8 gap-2">
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+            </div>
+            <p class="text-sm text-slate-500 text-center">
+              Silakan login &amp; cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi.
+            </p>
+            <p id="otpCountdown" class="text-sm text-slate-500 text-center">
+              <span id="otpCountdownMessage">Sesi akan berakhir dalam</span>
+              <span id="otpTimer" class="text-cyan-500 font-semibold">00:30</span>
+            </p>
+            <button id="otpResendBtn" type="button" class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50">
+              Kirim Ulang Kode Verifikasi
+            </button>
           </div>
-        </div>
-        <div>
-          <p class="text-[16px] tracking-[.025em] text-slate-500 p-3 bg-slate-100 mb-3">TOTAL TRANSAKSI</p>
-          <div class="mx-4">
-            <div class="flex justify-between py-3"><span>Nominal</span><span id="sheetNominal">Rp0</span></div>
-            <div class="flex justify-between py-3"><span>Biaya Transfer</span><span id="sheetFee">Rp0</span></div>
-            <div class="flex justify-between font-semibold py-3"><span>Total</span><span id="sheetTotal">Rp0</span></div>
-          </div>
-        </div>
-        <div>
-          <p class="text-[16px] tracking-[.025em] text-slate-500 p-3 bg-slate-100 mb-3">DETAIL TRANSAKSI</p>
-          <div class="mx-4">
-            <div class="flex justify-between py-3"><span>Metode Transfer</span><span id="sheetMethod"></span></div>
-            <div class="flex justify-between py-3"><span>Nomor Referensi</span><span id="sheetRef"></span></div>
-            <div class="flex justify-between py-3"><span>Tanggal &amp; Waktu</span><span id="sheetDate"></span></div>
-            <div class="flex justify-between py-3"><span>Kategori</span><span id="sheetCategory"></span></div>
-            <div class="flex justify-between py-3"><span>Catatan</span><span id="sheetNote"></span></div>
-          </div>
-        </div>
-        <div id="otpSection" class="hidden p-4 border border-slate-200 bg-white">
-          <h4 class="text-lg font-semibold mb-4">Masukkan kode verifikasi</h4>
-          <div class="flex justify-between gap-2 mb-4">
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-            <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-10 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-          </div>
-          <p class="text-sm text-slate-500 text-center mb-4">
-            Silakan login &amp; cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi.
-          </p>
-          <p id="otpCountdown" class="text-sm text-slate-500 text-center">
-            <span id="otpCountdownMessage">Sesi akan berakhir dalam</span>
-            <span id="otpTimer" class="text-cyan-500 font-semibold">00:30</span>
-          </p>
-          <button id="otpResendBtn" type="button" class="hidden mt-2 mx-auto p-2 border border-cyan-300 text-cyan-300 font-medium hover:bg-slate-50">
-            Kirim Ulang Kode Verifikasi
-          </button>
         </div>
       </div>
-      <div class="p-4 flex gap-3 border-t">
-        <button id="confirmBack" class="flex-1 rounded-xl border py-3">Batalkan</button>
-        <button id="confirmProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 opacity-50 cursor-not-allowed" disabled>Lanjut Transfer Saldo</button>
+      <div class="p-4 flex gap-3 border-t bg-white">
+        <button id="confirmBack" class="flex-1 rounded-xl border border-slate-200 py-3 font-semibold text-slate-700 hover:bg-slate-50">Batalkan</button>
+        <button id="confirmProceed" class="flex-1 rounded-xl bg-teal-500 text-white py-3 font-semibold opacity-50 cursor-not-allowed" disabled>Lanjut Pemindahan Saldo</button>
       </div>
     </div>
   </div> <!-- /drawer -->


### PR DESCRIPTION
## Summary
- restyle the balance transfer confirmation bottom sheet with the new banner, account card, totals, and details layout
- surface account metadata and transaction details through new helper logic feeding the refreshed markup
- align the proceed button copy and timestamp formatting with the updated confirmation requirements while keeping the OTP flow intact

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbe77e02bc833082b0f9a7c263d6a1