### PR TITLE
Implement mutasi drawer with filters and states

### DIFF
--- a/data/mutasi-data.js
+++ b/data/mutasi-data.js
@@ -1,0 +1,147 @@
+(function () {
+  const dataset = {
+    utama: {
+      status: 'success',
+      groups: [
+        {
+          date: '2025-09-02',
+          label: 'Selasa, 2 September 2025',
+          transactions: [
+            {
+              id: 'UTM-12001',
+              type: 'masuk',
+              title: 'Setoran Dana Penjualan',
+              note: 'Transfer dari PT Nusantara Maju',
+              amount: 250000000
+            },
+            {
+              id: 'UTM-12002',
+              type: 'keluar',
+              title: 'Pembayaran Vendor',
+              note: 'Ke PT Sinar Abadi Makmur',
+              amount: 175000000
+            }
+          ]
+        },
+        {
+          date: '2025-09-01',
+          label: 'Senin, 1 September 2025',
+          transactions: [
+            {
+              id: 'UTM-11951',
+              type: 'masuk',
+              title: 'Penerimaan Refund',
+              note: 'Pengembalian biaya operasional',
+              amount: 96000000
+            }
+          ]
+        }
+      ]
+    },
+    operasional: {
+      status: 'success',
+      groups: [
+        {
+          date: '2025-08-02',
+          label: 'Sabtu, 2 Agustus 2025',
+          transactions: [
+            {
+              id: 'OPR-23001',
+              type: 'keluar',
+              title: 'TRCDESC',
+              note: 'Description/Notes/Description/Note',
+              amount: 1000000000000
+            },
+            {
+              id: 'OPR-23002',
+              type: 'masuk',
+              title: 'TRCDESC',
+              note: 'Description/Notes/Description/Note',
+              amount: 1000000000000
+            }
+          ]
+        },
+        {
+          date: '2025-08-01',
+          label: 'Jumat, 1 Agustus 2025',
+          transactions: [
+            {
+              id: 'OPR-22987',
+              type: 'keluar',
+              title: 'Pembayaran Gaji Karyawan',
+              note: 'Payroll Agustus 2025',
+              amount: 850000000
+            }
+          ]
+        }
+      ]
+    },
+    'pembayaran-distributor': {
+      status: 'success',
+      groups: [
+        {
+          date: '2025-07-28',
+          label: 'Senin, 28 Juli 2025',
+          transactions: [
+            {
+              id: 'DST-11841',
+              type: 'keluar',
+              title: 'Pembayaran Distributor Wilayah Barat',
+              note: 'Invoice #INV-8721',
+              amount: 420000000
+            },
+            {
+              id: 'DST-11842',
+              type: 'masuk',
+              title: 'Pembayaran Distributor Wilayah Timur',
+              note: 'Setoran penjualan cabang Makassar',
+              amount: 570000000
+            }
+          ]
+        }
+      ]
+    }
+  };
+
+  function cloneGroups(groups) {
+    return (groups || []).map((group) => ({
+      date: group.date,
+      label: group.label,
+      transactions: (group.transactions || []).map((tx) => ({ ...tx }))
+    }));
+  }
+
+  function normaliseKey(key) {
+    if (!key) return '';
+    return key.toString().replace(/[^a-z0-9]/gi, '').toLowerCase();
+  }
+
+  function get(accountId) {
+    const key = normaliseKey(accountId);
+    const entry = dataset[key] || dataset[accountId] || dataset.default;
+    if (!entry) {
+      return { status: 'empty', groups: [] };
+    }
+    return {
+      status: entry.status || 'success',
+      groups: cloneGroups(entry.groups)
+    };
+  }
+
+  window.MUTASI_DATA = {
+    get,
+    all() {
+      return Object.keys(dataset).reduce((acc, key) => {
+        acc[key] = { status: dataset[key].status, groups: cloneGroups(dataset[key].groups) };
+        return acc;
+      }, {});
+    },
+    set(accountId, value) {
+      if (!accountId || typeof value !== 'object') return;
+      dataset[normaliseKey(accountId)] = {
+        status: value.status || 'success',
+        groups: cloneGroups(value.groups)
+      };
+    }
+  };
+})();

