### PR TITLE
Add e-Statement tab interaction in mutasi drawer

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -165,111 +165,202 @@
               type="button"
               class="flex-1 rounded-xl bg-white px-4 py-3 text-center font-semibold text-slate-900 shadow-sm"
               aria-current="true"
-              data-tab-button="mutasi"
+              data-tab-button="e-statement"
             >
-              Mutasi Rekening
+              e-Statement
             </button>
             <button
               type="button"
               class="flex-1 rounded-xl px-4 py-3 text-center font-semibold text-slate-400 transition hover:text-slate-600"
-              data-tab-button="e-statement"
-              disabled
+              data-tab-button="mutasi"
             >
-              e-Statement
+              Mutasi Rekening
             </button>
           </div>
         </div>
 
-        <div class="px-4 pb-4">
-          <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
-            <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
-            <p class="text-sm leading-relaxed">Dapat menampilkan periode mutasi hingga 3 tahun terakhir</p>
-          </div>
-        </div>
+        <div class="flex-1 flex flex-col overflow-hidden">
+          <div
+            data-tab-content="e-statement"
+            class="flex-1 flex flex-col overflow-y-auto px-4 pb-6"
+          >
+            <div class="flex flex-col gap-4">
+              <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+                <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
+                <p class="text-sm leading-relaxed">
+                  Unduh e-Statement rekening dalam format PDF berdasarkan periode yang Anda pilih.
+                </p>
+              </div>
 
-        <div class="px-4 pb-4" data-filter-group="mutasi">
-          <div class="flex flex-wrap gap-3">
-            <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
-              <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
-                <img src="img/icon/date-picker.svg" class="w-5 h-5 flex-none" alt="Rentang Tanggal" />
-                <span class="filter-label flex-1 text-left leading-tight">Rentang Tanggal</span>
-              </button>
-              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
-                <div class="flex flex-col gap-3">
-                  <label class="flex items-center gap-2">
-                    <input type="radio" name="mutasi-date" value="7 Hari Terakhir">
-                    <span>7 Hari Terakhir</span>
-                  </label>
-                  <label class="flex items-center gap-2">
-                    <input type="radio" name="mutasi-date" value="30 Hari Terakhir">
-                    <span>30 Hari Terakhir</span>
-                  </label>
-                  <label class="flex items-center gap-2">
-                    <input type="radio" name="mutasi-date" value="1 Tahun Terakhir">
-                    <span>1 Tahun Terakhir</span>
-                  </label>
-                  <label class="flex items-center gap-2">
-                    <input type="radio" name="mutasi-date" value="custom">
-                    <span>Custom Rentang Tanggal</span>
-                  </label>
-                  <div class="custom-range hidden">
-                    <div class="flex gap-2">
-                      <div class="flex flex-col w-1/2">
-                        <span class="mb-1 text-sm">Tanggal Awal</span>
-                        <input
-                          type="text"
-                          class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
-                          placeholder="DD/MM/YYYY"
-                          data-field="start"
-                          readonly
-                        />
-                      </div>
-                      <div class="flex flex-col w-1/2">
-                        <span class="mb-1 text-sm">Tanggal Akhir</span>
-                        <input
-                          type="text"
-                          class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
-                          placeholder="DD/MM/YYYY"
-                          data-field="end"
-                          readonly
-                        />
-                      </div>
+              <div class="flex flex-wrap gap-3">
+                <div class="relative" data-e-statement-dropdown="year">
+                  <button
+                    type="button"
+                    id="eStatementYearTrigger"
+                    class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold"
+                    aria-haspopup="listbox"
+                    aria-expanded="false"
+                  >
+                    <img src="img/icon/date-picker.svg" class="w-5 h-5 flex-none" alt="Tahun" />
+                    <span id="eStatementYearLabel" class="flex-1 text-left leading-tight">Pilih Tahun</span>
+                  </button>
+                  <div
+                    id="eStatementYearPanel"
+                    class="filter-panel absolute z-10 mt-2 p-2 rounded-xl border border-slate-200 bg-white shadow hidden w-[200px]"
+                    role="listbox"
+                  >
+                    <div class="flex flex-col gap-1">
+                      <button type="button" class="px-3 py-2 rounded-lg text-left text-sm hover:bg-slate-100" data-value="2023">2023</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left text-sm hover:bg-slate-100" data-value="2024">2024</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left text-sm hover:bg-slate-100" data-value="2025">2025</button>
                     </div>
                   </div>
                 </div>
-                <div class="flex justify-end gap-2 mt-4">
-                  <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
-                  <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
-                </div>
-              </div>
-            </div>
 
-            <div class="filter relative" data-filter="type" data-name="Jenis Transaksi" data-default="Jenis Transaksi">
-              <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
-                <img src="img/icon/filter.svg" class="w-5 h-5 flex-none" alt="Jenis Transaksi" />
-                <span class="filter-label flex-1 text-left leading-tight">Jenis Transaksi</span>
-              </button>
-              <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[280px]">
-                <div class="flex flex-col gap-3">
-                  <label class="flex items-center gap-2">
-                    <input type="checkbox" value="Masuk">
-                    <span>Masuk</span>
-                  </label>
-                  <label class="flex items-center gap-2">
-                    <input type="checkbox" value="Keluar">
-                    <span>Keluar</span>
-                  </label>
-                </div>
-                <div class="flex justify-end gap-2 mt-4">
-                  <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
-                  <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
+                <div class="relative" data-e-statement-dropdown="month">
+                  <button
+                    type="button"
+                    id="eStatementMonthTrigger"
+                    class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold"
+                    aria-haspopup="listbox"
+                    aria-expanded="false"
+                  >
+                    <img src="img/icon/filter.svg" class="w-5 h-5 flex-none" alt="Bulan" />
+                    <span id="eStatementMonthLabel" class="flex-1 text-left leading-tight">Pilih Bulan</span>
+                  </button>
+                  <div
+                    id="eStatementMonthPanel"
+                    class="filter-panel absolute z-10 mt-2 p-2 rounded-xl border border-slate-200 bg-white shadow hidden w-[200px]"
+                    role="listbox"
+                  >
+                    <div class="flex flex-col gap-1 text-sm">
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="01">Januari</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="02">Februari</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="03">Maret</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="04">April</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="05">Mei</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="06">Juni</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="07">Juli</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="08">Agustus</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="09">September</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="10">Oktober</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="11">November</button>
+                      <button type="button" class="px-3 py-2 rounded-lg text-left hover:bg-slate-100" data-value="12">Desember</button>
+                    </div>
+                  </div>
                 </div>
               </div>
