### PR TITLE
Update OTP verification flow for pending approval

### DIFF
--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -688,11 +688,14 @@
 
     addAccount(pendingConfirmationPayload)
       .then((newAccount) => {
-        renderAccounts();
-        showToast('Rekening baru berhasil dibuat');
+        const pendingDetails = {
+          account: newAccount,
+          payload: confirmationSnapshot,
+        };
+
         closeConfirmSheet({ resetPending: true });
-        resetFormState();
-        openPendingApprovalPane({ account: newAccount, payload: confirmationSnapshot });
+        closeDrawer();
+        openPendingApprovalPane(pendingDetails);
       })
       .catch(() => {
         showToast('Gagal menambahkan rekening. Silakan coba lagi.', { variant: 'error' });


### PR DESCRIPTION
## Summary
- stop rendering the account grid and success toast after OTP confirmation
- close the drawer before showing the pending approval pane for successful submissions

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d0ff0603788330b2e5dd61ae2d2825