### PR TITLE
Add confirmation bottom sheet for new account flow

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -270,6 +270,84 @@
     </div>
   </div>
 
+  <div id="addAccountConfirmOverlay" class="hidden fixed inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40"></div>
+  <div id="addAccountConfirmSheet" class="fixed inset-x-0 bottom-0 z-50 max-h-[90vh] bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col">
+    <div class="sticky top-0 px-4 pt-6 pb-4 text-center border-b border-slate-200 bg-white rounded-t-3xl">
+      <h3 class="text-base font-semibold">Konfirmasi Tambah Rekening</h3>
+    </div>
+    <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
+      <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+        <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi" />
+        <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
+      </div>
+
+      <section class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button type="button" id="addAccountConfirmGiroToggle" class="flex w-full items-center justify-between gap-3 px-4 py-4 text-left" aria-expanded="false">
+          <span class="text-sm font-semibold text-slate-900">Spesifikasi GIRO</span>
+          <svg data-chevron class="h-5 w-5 text-slate-500 transition-transform duration-200" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="m6 9 6 6 6-6"></path>
+          </svg>
+        </button>
+        <div id="addAccountConfirmGiroContent" class="hidden border-t border-slate-200" aria-hidden="true">
+          <dl class="divide-y divide-slate-200 px-4">
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Setoran Awal</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp1.000.000,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Saldo Minimum Mengendap</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp1.000.000,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Admin Bulanan</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp30.000,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Setoran Kliring</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp2.000,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Admin Bulanan di Rekening Pasif</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp500,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Admin Bulanan di Rekening di bawah Saldo Minimum</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp1.000,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Admin 3 Bulan di bawah Saldo Minimum</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp500,-</dd>
+            </div>
+            <div class="flex items-start justify-between gap-6 py-4">
+              <dt class="text-sm text-slate-500">Biaya Penutupan Rekening</dt>
+              <dd class="text-sm font-semibold text-slate-900">Rp55.000,-</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="space-y-4">
+        <p class="font-semibold text-slate-500 uppercase tracking-[.18em] bg-slate-100 p-2">Detail Rekening</p>
+        <div class="space-y-4">
+          <div class="flex items-start justify-between gap-6">
+            <span class="text-sm text-slate-500">Nama Rekening</span>
+            <span id="addAccountConfirmName" class="text-sm font-semibold text-slate-900 text-right max-w-[60%] break-words">-</span>
+          </div>
+          <div class="flex items-start justify-between gap-6">
+            <span class="text-sm text-slate-500">Tujuan Penambahan Rekening</span>
+            <span id="addAccountConfirmPurpose" class="text-sm font-semibold text-slate-900 text-right max-w-[60%] break-words">-</span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div class="sticky bottom-0 border-t border-slate-200 bg-white px-4 py-4">
+      <div class="flex items-center gap-3">
+        <button type="button" id="addAccountConfirmCancel" class="flex-1 rounded-xl border border-slate-300 py-3 font-semibold text-slate-700 hover:bg-slate-50 transition">Batalkan</button>
+        <button type="button" id="addAccountConfirmSubmit" class="flex-1 rounded-xl bg-cyan-600 py-3 font-semibold text-white transition hover:bg-cyan-700 disabled:opacity-50 disabled:cursor-not-allowed">Lanjut Tambah Rekening</button>
+      </div>
+    </div>
+  </div>
+
   <script src="data/rekening-data.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>


### PR DESCRIPTION
## Summary
- add a confirmation bottom sheet in informasi-rekening.html with overlay, accordion, and detail summary for the Tambah Rekening flow
- wire the drawer form submission to open the bottom sheet and handle the final confirmation inside informasi-rekening.js
- manage bottom sheet interactions including accordion toggle, overlay dismissal, escape handling, and payload submission back to the existing addAccount logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d008fe7e28833088c8634d360196df