### PR TITLE
Adjust transfer flow titles per active pane

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -305,7 +305,7 @@
       <!-- Success Pane -->
       <div id="successPane" class="hidden h-full flex flex-col">
         <div class="flex items-center justify-between p-4 border-b">
-          <h2 class="text-lg font-semibold">Transfer Saldo</h2>
+          <h2 id="successTitle" class="text-lg font-semibold">Transfer Saldo</h2>
           <button id="successHeaderClose" class="text-2xl leading-none">&times;</button>
         </div>
         <div class="flex-1 overflow-y-auto p-4">
@@ -460,7 +460,7 @@
     <!-- Confirmation Bottom Sheet -->
     <div id="confirmSheet" class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
       <div class="relative px-4 pt-6 pb-4 text-center border-b">
-        <h3 class="text-lg font-semibold">Konfirmasi Pemindahan Saldo</h3>
+        <h3 id="confirmTitle" class="text-lg font-semibold">Transfer Saldo</h3>
         <button id="confirmClose" type="button" class="absolute top-6 right-6 text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup lembar bawah">&times;</button>
       </div>
       <div class="flex-1 overflow-y-auto">
@@ -469,7 +469,7 @@
             <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi" />
             <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
           </div>
-          <p class="text-xs font-semibold tracking-[.2em] text-slate-500 uppercase">Transfer Saldo</p>
+          <p id="confirmActivityLabel" class="text-xs font-semibold tracking-[.2em] text-slate-500 uppercase">Transfer Saldo</p>
           <section class="bg-[#F2F9FF] border border-sky-200 rounded-[8px] p-4 text-left space-y-4">
             <div class="flex items-start gap-3">
             </div>
@@ -567,7 +567,7 @@
       </div>
       <div class="p-4 flex gap-3 border-t bg-white">
         <button id="confirmBack" class="flex-1 rounded-xl border border-slate-200 py-3 font-semibold text-slate-700 hover:bg-slate-50">Batalkan</button>
-        <button id="confirmProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 font-semibold opacity-50 cursor-not-allowed" disabled>Lanjut Pemindahan Saldo</button>
+        <button id="confirmProceed" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 font-semibold opacity-50 cursor-not-allowed" disabled>Lanjut Transfer Saldo</button>
       </div>
     </div>
   </div> <!-- /drawer -->

--- a/transfer.js
+++ b/transfer.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const cardGrid = document.getElementById('cardGrid');
 
   const successHeaderClose = document.getElementById('successHeaderClose');
+  const successTitle = document.getElementById('successTitle');
   const successCloseBtn = document.getElementById('successCloseBtn');
   const successSourceBadge = document.getElementById('successSourceBadge');
   const successSourceName = document.getElementById('successSourceName');
@@ -76,11 +77,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // confirmation sheet
   const confirmSheet = document.getElementById('confirmSheet');
+  const confirmTitle = document.getElementById('confirmTitle');
   const confirmBack = document.getElementById('confirmBack');
   const confirmProceed = document.getElementById('confirmProceed');
   const confirmClose = document.getElementById('confirmClose');
   const confirmSourceBadge = document.getElementById('confirmSourceBadge');
   const confirmDestinationBadge = document.getElementById('confirmDestinationBadge');
+  const confirmActivityLabel = document.getElementById('confirmActivityLabel');
   const sheetSource = document.getElementById('sheetSource');
   const sheetSourceCompany = document.getElementById('sheetSourceCompany');
   const sheetSourceDetail = document.getElementById('sheetSourceDetail');
@@ -88,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sheetDestinationCompany = document.getElementById('sheetDestinationCompany');
   const sheetDestinationDetail = document.getElementById('sheetDestinationDetail');
   const sheetNominal = document.getElementById('sheetNominal');
+  const sheetBiaya = document.getElementById('sheetBiaya');
   const sheetTotal = document.getElementById('sheetTotal');
   const sheetCategory = document.getElementById('sheetCategory');
   const sheetNote = document.getElementById('sheetNote');
