### PR TITLE
Adjust balance formatting and masking

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -138,7 +138,7 @@
           <div class="flex-1 min-w-[220px]">
             <h2 class="text-2xl font-semibold text-slate-900">Total Saldo Aktif</h2>
             <p class="mt-1 text-sm text-slate-500">dari semua rekening</p>
-            <p id="totalBalanceValue" data-total-balance class="mt-3 text-3xl font-bold text-slate-900 tracking-tight">Rp0,00</p>
+            <p id="totalBalanceValue" data-total-balance class="mt-3 text-3xl font-bold text-slate-900 tracking-tight">Rp0</p>
           </div>
           <div class="flex flex-col items-end gap-2 py-4 pr-4">
             <button

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -88,8 +88,8 @@
   const CURRENCY_FORMATTER = new Intl.NumberFormat('id-ID', {
     style: 'currency',
     currency: 'IDR',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
   });
 
   const TOAST_BASE_INNER_CLASSES = 'pointer-events-auto flex items-center gap-3 rounded-2xl px-4 py-3 shadow-lg text-sm';
@@ -146,9 +146,9 @@
       value = Number.isFinite(parsed) ? parsed : 0;
     }
     if (!Number.isFinite(value)) {
-      return CURRENCY_FORMATTER.format(0);
+      return CURRENCY_FORMATTER.format(0).replace(/\s+/g, '');
     }
-    return CURRENCY_FORMATTER.format(value);
+    return CURRENCY_FORMATTER.format(value).replace(/\s+/g, '');
   }
 
   function sanitizeNumber(value) {
@@ -156,8 +156,19 @@
     return String(value).replace(/\D+/g, '');
   }
 
-  function maskCurrencyText() {
-    return MASKED_BALANCE_TEXT;
+  function maskCurrencyText(originalValue) {
+    const text = typeof originalValue === 'string' ? originalValue : '';
+    if (text) {
+      const prefixMatch = text.match(/^([^\d-]+)/);
+      if (prefixMatch && prefixMatch[0].trim()) {
+        return `${prefixMatch[0].replace(/\s+/g, '')}${MASKED_BALANCE_TEXT}`;
+      }
+      const trimmed = text.trim();
+      if (trimmed.toUpperCase().startsWith('RP')) {
+        return `Rp${MASKED_BALANCE_TEXT}`;
+      }
+    }
+    return `Rp${MASKED_BALANCE_TEXT}`;
   }
 
   function registerBalanceElement(el, value) {


### PR DESCRIPTION
## Summary
- display account balances without fractional digits while keeping the "Rp" prefix tight to the amount
- ensure masked balances retain the currency prefix so hidden values appear as Rp••••
- update the initial total balance placeholder to match the new currency format

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d106b679c8833088519e78ddbf8ced