### PR TITLE
Adjust dashboard and transfer layouts for drawer states

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,11 +130,24 @@ balanceToggleBtn?.addEventListener('click', () => {
 const drawer = document.getElementById('drawer');
 const openBtn = document.getElementById('ubahAksesBtn');
 const closeBtn = document.getElementById('drawerCloseBtn');
+const dashboardGrid = document.getElementById('dashboardGrid');
+const pendingSection = document.getElementById('pendingSection');
+
+function updateDashboardLayout(isDrawerOpen) {
+  if (!dashboardGrid || !pendingSection) return;
+  dashboardGrid.classList.toggle('lg:grid-cols-3', !isDrawerOpen);
+  dashboardGrid.classList.toggle('lg:grid-cols-2', isDrawerOpen);
+  pendingSection.classList.toggle('lg:col-span-1', !isDrawerOpen);
+  pendingSection.classList.toggle('lg:col-span-2', isDrawerOpen);
+}
+
+updateDashboardLayout(drawer?.classList.contains('open'));
 
 function openDrawer() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
   drawer.classList.add('open');
+  updateDashboardLayout(true);
   if (typeof window.sidebarCollapseForDrawer === 'function') {
     window.sidebarCollapseForDrawer();
   }
@@ -142,6 +155,7 @@ function openDrawer() {
 
 function closeDrawer() {
   drawer.classList.remove('open');
+  updateDashboardLayout(false);
   if (typeof window.sidebarRestoreForDrawer === 'function') {
     window.sidebarRestoreForDrawer();
   }

--- a/transfer.js
+++ b/transfer.js
@@ -9,6 +9,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const closeBtn = document.getElementById('drawerCloseBtn');
   const cardGrid = document.getElementById('cardGrid');
 
+  function updateCardGridLayout(isDrawerOpen) {
+    if (!cardGrid) return;
+    cardGrid.classList.toggle('md:grid-cols-3', !isDrawerOpen);
+    cardGrid.classList.toggle('md:grid-cols-2', isDrawerOpen);
+  }
+
+  updateCardGridLayout(drawer?.classList.contains('open'));
+
   const successHeaderClose = document.getElementById('successHeaderClose');
   const successTitle = document.getElementById('successTitle');
   const successCloseBtn = document.getElementById('successCloseBtn');
@@ -462,6 +470,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane?.classList.add('hidden');
     successPane?.classList.remove('hidden');
     drawer.classList.add('open');
+    updateCardGridLayout(true);
     successCloseBtn?.focus();
     const activeType = lastTransactionDetails.type === 'move' ? 'move' : 'transfer';
     setActiveActivityCard(activeType);
@@ -899,6 +908,7 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.remove('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.add('open');
+    updateCardGridLayout(true);
     activePaneType = 'transfer';
     updateConfirmSheetContent(activePaneType);
     if (typeof window.sidebarCollapseForDrawer === 'function') {
@@ -912,6 +922,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.add('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.remove('open');
+    updateCardGridLayout(false);
     closeSheet();
     closeDestSheet();
     closeConfirmSheet();
@@ -929,6 +940,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.remove('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.add('open');
+    updateCardGridLayout(true);
     moveSourceBtn.textContent = 'Pilih sumber rekening';
     moveSourceBtn.classList.add('text-slate-500');
     moveDestBtn.textContent = 'Pilih rekening tujuan';


### PR DESCRIPTION
## Summary
- update the dashboard grid to swap between 3-column and 2-column layouts based on the drawer state
- adjust the transfer card grid so it collapses from three to two columns whenever the drawer opens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccef330fec8330b627ab433d119029