### PR TITLE
Add transfer popover and embedded transfer drawer from account info

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -503,6 +503,75 @@
       </div>
     </div>
   </div>
+
+  <div
+    id="transferPopover"
+    class="hidden fixed inset-0 z-40"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="transferPopoverTitle"
+  >
+    <div class="absolute inset-0 bg-slate-900/10" data-transfer-popover-dismiss></div>
+    <div
+      id="transferPopoverPanel"
+      class="absolute w-[320px] max-w-[calc(100vw-32px)] rounded-2xl border border-slate-200 bg-white shadow-2xl overflow-hidden"
+    >
+      <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200">
+        <h3 id="transferPopoverTitle" class="text-base font-semibold text-slate-900">Transfer</h3>
+        <button
+          type="button"
+          id="transferPopoverClose"
+          class="text-slate-400 transition hover:text-slate-600"
+          aria-label="Tutup"
+        >&times;</button>
+      </div>
+      <div class="divide-y divide-slate-200">
+        <button
+          type="button"
+          class="w-full flex items-start gap-3 px-4 py-4 text-left transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+          data-transfer-option="transfer"
+        >
+          <span class="mt-0.5 text-xl text-cyan-600" aria-hidden="true">↔</span>
+          <span class="flex-1 min-w-0">
+            <span class="block text-sm font-semibold text-cyan-600">Transfer Saldo</span>
+            <span class="mt-1 block text-xs text-slate-500 leading-snug">ke rekening bank lainnya ataupun sesama Amar Bank</span>
+          </span>
+        </button>
+        <button
+          type="button"
+          class="w-full flex items-start gap-3 px-4 py-4 text-left transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+          data-transfer-option="move"
+        >
+          <span class="mt-0.5 text-xl text-cyan-600" aria-hidden="true">⇅</span>
+          <span class="flex-1 min-w-0">
+            <span class="block text-sm font-semibold text-cyan-600">Pemindahan Saldo</span>
+            <span class="mt-1 block text-xs text-slate-500 leading-snug">Antar rekening GIRO Anda yang didaftarkan di Amar Bank Bisnis</span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="embeddedTransferDrawer" class="hidden fixed inset-0 z-40">
+    <div
+      class="absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-300"
+      data-transfer-drawer-overlay
+    ></div>
+    <div class="absolute inset-x-0 bottom-0 h-full pointer-events-none flex flex-col justify-end">
+      <div
+        id="embeddedTransferSheet"
+        class="pointer-events-auto h-full w-full max-h-full transform translate-y-full transition-transform duration-300"
+      >
+        <iframe
+          id="embeddedTransferFrame"
+          title="Transfer"
+          class="w-full h-full border-0 rounded-t-3xl shadow-2xl bg-white"
+          allow="clipboard-write"
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
   <script src="data/rekening-data.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -209,3 +209,31 @@ html, body{
   border-color:#f3f4f6;
   color:#1f2937;
 }
+
+.transfer-embedded,
+.transfer-embedded body{
+  height:100%;
+}
+
+.transfer-embedded body{
+  overflow:hidden;
+}
+
+.transfer-embedded body > .h-screen{
+  overflow:visible;
+}
+
+.transfer-embedded #sidebar,
+.transfer-embedded main{
+  display:none !important;
+}
+
+.transfer-embedded #drawer{
+  width:100% !important;
+  border-left-width:0 !important;
+  box-shadow:none;
+}
+
+.transfer-embedded #drawer.open{
+  width:100% !important;
+}

--- a/transfer.html
+++ b/transfer.html
@@ -25,6 +25,22 @@
       ]
     };
   </script>
+  <script>
+    (function () {
+      try {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('embedded') === '1') {
+          document.documentElement.classList.add('transfer-embedded');
+          const pane = params.get('pane');
+          if (pane) {
+            document.documentElement.dataset.transferInitialPane = pane;
+          }
+        }
+      } catch (err) {
+        // ignore URL parsing errors
+      }
+    })();
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 

--- a/transfer.js
+++ b/transfer.js
@@ -8,6 +8,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const successPane = document.getElementById('successPane');
   const closeBtn = document.getElementById('drawerCloseBtn');
   const cardGrid = document.getElementById('cardGrid');
+  const searchParams = new URLSearchParams(window.location.search);
+  const isEmbedded = document.documentElement.classList.contains('transfer-embedded');
+  const initialPaneParam = (document.documentElement.dataset.transferInitialPane || searchParams.get('pane') || '').toLowerCase();
+  const embeddedInitialPane = initialPaneParam === 'move' ? 'move' : 'transfer';
 
   function updateCardGridLayout() {
     // Maintain a consistent card layout regardless of drawer state so cards
@@ -973,6 +977,13 @@ document.addEventListener('DOMContentLoaded', () => {
       window.sidebarRestoreForDrawer();
     }
     clearActiveActivityCard();
+    if (isEmbedded && window.parent && window.parent !== window) {
+      try {
+        window.parent.postMessage({ type: 'ambis-transfer-close' }, '*');
+      } catch (err) {
+        // ignore messaging errors
+      }
+    }
   }
 
   function openMoveDrawerPanel() {
@@ -1022,6 +1033,14 @@ document.addEventListener('DOMContentLoaded', () => {
     openMoveDrawerPanel();
   });
   moveCloseBtn?.addEventListener('click', closeDrawer);
+
+  if (isEmbedded) {
+    if (embeddedInitialPane === 'move') {
+      openMoveDrawerPanel();
+    } else {
+      openDrawer();
+    }
+  }
 
   // helpers
   const dailyLimit = 200000000;


### PR DESCRIPTION
## Summary
- add a popover on informasi-rekening to choose between Transfer Saldo and Pemindahan Saldo
- open the selected flow inside an embedded drawer that loads transfer.html in drawer-only mode
- update transfer assets to support an embedded drawer-only experience and notify the parent when closed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d110820c308330a02f1fadc14eaa47