### PR TITLE
Display mutasi detail inside drawer

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -292,6 +292,101 @@
 
           <div id="mutasiSuccess" class="hidden px-6 pb-10 space-y-6">
             <div id="mutasiTransactionList" class="space-y-8"></div>
+
+            <div id="mutasiDetailView" class="hidden">
+              <button
+                type="button"
+                data-mutasi-detail-close
+                class="mb-4 flex items-center gap-2 text-sm font-semibold text-cyan-600 hover:text-cyan-700"
+              >
+                <span aria-hidden="true">&larr;</span>
+                <span>Kembali ke daftar transaksi</span>
+              </button>
+
+              <div class="rounded-2xl border border-slate-200 bg-white overflow-hidden shadow-sm">
+                <div class="px-6 pt-4 pb-2 border-b border-slate-200">
+                  <div class="mx-auto h-1.5 w-12 rounded-full bg-slate-200"></div>
+                </div>
+                <div class="px-6 pb-6">
+                  <div class="flex flex-col items-center text-center gap-4 pt-4">
+                    <div class="w-20 h-20 rounded-full bg-cyan-50 border border-cyan-100 grid place-items-center">
+                      <img src="img/icon/transfer-mutasi.svg" alt="Detail Transaksi" class="w-10 h-10" />
+                    </div>
+                    <h3 class="text-xl font-semibold text-slate-900">Detail Transaksi</h3>
+                  </div>
+
+                  <section class="mt-8 space-y-3">
+                    <p class="text-xs font-semibold tracking-[.18em] text-slate-500 uppercase">Aktivitas</p>
+                    <p id="mutasiDetailActivity" class="text-base font-semibold text-slate-900">Transfer Saldo</p>
+                  </section>
+
+                  <section class="mt-6 bg-[#F2F9FF] border border-sky-200 rounded-2xl p-4 space-y-6">
+                    <div class="flex items-start gap-4">
+                      <div id="mutasiDetailSourceBadge" class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-600 grid place-items-center font-semibold text-base">O</div>
+                      <div class="min-w-0 space-y-1">
+                        <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Sumber</p>
+                        <p id="mutasiDetailSourceName" class="text-base font-semibold text-slate-900 leading-snug truncate">Operasional</p>
+                        <p id="mutasiDetailSourceSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT ABC Indonesia</p>
+                        <p id="mutasiDetailSourceAccount" class="text-sm text-slate-500 leading-snug break-words">Amar Indonesia - 000967895483</p>
+                      </div>
+                    </div>
+                    <div class="border-t border-sky-200"></div>
+                    <div class="flex items-start gap-4">
+                      <div id="mutasiDetailDestinationBadge" class="w-10 h-10 rounded-full bg-amber-100 text-amber-600 grid place-items-center font-semibold text-base">S</div>
+                      <div class="min-w-0 space-y-1">
+                        <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Tujuan</p>
+                        <p id="mutasiDetailDestinationName" class="text-base font-semibold text-slate-900 leading-snug truncate">Supplier Baja</p>
+                        <p id="mutasiDetailDestinationSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT XYZ Indonesia</p>
+                        <p id="mutasiDetailDestinationAccount" class="text-sm text-slate-500 leading-snug break-words">BCA - 4750278562</p>
+                      </div>
+                    </div>
+                  </section>
+
+                  <section class="mt-8">
+                    <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">TOTAL TRANSAKSI</p>
+                    <div class="flex items-center justify-between text-sm text-slate-600">
+                      <span>Nominal</span>
+                      <span id="mutasiDetailTotal" class="text-right text-slate-900 font-semibold text-xl">Rp250.000.000</span>
+                    </div>
+                  </section>
+
+                  <section class="mt-8">
+                    <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">DETAIL TRANSAKSI</p>
+                    <dl class="space-y-4">
+                      <div class="flex justify-between gap-6 text-sm text-slate-600">
+                        <dt>Metode Transfer</dt>
+                        <dd id="mutasiDetailMethod" class="text-right text-slate-900 font-medium break-words">BI Fast</dd>
+                      </div>
+                      <div class="flex justify-between gap-6 text-sm text-slate-600">
+                        <dt>Nomor Referensi</dt>
+                        <dd id="mutasiDetailReference" class="text-right text-slate-900 font-medium break-words">1234567890</dd>
+                      </div>
+                      <div class="flex justify-between gap-6 text-sm text-slate-600">
+                        <dt>Tanggal dan Waktu</dt>
+                        <dd id="mutasiDetailDate" class="text-right text-slate-900 font-medium break-words">3 Januari 2024, 20.56</dd>
+                      </div>
+                      <div class="flex justify-between gap-6 text-sm text-slate-600">
+                        <dt>Kategori</dt>
+                        <dd id="mutasiDetailCategory" class="text-right text-slate-900 font-medium break-words">Pemindahan Dana</dd>
+                      </div>
+                      <div class="flex justify-between gap-6 text-sm text-slate-600">
+                        <dt>Catatan</dt>
+                        <dd id="mutasiDetailNote" class="text-right text-slate-900 font-medium break-words">Kesalahan Transfer</dd>
+                      </div>
+                    </dl>
+                  </section>
+                </div>
+                <div class="p-4 border-t border-slate-200 bg-white">
+                  <button
+                    type="button"
+                    data-mutasi-detail-close
+                    class="w-full rounded-xl border border-cyan-500 text-cyan-600 font-semibold py-3 hover:bg-cyan-50"
+                  >
+                    Tutup
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -304,94 +399,6 @@
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
-  <div id="mutasiDetailOverlay" class="fixed inset-0 bg-black/30 hidden opacity-0 pointer-events-none transition-opacity duration-200 z-40"></div>
-  <div
-    id="mutasiDetailSheet"
-    class="fixed inset-x-0 bottom-0 w-full md:max-w-2xl md:mx-auto bg-white rounded-t-3xl shadow-2xl max-h-[90vh] hidden translate-y-full transition-transform duration-300 z-50 flex flex-col pointer-events-none"
-  >
-    <div class="px-6 pt-4 pb-2 border-b border-slate-200">
-      <div class="mx-auto h-1.5 w-12 rounded-full bg-slate-200"></div>
-    </div>
-    <div class="flex-1 overflow-y-auto px-6 pb-6">
-      <div class="flex flex-col items-center text-center gap-4 pt-4">
-        <div class="w-20 h-20 rounded-full bg-cyan-50 border border-cyan-100 grid place-items-center">
-          <img src="img/icon/transfer-mutasi.svg" alt="Detail Transaksi" class="w-10 h-10" />
-        </div>
-        <h3 class="text-xl font-semibold text-slate-900">Detail Transaksi</h3>
-      </div>
-
-      <section class="mt-8 space-y-3">
-        <p class="text-xs font-semibold tracking-[.18em] text-slate-500 uppercase">Aktivitas</p>
-        <p id="mutasiDetailActivity" class="text-base font-semibold text-slate-900">Transfer Saldo</p>
-      </section>
-
-      <section class="mt-6 bg-[#F2F9FF] border border-sky-200 rounded-2xl p-4 space-y-6">
-        <div class="flex items-start gap-4">
-          <div id="mutasiDetailSourceBadge" class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-600 grid place-items-center font-semibold text-base">O</div>
-          <div class="min-w-0 space-y-1">
-            <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Sumber</p>
-            <p id="mutasiDetailSourceName" class="text-base font-semibold text-slate-900 leading-snug truncate">Operasional</p>
-            <p id="mutasiDetailSourceSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT ABC Indonesia</p>
-            <p id="mutasiDetailSourceAccount" class="text-sm text-slate-500 leading-snug break-words">Amar Indonesia - 000967895483</p>
-          </div>
-        </div>
-        <div class="border-t border-sky-200"></div>
-        <div class="flex items-start gap-4">
-          <div id="mutasiDetailDestinationBadge" class="w-10 h-10 rounded-full bg-amber-100 text-amber-600 grid place-items-center font-semibold text-base">S</div>
-          <div class="min-w-0 space-y-1">
-            <p class="text-xs font-semibold tracking-[.16em] text-slate-500 uppercase">Tujuan</p>
-            <p id="mutasiDetailDestinationName" class="text-base font-semibold text-slate-900 leading-snug truncate">Supplier Baja</p>
-            <p id="mutasiDetailDestinationSubtitle" class="text-sm text-slate-500 leading-snug truncate">PT XYZ Indonesia</p>
-            <p id="mutasiDetailDestinationAccount" class="text-sm text-slate-500 leading-snug break-words">BCA - 4750278562</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="mt-8">
-        <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">TOTAL TRANSAKSI</p>
-        <div class="flex items-center justify-between text-sm text-slate-600">
-          <span>Nominal</span>
-          <span id="mutasiDetailTotal" class="text-right text-slate-900 font-semibold text-xl">Rp250.000.000</span>
-        </div>
-      </section>
-
-      <section class="mt-8">
-        <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">DETAIL TRANSAKSI</p>
-        <dl class="space-y-4">
-          <div class="flex justify-between gap-6 text-sm text-slate-600">
-            <dt>Metode Transfer</dt>
-            <dd id="mutasiDetailMethod" class="text-right text-slate-900 font-medium break-words">BI Fast</dd>
-          </div>
-          <div class="flex justify-between gap-6 text-sm text-slate-600">
-            <dt>Nomor Referensi</dt>
-            <dd id="mutasiDetailReference" class="text-right text-slate-900 font-medium break-words">1234567890</dd>
-          </div>
-          <div class="flex justify-between gap-6 text-sm text-slate-600">
-            <dt>Tanggal dan Waktu</dt>
-            <dd id="mutasiDetailDate" class="text-right text-slate-900 font-medium break-words">3 Januari 2024, 20.56</dd>
-          </div>
-          <div class="flex justify-between gap-6 text-sm text-slate-600">
-            <dt>Kategori</dt>
-            <dd id="mutasiDetailCategory" class="text-right text-slate-900 font-medium break-words">Pemindahan Dana</dd>
-          </div>
-          <div class="flex justify-between gap-6 text-sm text-slate-600">
-            <dt>Catatan</dt>
-            <dd id="mutasiDetailNote" class="text-right text-slate-900 font-medium break-words">Kesalahan Transfer</dd>
-          </div>
-        </dl>
-      </section>
-    </div>
-    <div class="p-4 border-t border-slate-200 bg-white">
-      <button
-        type="button"
-        data-mutasi-detail-close
-        class="w-full rounded-xl border border-cyan-500 text-cyan-600 font-semibold py-3 hover:bg-cyan-50"
-      >
-        Tutup
-      </button>
-    </div>
-  </div>
-
   <script src="mutasi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/mutasi.js
