### PR TITLE
Use bullet placeholder when balances are hidden

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const balanceToggleBtn = document.getElementById('dashBalanceToggle');
 const balanceToggleLabel = balanceToggleBtn?.querySelector('[data-balance-toggle-label]');
 const balanceSensitiveEls = Array.from(document.querySelectorAll('[data-balance-sensitive]'));
 
+const MASKED_BALANCE_TEXT = '••••';
+
 const ambis = window.AMBIS || {};
 const sharedAccounts = typeof ambis.getAccounts === 'function'
   ? ambis.getAccounts({ clone: false })
@@ -107,15 +109,8 @@ function formatCurrency(num) {
   }).format(safeValue);
 }
 
-function maskCurrencyText(text) {
-  if (!text) {
-    return '••••••';
-  }
-  const match = text.match(/^(\s*Rp\s*)/i);
-  const prefix = match ? match[0] : '';
-  const rest = match ? text.slice(prefix.length) : text;
-  const maskedRest = rest.replace(/\S/g, '•');
-  return `${prefix}${maskedRest || '••••'}`;
+function maskCurrencyText() {
+  return MASKED_BALANCE_TEXT;
 }
 
 function setBalanceValue(el, value) {

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -1,5 +1,6 @@
 (function () {
   const balanceElements = new Set();
+  const MASKED_BALANCE_TEXT = '••••';
   let isMasked = false;
   let toastEl = null;
   let toastInnerNode = null;
@@ -155,17 +156,8 @@
     return String(value).replace(/\D+/g, '');
   }
 
-  function maskCurrencyText(text) {
-    if (!text) {
-      return '********';
-    }
-    const str = String(text);
-    const match = str.match(/^(\s*Rp\s*)/i);
-    const prefix = match ? match[0] : '';
-    const rest = match ? str.slice(prefix.length) : str;
-    const core = rest.replace(/\s+/g, '');
-    const starCount = Math.max(core.length, 8);
-    return `${prefix}${'*'.repeat(starCount)}`;
+  function maskCurrencyText() {
+    return MASKED_BALANCE_TEXT;
   }
 
   function registerBalanceElement(el, value) {


### PR DESCRIPTION
## Summary
- ensure dashboard balances render a four-bullet placeholder whenever values are hidden
- update the informasi rekening mask helper to reuse the same bullet placeholder text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d10431157c83308a99167a5d29a581