### PR TITLE
Match detail sheet width to drawer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -61,8 +61,9 @@
 
 /* Drawer panel that pushes main content instead of overlaying */
 #drawer{
+  --drawer-max-width:550px;
   width:0;
-  max-width:550px;
+  max-width:var(--drawer-max-width);
   overflow:hidden;
   transition:width .3s ease;
   border-left-width:0;
@@ -70,6 +71,13 @@
 #drawer.open{
   width:100%;
   border-left-width:24px;
+}
+
+#drawer #mutasiDetailSheet{
+  width:100%;
+  max-width:var(--drawer-max-width);
+  left:auto;
+  right:0;
 }
 
 /* Disabled button appearance */


### PR DESCRIPTION
## Summary
- define a shared drawer max-width variable in styles.css
- constrain the mutasi detail bottom sheet to the drawer width so it aligns with the panel edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd334f13c88330a973cf3523c4d38f