### PR TITLE
Add custom month-year picker modal for date filters

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,167 @@ html, body{
   color:#1f2937;
 }
 
+.month-year-picker-overlay{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:rgba(15,23,42,0.35);
+  z-index:60;
+}
+
+.month-year-picker-modal{
+  width:320px;
+  max-width:calc(100vw - 32px);
+  background:#ffffff;
+  border-radius:20px;
+  box-shadow:0 20px 45px rgba(15,23,42,0.12);
+  padding:24px;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
+}
+
+.month-year-picker-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.month-year-picker-nav{
+  width:36px;
+  height:36px;
+  border-radius:9999px;
+  border:1px solid #cbd5f5;
+  background:#ffffff;
+  color:#0f172a;
+  font-weight:600;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  transition:background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.month-year-picker-nav:hover{
+  background:#f1f5f9;
+  border-color:#94a3b8;
+}
+
+.month-year-picker-title{
+  flex:1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:16px;
+  font-weight:600;
+  color:#0f172a;
+  gap:4px;
+}
+
+.month-year-picker-title-part{
+  border:none;
+  background:transparent;
+  color:inherit;
+  font:inherit;
+  cursor:pointer;
+  padding:4px 10px;
+  border-radius:9999px;
+  transition:background-color 0.2s ease, color 0.2s ease;
+}
+
+.month-year-picker-title-part:hover{
+  background:#e2e8f0;
+}
+
+.month-year-picker-title-active{
+  background:#e0f2fe;
+  color:#0284c7;
+  font-weight:700;
+}
+
+.month-year-picker-content{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.month-year-picker-grid{
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0, 1fr));
+  gap:12px;
+}
+
+.month-year-picker-option{
+  border-radius:12px;
+  padding:10px 12px;
+  border:1px solid transparent;
+  background:transparent;
+  color:#0f172a;
+  font-size:14px;
+  font-weight:500;
+  text-align:center;
+  cursor:pointer;
+  transition:background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.month-year-picker-option:hover{
+  background:#f1f5f9;
+}
+
+.month-year-picker-option-active{
+  background:#e0f2fe;
+  border-color:#0ea5e9;
+  color:#0284c7;
+  font-weight:600;
+}
+
+.month-year-picker-footer{
+  display:flex;
+  gap:12px;
+}
+
+.month-year-picker-cancel,
+.month-year-picker-apply{
+  flex:1;
+  border-radius:12px;
+  padding:12px;
+  font-size:14px;
+  font-weight:600;
+  cursor:pointer;
+  transition:opacity 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.month-year-picker-cancel{
+  border:1px solid #0ea5e9;
+  background:#ffffff;
+  color:#0284c7;
+}
+
+.month-year-picker-cancel:hover{
+  background:#e0f2fe;
+}
+
+.month-year-picker-apply{
+  border:none;
+  background:#0284c7;
+  color:#ffffff;
+}
+
+.month-year-picker-apply:hover:enabled{
+  background:#0369a1;
+}
+
+.month-year-picker-apply:disabled{
+  opacity:0.5;
+  cursor:not-allowed;
+}
+
+body.month-year-picker-open{
+  overflow:hidden;
+}
+
 .transfer-embedded,
 .transfer-embedded body{
   height:100%;


### PR DESCRIPTION
## Summary
- add a reusable month and year picker overlay that opens from flatpickr headers
- hook custom picker into date filter flatpickr instances with static month selectors
- style the modal, grid layouts, and buttons for the new picker experience

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d13fcbc2848330a80ef42847385ffa