### PR TITLE
Align mutasi bottom sheet with transfer spec

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -300,26 +300,32 @@
 
       <div
         id="mutasiDetailSheet"
-        class="absolute inset-x-0 bottom-0 w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 h-3/4 max-h-[90%] z-20 flex flex-col overflow-hidden"
+        class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col overflow-hidden"
       >
-        <div class="px-6 pt-4 pb-2 border-b border-slate-200">
-          <div class="mx-auto h-1.5 w-12 rounded-full bg-slate-200"></div>
+        <div class="relative px-4 pt-6 pb-4 text-center border-b border-slate-200">
+          <h3 class="text-lg font-semibold text-slate-900">Detail Transaksi</h3>
+          <button
+            type="button"
+            data-mutasi-detail-close
+            class="absolute top-6 right-6 text-2xl leading-none text-slate-500 transition hover:text-slate-700"
+            aria-label="Tutup detail transaksi"
+          >&times;</button>
         </div>
         <div id="mutasiDetailView" class="flex-1 overflow-y-auto px-6 pb-6">
           <button
             type="button"
             data-mutasi-detail-close
-            class="mb-4 flex items-center gap-2 text-sm font-semibold text-cyan-600 hover:text-cyan-700"
+            class="mb-6 flex items-center gap-2 text-sm font-semibold text-cyan-600 hover:text-cyan-700"
           >
             <span aria-hidden="true">&larr;</span>
             <span>Kembali ke daftar transaksi</span>
           </button>
 
-          <div class="flex flex-col items-center text-center gap-4 pt-4">
+          <div class="flex flex-col items-center text-center gap-4 pt-2">
             <div class="w-20 h-20 rounded-full bg-cyan-50 border border-cyan-100 grid place-items-center">
               <img src="img/icon/transfer-mutasi.svg" alt="Detail Transaksi" class="w-10 h-10" />
             </div>
-            <h3 class="text-xl font-semibold text-slate-900">Detail Transaksi</h3>
+            <p class="text-sm font-semibold tracking-[.18em] text-slate-500 uppercase">Mutasi Rekening</p>
           </div>
 
           <section class="mt-8 space-y-3">


### PR DESCRIPTION
## Summary
- match the mutasi detail bottom sheet layout with the transfer page by adopting the same header structure and close affordances
- ensure the sheet container and introductory content follow the transfer bottom sheet spec while retaining existing interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd3510dd1c83309b54399c97195eb4