### PR TITLE
Ensure mutasi rentang tanggal filter has default label

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -194,10 +194,10 @@
 
             <div class="px-4 pb-4" data-filter-group="mutasi">
               <div class="flex flex-wrap gap-3">
-                <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="">
+                <div class="filter relative" data-filter="date" data-name="Rentang Tanggal" data-default="Rentang Tanggal">
                   <button class="filter-trigger h-11 px-4 rounded-xl border flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 active:bg-cyan-100 active:border-cyan-400 min-w-[200px] w-[200px] border-slate-300 bg-white text-slate-600 hover:bg-slate-50 hover:border-slate-300 text-sm font-semibold">
                     <img src="img/icon/date-picker.svg" class="w-5 h-5 flex-none" alt="Rentang Tanggal" />
-                    <span class="filter-label flex-1 text-left leading-tight"></span>
+                    <span class="filter-label flex-1 text-left leading-tight">Rentang Tanggal</span>
                   </button>
                   <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
                     <div class="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- set the rentang tanggal filter button to default to "Rentang Tanggal" so the drawer no longer opens with a blank label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29b0ca6a483309a0a65b200c359bf