+++ b/mutasi.js
@@ -15,8 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const retryBtn = document.getElementById('mutasiRetry');
   const filterGroup = document.querySelector('[data-filter-group="mutasi"]');
   const sidebar = document.getElementById('sidebar');
-  const detailOverlay = document.getElementById('mutasiDetailOverlay');
-  const detailSheet = document.getElementById('mutasiDetailSheet');
+  const detailView = document.getElementById('mutasiDetailView');
   const detailCloseButtons = document.querySelectorAll('[data-mutasi-detail-close]');
   const detailElements = {
     activity: document.getElementById('mutasiDetailActivity'),
@@ -132,62 +131,27 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function openDetailSheet(transaction) {
-    if (!detailOverlay || !detailSheet) return;
+    if (!detailView) return;
     fillDetailSheet(transaction || {});
     detailIsOpen = true;
-    detailOverlay.classList.remove('hidden');
-    detailSheet.classList.remove('hidden');
-    detailOverlay.classList.remove('pointer-events-none');
-    detailSheet.classList.remove('pointer-events-none');
-    requestAnimationFrame(() => {
-      detailOverlay.classList.add('opacity-100');
-      detailOverlay.classList.remove('opacity-0');
-      detailSheet.classList.remove('translate-y-full');
-    });
+    if (listEl) {
+      listEl.classList.add('hidden');
+    }
+    detailView.classList.remove('hidden');
+    if (drawerInner) {
+      drawerInner.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   }
 
   function closeDetailSheet(immediate = false) {
-    if (!detailOverlay || !detailSheet) return;
+    if (!detailView) return;
     if (!detailIsOpen && !immediate) return;
 
-    const hideImmediately = () => {
-      detailOverlay.classList.add('opacity-0');
-      detailOverlay.classList.remove('opacity-100');
-      detailOverlay.classList.add('pointer-events-none');
-      detailOverlay.classList.add('hidden');
-      detailSheet.classList.add('translate-y-full');
-      detailSheet.classList.add('pointer-events-none');
-      detailSheet.classList.add('hidden');
-    };
-
-    if (immediate) {
-      detailIsOpen = false;
-      hideImmediately();
-      return;
-    }
-
     detailIsOpen = false;
-    detailOverlay.classList.remove('opacity-100');
-    detailOverlay.classList.add('opacity-0');
-    detailOverlay.classList.add('pointer-events-none');
-    detailSheet.classList.add('translate-y-full');
-    detailSheet.classList.add('pointer-events-none');
-
-    const onTransitionEnd = (event) => {
-      if (event.target !== detailSheet) return;
-      detailSheet.removeEventListener('transitionend', onTransitionEnd);
-      detailOverlay.classList.add('hidden');
-      detailSheet.classList.add('hidden');
-    };
-
-    detailSheet.addEventListener('transitionend', onTransitionEnd);
-
-    setTimeout(() => {
-      if (!detailIsOpen) {
-        detailOverlay.classList.add('hidden');
-        detailSheet.classList.add('hidden');
-      }
-    }, 350);
+    detailView.classList.add('hidden');
+    if (listEl) {
+      listEl.classList.remove('hidden');
+    }
   }
 
   function collapseSidebar() {
@@ -540,10 +504,6 @@ document.addEventListener('DOMContentLoaded', () => {
         loadTransactions(activeAccount);
       }, 300);
     });
-  }
-
-  if (detailOverlay) {
-    detailOverlay.addEventListener('click', () => closeDetailSheet());
   }
 
   detailCloseButtons.forEach((button) => {


### PR DESCRIPTION
## Summary
- show the transaction detail content within the Mutasi drawer instead of opening a separate bottom sheet overlay
- reuse the existing detail layout inside the drawer and provide controls to return to the transaction list
- update the drawer scripting so transaction selection toggles between the list view and inline detail view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2de37ac48330bcfbf4fb3d732df0