### PR TITLE
Move pending approval pane into drawer

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -165,7 +165,9 @@
     <!-- ============ /MAIN ============ -->
 
     <!-- ============ DRAWER ============ -->
-    <div id="drawer" class="h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100 relative">
+  
+  <div id="drawer" class="h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100 relative">
+    <div id="addAccountPane" class="h-full flex flex-col relative" aria-hidden="false">
       <div class="sticky top-0 z-20 flex items-center justify-between p-4 border-b border-slate-200 bg-white">
         <h2 class="text-lg font-semibold text-slate-900">Tambah Rekening</h2>
         <button type="button" id="drawerCloseBtn" class="p-2 text-slate-500 hover:text-slate-700" aria-label="Tutup drawer">
@@ -370,19 +372,14 @@
         </div>
       </div>
     </div>
-  </div>
 
-  <div
-    id="pendingApprovalPane"
-    class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4 py-6"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="pendingApprovalTitle"
-    aria-hidden="true"
-  >
     <div
-      data-pending-dialog
-      class="relative flex w-full max-w-lg max-h-full flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
+      id="pendingApprovalPane"
+      class="hidden h-full flex flex-col bg-white"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pendingApprovalTitle"
+      aria-hidden="true"
     >
       <div class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
         <h2 id="pendingApprovalTitle" class="text-lg font-semibold text-slate-900">Detail Persetujuan</h2>
@@ -495,7 +492,6 @@
       </div>
     </div>
   </div>
-
   <script src="data/rekening-data.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -14,6 +14,7 @@
   let accountGridNode = null;
   let emptyStateNode = null;
   let drawerNode = null;
+  let addAccountPaneNode = null;
   let formNode = null;
   let giroAccordionButton = null;
   let giroAccordionContent = null;
@@ -606,10 +607,17 @@
     setPendingSpecExpanded(false);
     pendingPaneLastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
+    if (addAccountPaneNode) {
+      addAccountPaneNode.classList.add('hidden');
+      addAccountPaneNode.setAttribute('aria-hidden', 'true');
+    }
     pendingPaneNode.classList.remove('hidden');
     pendingPaneNode.setAttribute('aria-hidden', 'false');
-    if (document.body) {
-      document.body.classList.add('overflow-hidden');
+    if (drawerNode && !drawerNode.classList.contains('open')) {
+      drawerNode.classList.add('open');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
     }
 
     const focusTarget = pendingPaneNode.querySelector('[data-pending-focus]');
@@ -628,8 +636,15 @@
     }
     pendingPaneNode.classList.add('hidden');
     pendingPaneNode.setAttribute('aria-hidden', 'true');
-    if (document.body) {
-      document.body.classList.remove('overflow-hidden');
+    if (addAccountPaneNode) {
+      addAccountPaneNode.classList.remove('hidden');
+      addAccountPaneNode.setAttribute('aria-hidden', 'false');
+    }
+    if (drawerNode) {
+      drawerNode.classList.remove('open');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
     }
     if (pendingPaneLastFocusedElement && typeof pendingPaneLastFocusedElement.focus === 'function') {
       try {
@@ -676,7 +691,7 @@
         renderAccounts();
         showToast('Rekening baru berhasil dibuat');
         closeConfirmSheet({ resetPending: true });
-        closeDrawer();
+        resetFormState();
         openPendingApprovalPane({ account: newAccount, payload: confirmationSnapshot });
       })
       .catch(() => {
@@ -1130,6 +1145,14 @@
     if (!drawerNode.classList.contains('open')) {
       resetFormState();
     }
+    if (addAccountPaneNode) {
+      addAccountPaneNode.classList.remove('hidden');
+      addAccountPaneNode.setAttribute('aria-hidden', 'false');
+    }
+    if (pendingPaneNode) {
+      pendingPaneNode.classList.add('hidden');
+      pendingPaneNode.setAttribute('aria-hidden', 'true');
+    }
     drawerNode.classList.add('open');
     if (typeof window.sidebarCollapseForDrawer === 'function') {
       window.sidebarCollapseForDrawer();
@@ -1148,6 +1171,14 @@
 
   function closeDrawer() {
     if (!drawerNode) return;
+    if (addAccountPaneNode) {
+      addAccountPaneNode.classList.remove('hidden');
+      addAccountPaneNode.setAttribute('aria-hidden', 'false');
+    }
+    if (pendingPaneNode) {
+      pendingPaneNode.classList.add('hidden');
+      pendingPaneNode.setAttribute('aria-hidden', 'true');
+    }
     drawerNode.classList.remove('open');
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
@@ -1179,6 +1210,7 @@
     accountGridNode = document.getElementById('accountGrid');
     emptyStateNode = document.getElementById('accountEmptyState');
     drawerNode = document.getElementById('drawer');
+    addAccountPaneNode = document.getElementById('addAccountPane');
     formNode = document.getElementById('addAccountForm');
     giroAccordionButton = document.getElementById('giroSpecToggle');
     giroAccordionContent = document.getElementById('giroSpecContent');
@@ -1286,14 +1318,6 @@
         btn.addEventListener('click', () => {
           closePendingApprovalPane();
         });
-      });
-    }
-
-    if (pendingPaneNode) {
-      pendingPaneNode.addEventListener('click', (event) => {
-        if (event.target === pendingPaneNode) {
-          closePendingApprovalPane();
-        }
       });
     }
 


### PR DESCRIPTION
## Summary
- embed the pending approval view directly inside the informasi rekening drawer alongside the add-account pane
- adjust drawer and pending-pane logic to toggle visibility, manage focus, and keep the sidebar state in sync
- reset the add-account form after confirmation while opening the drawer-based pending view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0f0cda6308330a5f92fa45acfec0c