+
+              <div
+                id="eStatementAlert"
+                class="hidden rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-700 text-sm leading-relaxed"
+              ></div>
+
+              <button
+                type="button"
+                id="eStatementDownloadBtn"
+                class="h-11 rounded-xl bg-cyan-600 text-white font-semibold px-4 transition disabled:cursor-not-allowed disabled:opacity-50 hover:bg-cyan-700"
+                disabled
+              >
+                Unduh e-Statement
+              </button>
             </div>
           </div>
-        </div>
 
-        <div class="flex-1 overflow-y-auto" id="mutasiDrawerContent">
+          <div
+            data-tab-content="mutasi"
+            class="hidden flex-1 flex flex-col overflow-hidden"
+          >
+            <div class="px-4 pb-4">
+              <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+                <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
+                <p class="text-sm leading-relaxed">Dapat menampilkan periode mutasi hingga 3 tahun terakhir</p>
+              </div>
+            </div>
+
+            <div class="px-4 pb-4" data-filter-group="mutasi">
+              <div class="flex flex-wrap gap-3">
+                <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
+                  <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
+                    <img src="img/icon/date-picker.svg" class="w-5 h-5 flex-none" alt="Rentang Tanggal" />
+                    <span class="filter-label flex-1 text-left leading-tight">Rentang Tanggal</span>
+                  </button>
+                  <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
+                    <div class="flex flex-col gap-3">
+                      <label class="flex items-center gap-2">
+                        <input type="radio" name="mutasi-date" value="7 Hari Terakhir">
+                        <span>7 Hari Terakhir</span>
+                      </label>
+                      <label class="flex items-center gap-2">
+                        <input type="radio" name="mutasi-date" value="30 Hari Terakhir">
+                        <span>30 Hari Terakhir</span>
+                      </label>
+                      <label class="flex items-center gap-2">
+                        <input type="radio" name="mutasi-date" value="1 Tahun Terakhir">
+                        <span>1 Tahun Terakhir</span>
+                      </label>
+                      <label class="flex items-center gap-2">
+                        <input type="radio" name="mutasi-date" value="custom">
+                        <span>Custom Rentang Tanggal</span>
+                      </label>
+                      <div class="custom-range hidden">
+                        <div class="flex gap-2">
+                          <div class="flex flex-col w-1/2">
+                            <span class="mb-1 text-sm">Tanggal Awal</span>
+                            <input
+                              type="text"
+                              class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
+                              placeholder="DD/MM/YYYY"
+                              data-field="start"
+                              readonly
+                            />
+                          </div>
+                          <div class="flex flex-col w-1/2">
+                            <span class="mb-1 text-sm">Tanggal Akhir</span>
+                            <input
+                              type="text"
+                              class="h-10 border border-slate-300 rounded-lg text-center flatpickr-input"
+                              placeholder="DD/MM/YYYY"
+                              data-field="end"
+                              readonly
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="flex justify-end gap-2 mt-4">
+                      <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
+                      <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="filter relative" data-filter="type" data-name="Jenis Transaksi" data-default="Jenis Transaksi">
+                  <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
+                    <img src="img/icon/filter.svg" class="w-5 h-5 flex-none" alt="Jenis Transaksi" />
+                    <span class="filter-label flex-1 text-left leading-tight">Jenis Transaksi</span>
+                  </button>
+                  <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[280px]">
+                    <div class="flex flex-col gap-3">
+                      <label class="flex items-center gap-2">
+                        <input type="checkbox" value="Masuk">
+                        <span>Masuk</span>
+                      </label>
+                      <label class="flex items-center gap-2">
+                        <input type="checkbox" value="Keluar">
+                        <span>Keluar</span>
+                      </label>
+                    </div>
+                    <div class="flex justify-end gap-2 mt-4">
+                      <button class="cancel px-3 py-2 rounded-lg border text-slate-600 w-1/2">Batalkan</button>
+                      <button class="apply px-3 py-2 rounded-lg bg-cyan-600 text-white disabled:opacity-50 w-1/2" disabled>Terapkan</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="flex-1 overflow-y-auto" id="mutasiDrawerContent">
           <div id="mutasiLoading" class="h-full flex items-center justify-center">
             <div class="flex flex-col items-center gap-3 text-slate-500">
               <span class="w-10 h-10 border-4 border-cyan-200 border-t-cyan-600 rounded-full animate-spin"></span>


### PR DESCRIPTION
## Summary
- make the e-Statement tab the default drawer view with new dropdown controls for tahun and bulan
- enable the Unduh e-Statement action only when selections are complete and surface a confirmation alert with user email and brand name
- keep the existing mutasi filters within a separate tab so the drawer layout persists

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb4810e5083308b5684b76d20be55