### PR TITLE
Integrate mutasi drawer logic into account information

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -31,6 +31,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <!-- Global styles -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body class="font-[Mulish] bg-gray-50 text-slate-900">
@@ -915,7 +916,12 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/id.js"></script>
+  <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
+  <script src="data/mutasi-data.js"></script>
+  <script src="mutasi.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -1444,28 +1444,31 @@
     if (!account || typeof account !== 'object') {
       return MUTASI_DRAWER_DEFAULT_TITLE;
     }
-    const labelParts = [];
     if (typeof account.name === 'string' && account.name.trim()) {
-      labelParts.push(account.name.trim());
-    } else if (typeof account.displayName === 'string' && account.displayName.trim()) {
-      labelParts.push(account.displayName.trim());
+      return account.name.trim();
     }
-    if (typeof account.number === 'string' && account.number.trim()) {
-      labelParts.push(account.number.trim());
+    if (typeof account.displayName === 'string' && account.displayName.trim()) {
+      return account.displayName.trim();
     }
-    if (!labelParts.length && typeof account.company === 'string' && account.company.trim()) {
-      labelParts.push(account.company.trim());
+    if (typeof account.company === 'string' && account.company.trim()) {
+      return account.company.trim();
     }
-    if (!labelParts.length) {
-      return MUTASI_DRAWER_DEFAULT_TITLE;
+    if (typeof account.brandName === 'string' && account.brandName.trim()) {
+      return account.brandName.trim();
     }
-    return `${MUTASI_DRAWER_DEFAULT_TITLE} — ${labelParts.join(' - ')}`;
+    return MUTASI_DRAWER_DEFAULT_TITLE;
   }
 
   function openMutasiPane(account) {
     const title = getMutasiDrawerTitle(account);
     if (mutasiDrawerTitleNode) {
       mutasiDrawerTitleNode.textContent = title;
+    }
+    if (window.AMBIS_MUTASI && typeof window.AMBIS_MUTASI.prepareAccount === 'function') {
+      window.AMBIS_MUTASI.prepareAccount(account, {
+        updateTitle: false,
+        updateAccountLabel: false,
+      });
     }
     showDrawerPane('mutasi');
     ensureDrawerOpen();
@@ -1516,6 +1519,9 @@
   }
 
   function closeMutasiPane({ restoreFocus = true } = {}) {
+    if (window.AMBIS_MUTASI && typeof window.AMBIS_MUTASI.closeDetailSheet === 'function') {
+      window.AMBIS_MUTASI.closeDetailSheet(true);
+    }
     closeDrawer({ restoreFocus });
   }
 


### PR DESCRIPTION
## Summary
- load the same mutasi resources on the account information page so its drawer reuses the shared data and UI logic
- update the account information drawer handler to show only the account name and trigger the shared mutasi renderer
- extend the mutasi module to expose a reusable API for embedded drawers without affecting the standalone page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d131f809888330b85ce10590af2335