### PR TITLE
Keep dashboard and transfer grids static

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,21 +133,27 @@ const closeBtn = document.getElementById('drawerCloseBtn');
 const dashboardGrid = document.getElementById('dashboardGrid');
 const pendingSection = document.getElementById('pendingSection');
 
-function updateDashboardLayout(isDrawerOpen) {
+function updateDashboardLayout() {
+  /*
+   * Keep the dashboard grid layout static so the content doesn't shift when
+   * the drawer opens or closes. Column adjustments previously triggered
+   * noticeable card/text movement, which we now avoid by leaving the grid
+   * configuration untouched.
+   */
   if (!dashboardGrid || !pendingSection) return;
-  dashboardGrid.classList.toggle('lg:grid-cols-3', !isDrawerOpen);
-  dashboardGrid.classList.toggle('lg:grid-cols-2', isDrawerOpen);
-  pendingSection.classList.toggle('lg:col-span-1', !isDrawerOpen);
-  pendingSection.classList.toggle('lg:col-span-2', isDrawerOpen);
+  dashboardGrid.classList.add('lg:grid-cols-3');
+  dashboardGrid.classList.remove('lg:grid-cols-2');
+  pendingSection.classList.add('lg:col-span-1');
+  pendingSection.classList.remove('lg:col-span-2');
 }
 
-updateDashboardLayout(drawer?.classList.contains('open'));
+updateDashboardLayout();
 
 function openDrawer() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
   drawer.classList.add('open');
-  updateDashboardLayout(true);
+  updateDashboardLayout();
   if (typeof window.sidebarCollapseForDrawer === 'function') {
     window.sidebarCollapseForDrawer();
   }
@@ -155,7 +161,7 @@ function openDrawer() {
 
 function closeDrawer() {
   drawer.classList.remove('open');
-  updateDashboardLayout(false);
+  updateDashboardLayout();
   if (typeof window.sidebarRestoreForDrawer === 'function') {
     window.sidebarRestoreForDrawer();
   }

--- a/transfer.js
+++ b/transfer.js
@@ -9,13 +9,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const closeBtn = document.getElementById('drawerCloseBtn');
   const cardGrid = document.getElementById('cardGrid');
 
-  function updateCardGridLayout(isDrawerOpen) {
+  function updateCardGridLayout() {
+    // Maintain a consistent card layout regardless of drawer state so cards
+    // stay in place when the column configuration would previously change.
     if (!cardGrid) return;
-    cardGrid.classList.toggle('md:grid-cols-3', !isDrawerOpen);
-    cardGrid.classList.toggle('md:grid-cols-2', isDrawerOpen);
+    cardGrid.classList.add('md:grid-cols-3');
+    cardGrid.classList.remove('md:grid-cols-2');
   }
 
-  updateCardGridLayout(drawer?.classList.contains('open'));
+  updateCardGridLayout();
 
   const successHeaderClose = document.getElementById('successHeaderClose');
   const successTitle = document.getElementById('successTitle');
@@ -470,7 +472,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane?.classList.add('hidden');
     successPane?.classList.remove('hidden');
     drawer.classList.add('open');
-    updateCardGridLayout(true);
+    updateCardGridLayout();
     successCloseBtn?.focus();
     const activeType = lastTransactionDetails.type === 'move' ? 'move' : 'transfer';
     setActiveActivityCard(activeType);
@@ -908,7 +910,7 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.remove('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.add('open');
-    updateCardGridLayout(true);
+    updateCardGridLayout();
     activePaneType = 'transfer';
     updateConfirmSheetContent(activePaneType);
     if (typeof window.sidebarCollapseForDrawer === 'function') {
@@ -922,7 +924,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.add('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.remove('open');
-    updateCardGridLayout(false);
+    updateCardGridLayout();
     closeSheet();
     closeDestSheet();
     closeConfirmSheet();
@@ -940,7 +942,7 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.remove('hidden');
     successPane?.classList.add('hidden');
     drawer.classList.add('open');
-    updateCardGridLayout(true);
+    updateCardGridLayout();
     moveSourceBtn.textContent = 'Pilih sumber rekening';
     moveSourceBtn.classList.add('text-slate-500');
     moveDestBtn.textContent = 'Pilih rekening tujuan';


### PR DESCRIPTION
## Summary
- keep the dashboard widgets locked to the three-column layout so the drawer no longer shifts card/text positions
- prevent the transfer activity cards from switching column counts when the drawer opens to keep cards steady

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccf68594848330bbb18470affbbd41