### PR TITLE
Style custom date range inputs

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -565,32 +565,58 @@
                   </button>
                   <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
                     <div class="flex flex-col gap-3">
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="7 Hari Terakhir">
-                        <span>7 Hari Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="7 Hari Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">7 Hari Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="30 Hari Terakhir">
-                        <span>30 Hari Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="30 Hari Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">30 Hari Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="1 Tahun Terakhir">
-                        <span>1 Tahun Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="1 Tahun Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">1 Tahun Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="custom">
-                        <span>Custom Rentang Tanggal</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="custom" class="mt-1.5">
+                        <span class="font-medium leading-tight">Custom Rentang Tanggal</span>
                       </label>
                       <div class="custom-range hidden">
-                        <div class="flex flex-col">
-                          <span class="mb-1 text-sm">Rentang Tanggal</span>
-                          <input
-                            type="text"
-                            class="h-10 border border-slate-300 rounded-lg text-center"
-                            placeholder="DD/MM/YYYY – DD/MM/YYYY"
-                            data-date-range
-                            readonly
-                          />
+                        <div class="grid grid-cols-2 gap-3">
+                          <label class="flex flex-col gap-2">
+                            <span class="text-sm font-semibold text-slate-900">Tanggal Awal</span>
+                            <div class="relative">
+                              <img
+                                src="img/icon/date-picker.svg"
+                                alt=""
+                                class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+                              >
+                              <input
+                                type="text"
+                                class="h-11 w-full rounded-lg border border-slate-300 bg-white pl-10 pr-3 text-sm text-slate-700 placeholder-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                placeholder="DD/MM/YYYY"
+                                data-date-start
+                                readonly
+                              />
+                            </div>
+                          </label>
+                          <label class="flex flex-col gap-2">
+                            <span class="text-sm font-semibold text-slate-900">Tanggal Akhir</span>
+                            <div class="relative">
+                              <img
+                                src="img/icon/date-picker.svg"
+                                alt=""
+                                class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+                              >
+                              <input
+                                type="text"
+                                class="h-11 w-full rounded-lg border border-slate-300 bg-white pl-10 pr-3 text-sm text-slate-700 placeholder-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                placeholder="DD/MM/YYYY"
+                                data-date-end
+                                readonly
+                              />
+                            </div>
+                          </label>
                         </div>
                       </div>
                     </div>

--- a/mutasi.html
+++ b/mutasi.html
@@ -201,44 +201,58 @@
                   </button>
                   <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-[360px]">
                     <div class="flex flex-col gap-3">
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="7 Hari Terakhir">
-                        <span>7 Hari Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="7 Hari Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">7 Hari Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="30 Hari Terakhir">
-                        <span>30 Hari Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="30 Hari Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">30 Hari Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="1 Tahun Terakhir">
-                        <span>1 Tahun Terakhir</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="1 Tahun Terakhir" class="mt-1.5">
+                        <span class="font-medium leading-tight">1 Tahun Terakhir</span>
                       </label>
-                      <label class="flex items-center gap-2">
-                        <input type="radio" name="mutasi-date" value="custom">
-                        <span>Custom Rentang Tanggal</span>
+                      <label class="flex items-start gap-3 text-sm text-slate-700">
+                        <input type="radio" name="mutasi-date" value="custom" class="mt-1.5">
+                        <span class="font-medium leading-tight">Custom Rentang Tanggal</span>
                       </label>
                       <div class="custom-range hidden">
-                        <div class="flex flex-col gap-3">
-                          <div class="flex flex-col">
-                            <span class="mb-1 text-sm">Tanggal Awal</span>
-                            <input
-                              type="text"
-                              class="h-10 border border-slate-300 rounded-lg text-center"
-                              placeholder="Pilih tanggal"
-                              data-date-start
-                              readonly
-                            />
-                          </div>
-                          <div class="flex flex-col">
-                            <span class="mb-1 text-sm">Tanggal Akhir</span>
-                            <input
-                              type="text"
-                              class="h-10 border border-slate-300 rounded-lg text-center"
-                              placeholder="Pilih tanggal"
-                              data-date-end
-                              readonly
-                            />
-                          </div>
+                        <div class="grid grid-cols-2 gap-3">
+                          <label class="flex flex-col gap-2">
+                            <span class="text-sm font-semibold text-slate-900">Tanggal Awal</span>
+                            <div class="relative">
+                              <img
+                                src="img/icon/date-picker.svg"
+                                alt=""
+                                class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+                              >
+                              <input
+                                type="text"
+                                class="h-11 w-full rounded-lg border border-slate-300 bg-white pl-10 pr-3 text-sm text-slate-700 placeholder-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                placeholder="DD/MM/YYYY"
+                                data-date-start
+                                readonly
+                              />
+                            </div>
+                          </label>
+                          <label class="flex flex-col gap-2">
+                            <span class="text-sm font-semibold text-slate-900">Tanggal Akhir</span>
+                            <div class="relative">
+                              <img
+                                src="img/icon/date-picker.svg"
+                                alt=""
+                                class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+                              >
+                              <input
+                                type="text"
+                                class="h-11 w-full rounded-lg border border-slate-300 bg-white pl-10 pr-3 text-sm text-slate-700 placeholder-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                placeholder="DD/MM/YYYY"
+                                data-date-end
+                                readonly
+                              />
+                            </div>
+                          </label>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- restyle the date filter radio options to emphasize the custom range selection
- add side-by-side calendar inputs for custom start and end dates on mutasi and informasi rekening pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2a0318d388330b296d85ce821072a