### PR TITLE
Fix mutasi type filtering

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -187,7 +187,7 @@
           </div>
         </div>
 
-        <div class="px-4 pb-4 data-filter-group="mutasi">
+        <div class="px-4 pb-4" data-filter-group="mutasi">
           <div class="flex flex-wrap gap-3">
             <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
               <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">

--- a/mutasi.js
+++ b/mutasi.js
@@ -326,7 +326,9 @@ document.addEventListener('DOMContentLoaded', () => {
       cards.className = 'rounded-2xl border border-slate-300 overflow-hidden bg-white';
 
       (group.transactions || []).forEach((tx, txIndex, arr) => {
-        const isCredit = (tx.type || '').toLowerCase() === 'masuk';
+        const typeNormalized = (tx.type || '').toLowerCase();
+        const isCredit = typeNormalized === 'masuk';
+        const isDebit = typeNormalized === 'keluar';
         const badgeClass = isCredit
           ? 'bg-emerald-50 text-emerald-600'
           : 'bg-rose-50 text-rose-600';
@@ -336,7 +338,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const button = document.createElement('button');
         button.type = 'button';
         button.className = 'w-full bg-white p-4 text-left transition';
-        button.dataset.category = isCredit ? 'masuk' : 'keluar';
+        const category = isCredit ? 'masuk' : (isDebit ? 'keluar' : '');
+        if (category) {
+          button.setAttribute('data-category', category);
+        } else {
+          button.removeAttribute('data-category');
+        }
         button.innerHTML = `
           <div class="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
             <div class="flex min-w-0 items-start gap-4">


### PR DESCRIPTION
## Summary
- fix the mutasi filter container markup so the drawer exposes its group id
- tag rendered transactions with an explicit data-category attribute derived from their type

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceaf870ebc8330a9666ac484f88caa