--- a/mutasi.html
+++ b/mutasi.html
@@ -29,6 +29,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <!-- Global styles -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body class="font-[Mulish] bg-gray-50 text-slate-900">
@@ -149,9 +150,147 @@
       </div>
     </main>
     <!-- ============ /MAIN ============ -->
+
+    <!-- ============ DRAWER ============ -->
+    <div id="drawer" class="h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100">
+      <div class="flex flex-col h-full" id="mutasiDrawerInner">
+        <div class="flex items-center justify-between px-6 py-5 border-b border-slate-200">
+          <h2 id="mutasiDrawerTitle" class="text-lg font-semibold">Mutasi Rekening</h2>
+          <button id="mutasiDrawerClose" class="text-2xl leading-none text-slate-500 hover:text-slate-700">&times;</button>
+        </div>
+
+        <div class="border-b border-slate-200 px-6">
+          <div class="flex items-center gap-6">
+            <button type="button" class="py-4 font-semibold text-slate-900 border-b-2 border-cyan-500" aria-current="true">Mutasi Rekening</button>
+            <button type="button" class="py-4 text-slate-400 cursor-not-allowed" disabled>e-Statement</button>
+          </div>
+        </div>
+
+        <div class="px-6 pt-4 pb-3 border-b border-slate-100">
+          <p id="mutasiDrawerAccountLabel" class="text-lg font-semibold mb-4">-</p>
+          <div class="flex items-start gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-slate-700">
+            <span class="w-8 h-8 rounded-full bg-blue-100 text-blue-600 grid place-items-center text-lg">ℹ️</span>
+            <p class="text-sm">Dapat menampilkan periode mutasi hingga 3 tahun terakhir</p>
+          </div>
+        </div>
+
+        <div class="px-6 py-4 border-b border-slate-100" data-filter-group="mutasi">
+          <div class="flex flex-wrap gap-3">
+            <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2">
+                <img src="img/icon/date-picker.svg" class="w-5 h-5" alt="Rentang Tanggal" />
+                <span class="filter-label max-w-[140px] truncate">Rentang Tanggal</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
+                <div class="flex flex-col gap-3">
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="mutasi-date" value="7 Hari Terakhir">
+                    <span>7 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="mutasi-date" value="30 Hari Terakhir">
+                    <span>30 Hari Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="mutasi-date" value="1 Tahun Terakhir">
+                    <span>1 Tahun Terakhir</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="radio" name="mutasi-date" value="custom">
+                    <span>Custom Rentang Tanggal</span>
+                  </label>
+                  <div class="custom-range hidden">
+                    <div class="flex gap-2">
+                      <div class="flex flex-col w-1/2">
+                        <span class="mb-1 text-sm">Tanggal Awal</span>
+                        <input
+                          type="text"
+                          class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="start"
+                          readonly
+                        />
+                      </div>
+                      <div class="flex flex-col w-1/2">
+                        <span class="mb-1 text-sm">Tanggal Akhir</span>
+                        <input
+                          type="text"
+                          class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
+                          placeholder="DD/MM/YYYY"
+                          data-field="end"
+                          readonly
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
+                  <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="filter relative" data-filter="type" data-name="Jenis Transaksi" data-default="Jenis Transaksi">
+              <button class="filter-trigger h-11 px-4 rounded-xl border border-slate-300 bg-white flex items-center gap-2">
+                <img src="img/icon/filter.svg" class="w-5 h-5" alt="Jenis Transaksi" />
+                <span class="filter-label max-w-[140px] truncate">Jenis Transaksi</span>
+              </button>
+              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[280px]">
+                <div class="flex flex-col gap-3">
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Masuk">
+                    <span>Masuk</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Keluar">
+                    <span>Keluar</span>
+                  </label>
+                </div>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
+                  <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex-1 overflow-y-auto" id="mutasiDrawerContent">
+          <div id="mutasiLoading" class="h-full flex items-center justify-center">
+            <div class="flex flex-col items-center gap-3 text-slate-500">
+              <span class="w-10 h-10 border-4 border-cyan-200 border-t-cyan-600 rounded-full animate-spin"></span>
+              <span>Memuat data mutasi...</span>
+            </div>
+          </div>
+
+          <div id="mutasiError" class="hidden px-6 py-8 space-y-4">
+            <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">Gagal memuat data, coba lagi</div>
+            <button id="mutasiRetry" class="px-4 py-3 rounded-xl border border-cyan-500 text-cyan-600 hover:bg-cyan-50 w-full">Muat Ulang</button>
+          </div>
+
+          <div id="mutasiEmpty" class="hidden px-6 py-12 flex flex-col items-center text-center gap-4 text-slate-500">
+            <div class="w-20 h-20 rounded-full bg-slate-100 grid place-items-center text-3xl">📄</div>
+            <div>
+              <p class="font-semibold text-slate-700">Tidak ada transaksi pada periode ini</p>
+              <p class="text-sm">Silakan ubah filter atau rentang tanggal untuk melihat transaksi lainnya.</p>
+            </div>
+          </div>
+
+          <div id="mutasiSuccess" class="hidden px-6 pb-10 space-y-6">
+            <div id="mutasiTransactionList" class="space-y-8"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ============ /DRAWER ============ -->
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/id.js"></script>
+  <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
+  <script src="data/mutasi-data.js"></script>
   <script src="mutasi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/mutasi.js
