### PR TITLE
Ensure masked balances retain currency prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,8 +109,19 @@ function formatCurrency(num) {
   }).format(safeValue);
 }
 
-function maskCurrencyText() {
-  return MASKED_BALANCE_TEXT;
+function maskCurrencyText(originalValue) {
+  const text = typeof originalValue === 'string' ? originalValue : '';
+  if (text) {
+    const prefixMatch = text.match(/^([^\d-]+)/);
+    if (prefixMatch && prefixMatch[0].trim()) {
+      return `${prefixMatch[0].replace(/\s+/g, '')}${MASKED_BALANCE_TEXT}`;
+    }
+    const trimmed = text.trim();
+    if (trimmed.toUpperCase().startsWith('RP')) {
+      return `Rp${MASKED_BALANCE_TEXT}`;
+    }
+  }
+  return `Rp${MASKED_BALANCE_TEXT}`;
 }
 
 function setBalanceValue(el, value) {


### PR DESCRIPTION
## Summary
- preserve the "Rp" currency prefix when masking balance values on the dashboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d10984c58483309fb7151ed5534098