### PR TITLE
Embed month-year picker modal inside flatpickr calendar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -125,11 +125,34 @@ html, body{
 }
 /* Flatpickr custom datepicker styles */
 .flatpickr-calendar{
+  position:relative;
   padding:16px !important;
   border:1px solid #e2e8f0 !important;
   box-shadow:0 4px 6px rgba(0,0,0,0.05) !important;
   border-radius:16px !important;
   width:340px !important;
+}
+
+.flatpickr-calendar.month-year-picker-active .flatpickr-months,
+.flatpickr-calendar.month-year-picker-active .flatpickr-innerContainer,
+.flatpickr-calendar.month-year-picker-active .flatpickr-time{
+  visibility:hidden;
+  pointer-events:none;
+}
+
+.flatpickr-calendar .month-year-picker-overlay{
+  position:absolute;
+  inset:0;
+  display:none;
+  align-items:center;
+  justify-content:center;
+  background:#ffffff;
+  border-radius:inherit;
+  z-index:60;
+}
+
+.flatpickr-calendar.month-year-picker-active .month-year-picker-overlay{
+  display:flex;
 }
 
 .flatpickr-months{
@@ -211,18 +234,19 @@ html, body{
 }
 
 .month-year-picker-overlay{
-  position:fixed;
+  position:absolute;
   inset:0;
   display:flex;
   align-items:center;
   justify-content:center;
-  background:rgba(15,23,42,0.35);
+  background:#ffffff;
+  border-radius:inherit;
   z-index:60;
 }
 
 .month-year-picker-modal{
-  width:320px;
-  max-width:calc(100vw - 32px);
+  width:100%;
+  max-width:320px;
   background:#ffffff;
   border-radius:20px;
   box-shadow:0 20px 45px rgba(15,23,42,0.12);
@@ -365,10 +389,6 @@ html, body{
 .month-year-picker-apply:disabled{
   opacity:0.5;
   cursor:not-allowed;
-}
-
-body.month-year-picker-open{
-  overflow:hidden;
 }
 
 .transfer-embedded,


### PR DESCRIPTION
## Summary
- mount the month-year picker markup inside each flatpickr calendar container and toggle it with a calendar-level active class
- update the month/year trigger binding to listen on the entire flatpickr month header and keep the year input read-only
- refresh supporting styles so the modal replaces the calendar content when active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d15c085ed8833085052c48c5836c15