### PR TITLE
Route transfer options through account drawer

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -182,7 +182,7 @@
     <div id="addAccountPane" class="h-full flex flex-col relative" aria-hidden="false">
       <div class="sticky top-0 z-20 flex items-center justify-between p-4 border-b border-slate-200 bg-white">
         <h2 class="text-lg font-semibold text-slate-900">Tambah Rekening</h2>
-        <button type="button" id="drawerCloseBtn" class="p-2 text-slate-500 hover:text-slate-700" aria-label="Tutup drawer">
+        <button type="button" id="drawerCloseBtn" data-drawer-close class="p-2 text-slate-500 hover:text-slate-700" aria-label="Tutup drawer">
           &times;
         </button>
       </div>
@@ -502,19 +502,46 @@
         </button>
       </div>
     </div>
+    <div
+      id="transferPane"
+      class="hidden h-full flex flex-col bg-white"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="transferPaneTitle"
+      aria-hidden="true"
+    >
+      <div class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+        <h2 id="transferPaneTitle" class="text-lg font-semibold text-slate-900">Transfer Saldo</h2>
+        <button
+          type="button"
+          class="text-2xl leading-none text-slate-500 transition hover:text-slate-700"
+          aria-label="Tutup"
+          data-drawer-close
+          data-transfer-focus
+        >&times;</button>
+      </div>
+      <div class="flex-1 min-h-0">
+        <iframe
+          id="transferPaneFrame"
+          title="Transfer"
+          class="w-full h-full border-0"
+          allow="clipboard-write"
+          tabindex="-1"
+        ></iframe>
+      </div>
+    </div>
   </div>
 
   <div
     id="transferPopover"
-    class="hidden fixed inset-0 z-40"
+    class="hidden fixed inset-0 z-40 pointer-events-none"
     role="dialog"
     aria-modal="true"
     aria-labelledby="transferPopoverTitle"
   >
-    <div class="absolute inset-0 bg-slate-900/10" data-transfer-popover-dismiss></div>
     <div
       id="transferPopoverPanel"
-      class="absolute w-[320px] max-w-[calc(100vw-32px)] rounded-2xl border border-slate-200 bg-white shadow-2xl overflow-hidden"
+      class="absolute w-[320px] max-w-[calc(100vw-32px)] rounded-2xl border border-slate-200 bg-white shadow-2xl overflow-hidden pointer-events-auto"
     >
       <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200">
         <h3 id="transferPopoverTitle" class="text-base font-semibold text-slate-900">Transfer</h3>
@@ -548,26 +575,6 @@
             <span class="mt-1 block text-xs text-slate-500 leading-snug">Antar rekening GIRO Anda yang didaftarkan di Amar Bank Bisnis</span>
           </span>
         </button>
-      </div>
-    </div>
-  </div>
-
-  <div id="embeddedTransferDrawer" class="hidden fixed inset-0 z-40">
-    <div
-      class="absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-300"
-      data-transfer-drawer-overlay
-    ></div>
-    <div class="absolute inset-x-0 bottom-0 h-full pointer-events-none flex flex-col justify-end">
-      <div
-        id="embeddedTransferSheet"
-        class="pointer-events-auto h-full w-full max-h-full transform translate-y-full transition-transform duration-300"
-      >
-        <iframe
-          id="embeddedTransferFrame"
-          title="Transfer"
-          class="w-full h-full border-0 rounded-t-3xl shadow-2xl bg-white"
-          allow="clipboard-write"
-        ></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a dedicated transfer pane inside the shared drawer and reuse it for transfer and move flows
- remove the transfer popover overlay and close the menu via outside-click logic
- refactor drawer management logic to switch between add-account, pending approval, and transfer panes while handling embedded iframe messaging

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68d115a47cc883309a3980adf666411b