### PR TITLE
Highlight active date range options

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -151,3 +151,21 @@ html, body{
 .transfer-embedded #drawer.open{
   width:100% !important;
 }
+
+/* Date filter option highlighting */
+.filter-panel label.filter-date-option{
+  padding:8px 12px;
+  border-radius:12px;
+  transition:background-color .2s ease, color .2s ease;
+}
+.filter-panel label.filter-date-option-active{
+  background-color:#E6F5F7;
+  color:#0E7490;
+  font-weight:600;
+}
+.filter-panel label.filter-date-option-active span{
+  color:inherit;
+}
+.filter-panel label.filter-date-option-active input[type="radio"]{
+  accent-color:#0E7490;
+}


### PR DESCRIPTION
## Summary
- add shared helpers to manage highlighting and default selection for date range filter options
- auto-select the custom range when dates are picked and keep the active preset highlighted on changes
- style date filter option labels so the active selection is visually distinct

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d246f5e14c8330b68dc12679a94521