### PR TITLE
Update date filter label behavior

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -104,31 +104,15 @@
     return `${year}-${month}-${day}`;
   }
 
-  function getPresetDateRange(value) {
-    const today = new Date();
-    const end = new Date(today.getTime());
-    let start = null;
-
-    if (value === '7 Hari Terakhir') {
-      start = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-    } else if (value === '30 Hari Terakhir') {
-      start = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 30);
-    } else if (value === '1 Tahun Terakhir') {
-      start = new Date(today.getFullYear() - 1, today.getMonth(), today.getDate());
-    }
-
-    if (!start) return null;
-    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
-    return { start, end };
-  }
-
   function getPresetDateLabel(value) {
-    const range = getPresetDateRange(value);
-    if (!range) return '';
-    const startText = formatDateLabel(range.start);
-    const endText = formatDateLabel(range.end);
-    if (!startText || !endText) return '';
-    return `${startText} – ${endText}`;
+    switch (value) {
+      case '7 Hari Terakhir':
+      case '30 Hari Terakhir':
+      case '1 Tahun Terakhir':
+        return value;
+      default:
+        return '';
+    }
   }
 
   const allFilters = document.querySelectorAll('.filter');
@@ -520,9 +504,7 @@
         const startISO = formatISODate(start);
         const endISO = formatISODate(end);
         filter.dataset.applied = `custom:${startISO}|${endISO}`;
-        const startLabel = formatDateLabel(start);
-        const endLabel = formatDateLabel(end);
-        labelSpan.textContent = `${startLabel} – ${endLabel}`;
+        labelSpan.textContent = 'Custom';
         setTriggerState(true);
       } else {
         filter.dataset.applied = selected.join(',');

--- a/mutasi.html
+++ b/mutasi.html
@@ -194,10 +194,10 @@
 
             <div class="px-4 pb-4" data-filter-group="mutasi">
               <div class="flex flex-wrap gap-3">
-                <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
+                <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="">
                   <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
                     <img src="img/icon/date-picker.svg" class="w-5 h-5 flex-none" alt="Rentang Tanggal" />
-                    <span class="filter-label flex-1 text-left leading-tight">Rentang Tanggal</span>
+                    <span class="filter-label flex-1 text-left leading-tight"></span>
                   </button>
                   <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
                     <div class="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- remove the default Rentang Tanggal label so the button starts blank
- show preset names or "Custom" on the Rentang Tanggal trigger when a filter is applied

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2944f874083308b02aeb42e6e7175