### PR TITLE
Ensure datepicker opens on input focus

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -476,6 +476,25 @@
           onChange: updateButtons
         });
         inp.addEventListener('input', updateButtons);
+
+        const openCalendar = () => {
+          const instance = inp._flatpickr;
+          if (instance && !instance.isOpen) {
+            instance.open();
+          }
+        };
+
+        inp.addEventListener('focus', openCalendar);
+        inp.addEventListener('click', (event) => {
+          event.preventDefault();
+          openCalendar();
+        });
+        inp.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            openCalendar();
+          }
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure custom range date inputs open their flatpickr calendar when focused or clicked
- keep the existing filter behaviour intact while making the picker easier to reach

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1615068208330abd64dc4a77f1224