### PR TITLE
Add transaction detail bottom sheet for mutasi page

### DIFF
--- a/data/mutasi-data.js
+++ b/data/mutasi-data.js
@@ -12,14 +12,52 @@
               type: 'masuk',
               title: 'Setoran Dana Penjualan',
               note: 'Transfer dari PT Nusantara Maju',
-              amount: 250000000
+              amount: 250000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'BI Fast',
+                reference: '1234567890',
+                datetime: '2024-01-03T20:56:00+07:00',
+                category: 'Pemindahan Dana',
+                note: 'Kesalahan Transfer',
+                total: 250000000,
+                source: {
+                  name: 'Operasional',
+                  subtitle: 'PT ABC Indonesia',
+                  account: 'Amar Indonesia - 000967895483'
+                },
+                destination: {
+                  name: 'Supplier Baja',
+                  subtitle: 'PT XYZ Indonesia',
+                  account: 'BCA - 4750278562'
+                }
+              }
             },
             {
               id: 'UTM-12002',
               type: 'keluar',
               title: 'Pembayaran Vendor',
               note: 'Ke PT Sinar Abadi Makmur',
-              amount: 175000000
+              amount: 175000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'SKN',
+                reference: 'TRX-UTM12002',
+                datetime: '2024-02-14T09:30:00+07:00',
+                category: 'Pembayaran Vendor',
+                note: 'Pelunasan invoice bulanan',
+                total: 175000000,
+                source: {
+                  name: 'Operasional',
+                  subtitle: 'PT ABC Indonesia',
+                  account: 'BCA - 0987654321'
+                },
+                destination: {
+                  name: 'PT Sinar Abadi Makmur',
+                  subtitle: 'Vendor Utama',
+                  account: 'Mandiri - 1234567890'
+                }
+              }
             }
           ]
         },
@@ -32,7 +70,26 @@
               type: 'masuk',
               title: 'Penerimaan Refund',
               note: 'Pengembalian biaya operasional',
-              amount: 96000000
+              amount: 96000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'Online Transfer',
+                reference: 'TRX-UTM11951',
+                datetime: '2024-02-01T16:20:00+07:00',
+                category: 'Pengembalian Dana',
+                note: 'Refund biaya operasional cabang',
+                total: 96000000,
+                source: {
+                  name: 'Rekening Refund',
+                  subtitle: 'PT Nusantara Logistics',
+                  account: 'BRI - 5566778899'
+                },
+                destination: {
+                  name: 'Utama',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895410'
+                }
+              }
             }
           ]
         }
@@ -50,14 +107,52 @@
               type: 'keluar',
               title: 'TRCDESC',
               note: 'Description/Notes/Description/Note',
-              amount: 1000000000000
+              amount: 1000000000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'RTGS',
+                reference: 'TRX-OPR23001',
+                datetime: '2024-03-05T11:00:00+07:00',
+                category: 'Investasi',
+                note: 'Pemindahan dana antar rekening korporat',
+                total: 1000000000000,
+                source: {
+                  name: 'Operasional',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895483'
+                },
+                destination: {
+                  name: 'Rekening Investasi',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'BCA - 8899001122'
+                }
+              }
             },
             {
               id: 'OPR-23002',
               type: 'masuk',
               title: 'TRCDESC',
               note: 'Description/Notes/Description/Note',
-              amount: 1000000000000
+              amount: 1000000000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'Transfer Internal',
+                reference: 'TRX-OPR23002',
+                datetime: '2024-03-06T14:45:00+07:00',
+                category: 'Pengembalian Dana',
+                note: 'Pengembalian modal investasi jangka pendek',
+                total: 1000000000000,
+                source: {
+                  name: 'Rekening Investasi',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'BCA - 8899001122'
+                },
+                destination: {
+                  name: 'Operasional',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895483'
+                }
+              }
             }
           ]
         },
