### PR TITLE
Use separate date pickers for custom mutasi range

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -218,15 +218,27 @@
                         <span>Custom Rentang Tanggal</span>
                       </label>
                       <div class="custom-range hidden">
-                        <div class="flex flex-col">
-                          <span class="mb-1 text-sm">Rentang Tanggal</span>
-                          <input
-                            type="text"
-                            class="h-10 border border-slate-300 rounded-lg text-center"
-                            placeholder="DD/MM/YYYY – DD/MM/YYYY"
-                            data-date-range
-                            readonly
-                          />
+                        <div class="flex flex-col gap-3">
+                          <div class="flex flex-col">
+                            <span class="mb-1 text-sm">Tanggal Awal</span>
+                            <input
+                              type="text"
+                              class="h-10 border border-slate-300 rounded-lg text-center"
+                              placeholder="Pilih tanggal"
+                              data-date-start
+                              readonly
+                            />
+                          </div>
+                          <div class="flex flex-col">
+                            <span class="mb-1 text-sm">Tanggal Akhir</span>
+                            <input
+                              type="text"
+                              class="h-10 border border-slate-300 rounded-lg text-center"
+                              placeholder="Pilih tanggal"
+                              data-date-end
+                              readonly
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace the custom rentang tanggal field with separate start and end inputs inside the mutasi filter drawer
- update the shared filter script to manage two single-date Air Datepicker instances and keep their state in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d23c07d3d48330bb23d7906c3b9b91