@@ -124,6 +128,11 @@ document.addEventListener('DOMContentLoaded', () => {
     || openMoveBtn?.closest('[data-activity-card="move"]');
   const DEFAULT_CARD_BORDER = 'border-slate-200';
   const ACTIVE_CARD_BORDER = 'border-cyan-300';
+  const DEFAULT_ACTIVITY_TYPE = 'transfer';
+  const ACTIVITY_TITLES = {
+    transfer: 'Transfer Saldo',
+    move: 'Pemindahan Saldo'
+  };
 
   function setActivityCardState(card, active) {
     if (!card) return;
@@ -138,6 +147,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function clearActiveActivityCard() {
     setActiveActivityCard(null);
+  }
+
+  function getActivityTitle(type) {
+    return ACTIVITY_TITLES[type] || ACTIVITY_TITLES[DEFAULT_ACTIVITY_TYPE];
+  }
+
+  function updateConfirmProceedLabel(type) {
+    if (!confirmProceed) return;
+    const title = getActivityTitle(type);
+    confirmProceed.textContent = `Lanjut ${title}`;
+  }
+
+  function updateConfirmSheetContent(type) {
+    const title = getActivityTitle(type);
+    if (confirmTitle) {
+      confirmTitle.textContent = title;
+    }
+    if (confirmActivityLabel) {
+      confirmActivityLabel.textContent = title;
+    }
+    updateConfirmProceedLabel(type);
   }
 
   // data
@@ -191,6 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let selectedSourceAccountData = null;
   let selectedDestinationAccountData = null;
   let lastTransactionDetails = null;
+  let activePaneType = DEFAULT_ACTIVITY_TYPE;
 
   // move drawer state
   let moveSourceSelected = false;
@@ -367,6 +398,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function populateSuccessView(details) {
     if (!details || !successPane) return;
+    const activityTitle = getActivityTitle(details.type);
+    if (successTitle) {
+      successTitle.textContent = activityTitle;
+    }
     const source = details.source || {};
     const destination = details.destination || {};
 
@@ -655,9 +690,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (otpTimerEl) {
       otpTimerEl.textContent = '00:30';
     }
-    if (confirmProceed) {
-      confirmProceed.textContent = 'Lanjut Pemindahan Saldo';
-    }
+    const labelType = lastTransactionDetails?.type || activePaneType || DEFAULT_ACTIVITY_TYPE;
+    updateConfirmProceedLabel(labelType);
     setConfirmProceedEnabled(true);
   }
 
@@ -865,6 +899,8 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.remove('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.add('open');
+    activePaneType = 'transfer';
+    updateConfirmSheetContent(activePaneType);
     if (typeof window.sidebarCollapseForDrawer === 'function') {
       window.sidebarCollapseForDrawer();
     }
@@ -880,6 +916,8 @@ document.addEventListener('DOMContentLoaded', () => {
     closeDestSheet();
     closeConfirmSheet();
     lastTransactionDetails = null;
+    activePaneType = DEFAULT_ACTIVITY_TYPE;
+    updateConfirmSheetContent(activePaneType);
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
     }
@@ -912,6 +950,8 @@ document.addEventListener('DOMContentLoaded', () => {
     moveSourceAccountData = null;
     moveDestAccountData = null;
     updateMoveConfirmState();
+    activePaneType = 'move';
+    updateConfirmSheetContent(activePaneType);
     if (typeof window.sidebarCollapseForDrawer === 'function') {
       window.sidebarCollapseForDrawer();
     }
@@ -1110,6 +1150,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (sheetNominal) {
       sheetNominal.textContent = 'Rp' + formatter.format(amountValue);
     }
+    if (sheetBiaya) {
+      sheetBiaya.textContent = 'Rp' + formatter.format(selectedFee);
+    }
     if (sheetTotal) {
       sheetTotal.textContent = 'Rp' + formatter.format(amountValue + selectedFee);
     }
@@ -1131,6 +1174,7 @@ document.addEventListener('DOMContentLoaded', () => {
       note: noteValue || '-',
       createdBy: currentUserFullName
     };
+    updateConfirmSheetContent('transfer');
     setConfirmProceedEnabled(true);
     sheetOverlay.classList.remove('hidden');
     requestAnimationFrame(() => {
@@ -1153,6 +1197,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (sheetNominal) {
       sheetNominal.textContent = 'Rp' + formatter.format(moveAmountValue);
     }
+    if (sheetBiaya) {
+      sheetBiaya.textContent = 'Rp' + formatter.format(0);
+    }
     if (sheetTotal) {
       sheetTotal.textContent = 'Rp' + formatter.format(moveAmountValue);
     }
@@ -1174,6 +1221,7 @@ document.addEventListener('DOMContentLoaded', () => {
       note: noteValue || '-',
       createdBy: currentUserFullName
     };
+    updateConfirmSheetContent('move');
     setConfirmProceedEnabled(true);
     sheetOverlay.classList.remove('hidden');
     requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
- add IDs to the confirmation and success pane headings to allow dynamic text updates
- centralize transfer activity labels in transfer.js and update the confirmation sheet and success pane based on the active flow
- ensure confirmation details include the correct fee value for transfers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce5e6fad08330bb4f11812798ead7