@@ -70,7 +165,26 @@
               type: 'keluar',
               title: 'Pembayaran Gaji Karyawan',
               note: 'Payroll Agustus 2025',
-              amount: 850000000
+              amount: 850000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'Payroll Bulk',
+                reference: 'TRX-OPR22987',
+                datetime: '2024-08-25T08:00:00+07:00',
+                category: 'Pembayaran Gaji',
+                note: 'Pembayaran gaji seluruh karyawan',
+                total: 850000000,
+                source: {
+                  name: 'Operasional',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895483'
+                },
+                destination: {
+                  name: 'Karyawan',
+                  subtitle: 'Berbagai rekening',
+                  account: 'Multi-bank'
+                }
+              }
             }
           ]
         }
@@ -88,14 +202,52 @@
               type: 'keluar',
               title: 'Pembayaran Distributor Wilayah Barat',
               note: 'Invoice #INV-8721',
-              amount: 420000000
+              amount: 420000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'Virtual Account',
+                reference: 'TRX-DST11841',
+                datetime: '2024-05-10T13:10:00+07:00',
+                category: 'Pembayaran Distributor',
+                note: 'Pembayaran invoice #INV-8721',
+                total: 420000000,
+                source: {
+                  name: 'Pembayaran Distributor',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895450'
+                },
+                destination: {
+                  name: 'Distributor Wilayah Barat',
+                  subtitle: 'PT Samudra Niaga',
+                  account: 'BNI - 7788990011'
+                }
+              }
             },
             {
               id: 'DST-11842',
               type: 'masuk',
               title: 'Pembayaran Distributor Wilayah Timur',
               note: 'Setoran penjualan cabang Makassar',
-              amount: 570000000
+              amount: 570000000,
+              detail: {
+                activity: 'Transfer Saldo',
+                method: 'BI Fast',
+                reference: 'TRX-DST11842',
+                datetime: '2024-05-11T15:05:00+07:00',
+                category: 'Setoran Penjualan',
+                note: 'Setoran penjualan cabang Makassar',
+                total: 570000000,
+                source: {
+                  name: 'Distributor Wilayah Timur',
+                  subtitle: 'PT Makassar Prima',
+                  account: 'BCA - 6677889900'
+                },
+                destination: {
+                  name: 'Pembayaran Distributor',
+                  subtitle: 'PT Sarana Pancing Indonesia',
+                  account: 'Amar Indonesia - 000967895450'
+                }
+              }
             }
           ]
         }

