### PR TITLE
Add OTP verification to add account confirmation

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -337,6 +337,29 @@
                 </div>
               </div>
             </section>
+            <div id="addAccountOtpSection" class="hidden border-t border-slate-200 pt-6 space-y-4">
+              <h4 class="text-lg font-semibold text-slate-900">Masukkan kode verifikasi</h4>
+              <div class="grid grid-cols-8 gap-2">
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              </div>
+              <p class="text-sm text-slate-500 text-center">
+                Silakan login &amp; cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi.
+              </p>
+              <p id="addAccountOtpCountdown" class="text-sm text-slate-500 text-center">
+                <span id="addAccountOtpCountdownMessage">Sesi akan berakhir dalam</span>
+                <span id="addAccountOtpTimer" class="text-cyan-500 font-semibold">00:30</span>
+              </p>
+              <button id="addAccountOtpResend" type="button" class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50">
+                Kirim Ulang Kode Verifikasi
+              </button>
+            </div>
           </div>
           <div class="sticky bottom-0 border-t border-slate-200 bg-white px-4 py-4">
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add an OTP verification section to the add-account confirmation sheet
- implement OTP timer, resend, and input handling mirroring the transfer flow
- gate the final account creation behind OTP completion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0286a1608833087523be5a04c5aa6