+++ b/mutasi.js
@@ -2,7 +2,28 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('mutasiAccountGrid');
   if (!container) return;
 
+  const drawer = document.getElementById('drawer');
+  const drawerInner = document.getElementById('mutasiDrawerInner');
+  const closeBtn = document.getElementById('mutasiDrawerClose');
+  const drawerTitle = document.getElementById('mutasiDrawerTitle');
+  const drawerAccountLabel = document.getElementById('mutasiDrawerAccountLabel');
+  const loadingEl = document.getElementById('mutasiLoading');
+  const errorEl = document.getElementById('mutasiError');
+  const emptyEl = document.getElementById('mutasiEmpty');
+  const successEl = document.getElementById('mutasiSuccess');
+  const listEl = document.getElementById('mutasiTransactionList');
+  const retryBtn = document.getElementById('mutasiRetry');
+  const filterGroup = document.querySelector('[data-filter-group="mutasi"]');
+  const sidebar = document.getElementById('sidebar');
+
+  const formatter = new Intl.NumberFormat('id-ID');
+  const dataSource = window.MUTASI_DATA || null;
   const ambis = window.AMBIS || {};
+
+  let activeAccount = null;
+  let activeData = null;
+  let sidebarWasCollapsed = false;
+  let loadTimer = null;
 
   function getAccounts() {
     if (typeof ambis.getAccounts === 'function') {
@@ -12,6 +33,292 @@ document.addEventListener('DOMContentLoaded', () => {
       return ambis.accounts;
     }
     return [];
+  }
+
+  function formatCurrency(amount) {
+    const value = Math.abs(Number(amount) || 0);
+    return `Rp${formatter.format(value)}`;
+  }
+
+  function collapseSidebar() {
+    if (!sidebar) return;
+    sidebarWasCollapsed = sidebar.classList.contains('collapsed');
+    if (!sidebarWasCollapsed) {
+      sidebar.classList.add('collapsed');
+    }
+  }
+
+  function restoreSidebar() {
+    if (!sidebar) return;
+    if (!sidebarWasCollapsed) {
+      sidebar.classList.remove('collapsed');
+    }
+  }
+
+  function showState(state) {
+    const mapping = {
+      loading: loadingEl,
+      error: errorEl,
+      empty: emptyEl,
+      success: successEl,
+    };
+
+    Object.values(mapping).forEach((el) => {
+      if (el) el.classList.add('hidden');
+    });
+
+    if (state === 'loading') {
+      if (loadingEl) loadingEl.classList.remove('hidden');
+      return;
+    }
+
+    if (state === 'error') {
+      if (errorEl) errorEl.classList.remove('hidden');
+      return;
+    }
+
+    if (state === 'empty') {
+      if (emptyEl) emptyEl.classList.remove('hidden');
+      return;
+    }
+
+    if (state === 'success') {
+      if (successEl) successEl.classList.remove('hidden');
+    }
+  }
+
+  function resetFilters() {
+    if (!filterGroup) return;
+    const filters = filterGroup.querySelectorAll('.filter');
+    filters.forEach((filter) => {
+      filter.dataset.applied = '';
+      const label = filter.querySelector('.filter-label');
+      if (label) {
+        label.textContent = filter.dataset.default || '';
+      }
+      filter.querySelectorAll('input').forEach((input) => {
+        if (input.type === 'radio' || input.type === 'checkbox') {
+          input.checked = false;
+        } else {
+          input.value = '';
+          if (input._flatpickr) input._flatpickr.clear();
+        }
+      });
+      const custom = filter.querySelector('.custom-range');
+      if (custom) custom.classList.add('hidden');
+    });
+  }
+
+  function getDataForAccount(account) {
+    if (!account) return { status: 'empty', groups: [] };
+    const key = account.id || account.numberRaw || account.number || '';
+    if (dataSource && typeof dataSource.get === 'function') {
+      return dataSource.get(key);
+    }
+    return { status: 'empty', groups: [] };
+  }
+
+  function sanitiseGroups(groups) {
+    return (groups || []).map((group) => ({
+      date: group.date,
+      label: group.label,
+      transactions: (group.transactions || []).map((tx) => ({ ...tx })),
+    }));
+  }
+
+  function renderTransactions(groups) {
+    if (!listEl) return;
+    listEl.innerHTML = '';
+
+    groups.forEach((group) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'space-y-3';
+
+      const heading = document.createElement('p');
+      heading.className = 'font-semibold text-slate-900';
+      heading.textContent = group.label || '-';
+      wrapper.appendChild(heading);
+
+      const cards = document.createElement('div');
+      cards.className = 'space-y-3';
+
+      (group.transactions || []).forEach((tx) => {
+        const tone = tx.type === 'masuk' ? 'bg-emerald-100 text-emerald-600' : 'bg-rose-100 text-rose-600';
+        const symbol = tx.type === 'masuk' ? '↑' : '↓';
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'w-full flex items-center justify-between gap-4 p-4 rounded-xl border border-slate-200 bg-white text-left hover:border-cyan-300 hover:shadow-sm transition';
+        button.innerHTML = `
+          <div class="flex items-start gap-4">
+            <span class="flex-none w-10 h-10 rounded-full grid place-items-center ${tone} text-lg font-semibold">${symbol}</span>
+            <div>
+              <p class="font-semibold text-slate-900">${tx.title || '-'}</p>
+              <p class="text-sm text-slate-500">${tx.note || ''}</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-3">
+            <span class="font-semibold text-slate-900">${formatCurrency(tx.amount)}</span>
+            <span class="text-slate-300 text-2xl leading-none">&rsaquo;</span>
+          </div>
+        `;
+        button.addEventListener('click', () => {
+          console.info('Open detail for transaction', tx.id || tx.title);
+        });
+        cards.appendChild(button);
+      });
+
+      wrapper.appendChild(cards);
+      listEl.appendChild(wrapper);
+    });
+  }
+
+  function parseDate(value) {
+    if (!value) return new Date('1970-01-01');
+    const parts = value.split('-');
+    if (parts.length !== 3) return new Date(value);
+    const [year, month, day] = parts.map((p) => parseInt(p, 10));
+    return new Date(year || 0, (month || 1) - 1, day || 1);
+  }
+
+  function getFilters() {
+    if (!filterGroup) return { date: '', type: [] };
+
+    const read = (name) => {
+      const el = filterGroup.querySelector(`.filter[data-filter="${name}"]`);
+      return el ? el.dataset.applied || '' : '';
+    };
+
+    const typeRaw = read('type');
+
+    return {
+      date: read('date'),
+      type: typeRaw ? typeRaw.split(',').filter(Boolean) : [],
+    };
+  }
+
+  function filterGroupsByType(groups, values) {
+    if (!values || values.length === 0) return groups;
+    const wanted = values.map((val) => val.toLowerCase());
+    return groups
+      .map((group) => ({
+        ...group,
+        transactions: (group.transactions || []).filter((tx) => {
+          const type = (tx.type || '').toLowerCase();
+          if (!type) return false;
+          if (type === 'masuk' && wanted.includes('masuk')) return true;
+          if (type === 'keluar' && wanted.includes('keluar')) return true;
+          return false;
+        }),
+      }))
+      .filter((group) => (group.transactions || []).length > 0);
+  }
+
+  function filterGroupsByDate(groups, value) {
+    if (!value) return groups;
+
+    const now = new Date();
+    let start = null;
+    let end = null;
+
+    if (value === '7 Hari Terakhir') {
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+      end = now;
+    } else if (value === '30 Hari Terakhir') {
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+      end = now;
+    } else if (value === '1 Tahun Terakhir') {
+      start = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+      end = now;
+    } else if (value.startsWith('custom:')) {
+      const [startStr, endStr] = value.slice(7).split('|');
+      if (startStr) start = new Date(startStr);
+      if (endStr) end = new Date(endStr);
+    }
+
+    if (!start && !end) return groups;
+
+    return groups
+      .map((group) => ({
+        ...group,
+        transactions: (group.transactions || []).filter((tx) => {
+          const txDate = parseDate(tx.date || group.date);
+          if (start && txDate < start) return false;
+          if (end && txDate > end) return false;
+          return true;
+        }),
+      }))
+      .filter((group) => (group.transactions || []).length > 0);
+  }
+
+  function applyFiltersAndRender() {
+    if (!activeData) {
+      showState('empty');
+      return;
+    }
+
+    if (activeData.status === 'loading') {
+      showState('loading');
+      return;
+    }
+
+    if (activeData.status === 'error') {
+      showState('error');
+      return;
+    }
+
+    let groups = sanitiseGroups(activeData.groups);
+    const filters = getFilters();
+
+    groups = filterGroupsByDate(groups, filters.date);
+    groups = filterGroupsByType(groups, filters.type);
+
+    if (!groups.length) {
+      showState('empty');
+      return;
+    }
+
+    showState('success');
+    renderTransactions(groups);
+  }
+
+  function loadTransactions(account) {
+    activeData = getDataForAccount(account);
+    applyFiltersAndRender();
+  }
+
+  function openDrawer(account) {
+    if (!drawer) return;
+    activeAccount = account;
+    activeData = null;
+
+    if (drawerTitle) drawerTitle.textContent = account.displayName || account.name || 'Mutasi Rekening';
+    if (drawerAccountLabel) drawerAccountLabel.textContent = account.displayName || account.name || 'Mutasi Rekening';
+
+    resetFilters();
+    showState('loading');
+    drawer.classList.add('open');
+    collapseSidebar();
+
+    if (drawerInner) {
+      drawerInner.classList.remove('opacity-0');
+    }
+
+    if (loadTimer) clearTimeout(loadTimer);
+    loadTimer = setTimeout(() => {
+      loadTransactions(account);
+    }, 300);
+  }
+
+  function closeDrawer() {
+    if (!drawer) return;
+    drawer.classList.remove('open');
+    restoreSidebar();
+    activeAccount = null;
+    activeData = null;
+    if (loadTimer) {
+      clearTimeout(loadTimer);
+      loadTimer = null;
+    }
   }
 
   function renderCards() {
@@ -38,6 +345,11 @@ document.addEventListener('DOMContentLoaded', () => {
         <button class="mt-auto rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 hover:bg-cyan-50">Pilih Rekening</button>
       `;
 
+      const button = card.querySelector('button');
+      if (button) {
+        button.addEventListener('click', () => openDrawer(account));
+      }
+
       container.appendChild(card);
     });
   }
@@ -47,4 +359,26 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof ambis.onBrandNameChange === 'function') {
     ambis.onBrandNameChange(renderCards);
   }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', closeDrawer);
+  }
+
+  if (retryBtn) {
+    retryBtn.addEventListener('click', () => {
+      if (!activeAccount) return;
+      showState('loading');
+      if (loadTimer) clearTimeout(loadTimer);
+      loadTimer = setTimeout(() => {
+        loadTransactions(activeAccount);
+      }, 300);
+    });
+  }
+
+  document.addEventListener('filter-change', (event) => {
+    const groupId = event.detail ? event.detail.groupId : null;
+    if (!groupId || groupId === 'mutasi') {
+      applyFiltersAndRender();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- build the mutasi drawer markup with dynamic title, tabs, filters, banner, and state containers
- add mock transaction dataset for each account to drive the drawer list view
- implement drawer interactions: open/close behavior, sidebar collapse, data loading states, and filter-based rendering of grouped transactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd0b38bfb48330b9eaeefa1c6b0822