--- a/mutasi.html
+++ b/mutasi.html
@@ -304,6 +304,94 @@
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
+  <div id="mutasiDetailOverlay" class="fixed inset-0 bg-black/30 hidden opacity-0 pointer-events-none transition-opacity duration-200 z-40"></div>
+  <div
+    id="mutasiDetailSheet"
+    class="fixed inset-x-0 bottom-0 w-full md:max-w-2xl md:mx-auto bg-white rounded-t-3xl shadow-2xl max-h-[90vh] hidden translate-y-full transition-transform duration-300 z-50 flex flex-col pointer-events-none"
+  >
+    <div class="px-6 pt-4 pb-2 border-b border-slate-200">
+      <div class="mx-auto h-1.5 w-12 rounded-full bg-slate-200"></div>
+    </div>
+    <div class="flex-1 overflow-y-auto px-6 pb-6">
+      <div class="flex flex-col items-center text-center gap-4 pt-4">
+        <div class="w-20 h-20 rounded-full bg-cyan-50 border border-cyan-100 grid place-items-center">
+          <img src="img/icon/transfer-mutasi.svg" alt="Detail Transaksi" class="w-10 h-10" />
+        </div>
+        <h3 class="text-xl font-semibold text-slate-900">Detail Transaksi</h3>
+      </div>
+
+      <section class="mt-8 space-y-3">
+        <p class="text-xs font-semibold tracking-[.18em] text-slate-500 uppercase">Aktivitas</p>
+        <p id="mutasiDetailActivity" class="text-base font-semibold text-slate-900">Transfer Saldo</p>
+      </section>
+
+      <section class="mt-6 bg-[#F2F9FF] border border-sky-200 rounded-2xl p-4 space-y-6">
+        <div class="flex items-start gap-4">
+          <div id="mutasiDetailSourceBadge" class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-600 grid place-items-center font-semibold text-base">O</div>
+          <div class="min-w-0 space-y-1">
+            <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Sumber</p>
+            <p id="mutasiDetailSourceName" class="text-base font-semibold text-slate-900 leading-snug truncate">Operasional</p>
+            <p id="mutasiDetailSourceSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT ABC Indonesia</p>
+            <p id="mutasiDetailSourceAccount" class="text-sm text-slate-500 leading-snug break-words">Amar Indonesia - 000967895483</p>
+          </div>
+        </div>
+        <div class="border-t border-sky-200"></div>
+        <div class="flex items-start gap-4">
+          <div id="mutasiDetailDestinationBadge" class="w-10 h-10 rounded-full bg-amber-100 text-amber-600 grid place-items-center font-semibold text-base">S</div>
+          <div class="min-w-0 space-y-1">
+            <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Tujuan</p>
+            <p id="mutasiDetailDestinationName" class="text-base font-semibold text-slate-900 leading-snug truncate">Supplier Baja</p>
+            <p id="mutasiDetailDestinationSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT XYZ Indonesia</p>
+            <p id="mutasiDetailDestinationAccount" class="text-sm text-slate-500 leading-snug break-words">BCA - 4750278562</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">TOTAL TRANSAKSI</p>
+        <div class="flex items-center justify-between text-sm text-slate-600">
+          <span>Nominal</span>
+          <span id="mutasiDetailTotal" class="text-right text-slate-900 font-semibold text-xl">Rp250.000.000</span>
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">DETAIL TRANSAKSI</p>
+        <dl class="space-y-4">
+          <div class="flex justify-between gap-6 text-sm text-slate-600">
+            <dt>Metode Transfer</dt>
+            <dd id="mutasiDetailMethod" class="text-right text-slate-900 font-medium break-words">BI Fast</dd>
+          </div>
+          <div class="flex justify-between gap-6 text-sm text-slate-600">
+            <dt>Nomor Referensi</dt>
+            <dd id="mutasiDetailReference" class="text-right text-slate-900 font-medium break-words">1234567890</dd>
+          </div>
+          <div class="flex justify-between gap-6 text-sm text-slate-600">
+            <dt>Tanggal dan Waktu</dt>
+            <dd id="mutasiDetailDate" class="text-right text-slate-900 font-medium break-words">3 Januari 2024, 20.56</dd>
+          </div>
+          <div class="flex justify-between gap-6 text-sm text-slate-600">
+            <dt>Kategori</dt>
+            <dd id="mutasiDetailCategory" class="text-right text-slate-900 font-medium break-words">Pemindahan Dana</dd>
+          </div>
+          <div class="flex justify-between gap-6 text-sm text-slate-600">
+            <dt>Catatan</dt>
+            <dd id="mutasiDetailNote" class="text-right text-slate-900 font-medium break-words">Kesalahan Transfer</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+    <div class="p-4 border-t border-slate-200 bg-white">
+      <button
+        type="button"
+        data-mutasi-detail-close
+        class="w-full rounded-xl border border-cyan-500 text-cyan-600 font-semibold py-3 hover:bg-cyan-50"
+      >
+        Tutup
+      </button>
+    </div>
+  </div>
+
   <script src="mutasi.js"></script>
   <script src="sidebar.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add the transaction detail bottom sheet markup to `mutasi.html`
- extend the mock mutasi dataset with structured detail metadata for each transaction
- implement the JavaScript logic to populate and control the new bottom sheet when a transaction card is selected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd29ce41ec833083824904deeabd4e