### PR TITLE
Implement daily limit drawer logic

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -154,11 +154,11 @@
           </div>
 
           <!-- Values -->
-          <p class="font-bold text-slate-900">Rp150.000.000</p>
-          <p class="text-slate-500   mb-4">dari total batas transaksi Rp200.000.000</p>
+          <p id="currentLimitDisplay" class="font-bold text-slate-900">Rp150.000.000</p>
+          <p class="text-slate-500 mb-4">dari total batas transaksi <span id="maxLimitDisplay">Rp200.000.000</span></p>
 
           <!-- Button -->
-          <button class="w-full rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 flex items-center justify-center gap-2 hover:bg-cyan-50">
+          <button id="openLimitDrawerBtn" class="w-full rounded-lg border border-cyan-500 text-cyan-600 px-4 py-2 flex items-center justify-center gap-2 hover:bg-cyan-50">
             Ubah Batas Transaksi
             <img src="img/icon/batas-transaksi.svg" alt="" class="w-5 h-5"/>
           </button>
@@ -166,8 +166,48 @@
       </div>
     </main>
     <!-- ============ /MAIN ============ -->
+
+    <!-- Drawer -->
+    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100">
+      <div class="flex items-start justify-between gap-4 border-b px-6 py-5">
+        <div>
+          <h2 class="text-xl font-semibold">Ubah Batas Transaksi Harian</h2>
+        </div>
+        <button type="button" id="limitDrawerCloseBtn" class="text-2xl leading-none" aria-label="Tutup">
+          &times;
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+        <div class="space-y-2">
+          <label class="block text-sm text-slate-500">Batas Transaksi Harian Maksimum</label>
+          <div id="drawerMaxLimit" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 font-semibold text-slate-900">Rp200.000.000</div>
+        </div>
+
+        <div class="space-y-2">
+          <label class="block text-sm text-slate-500">Batas Transaksi Harian Saat Ini</label>
+          <div id="drawerCurrentLimit" class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 font-semibold text-slate-900">Rp150.000.000</div>
+        </div>
+
+        <div class="space-y-2">
+          <label for="newLimitInput" class="block text-sm text-slate-500">Batas Transaksi Harian Baru</label>
+          <div class="flex items-center rounded-xl border border-slate-200 bg-white px-4 py-3">
+            <span class="mr-2 font-semibold text-slate-500">Rp</span>
+            <input id="newLimitInput" type="text" inputmode="numeric" autocomplete="off" class="w-full border-none p-0 focus:ring-0" placeholder="0" aria-describedby="newLimitError">
+          </div>
+          <p id="newLimitError" class="hidden text-sm text-red-600"></p>
+        </div>
+      </div>
+
+      <div class="border-t px-6 py-5 sticky bottom-0 bg-white">
+        <button id="confirmLimitBtn" type="button" class="w-full rounded-xl bg-cyan-500 text-white py-3 font-semibold" disabled>
+          Konfirmasi Perubahan Batas Transaksi
+        </button>
+      </div>
+    </div>
   </div>
 
+  <script src="batas-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -1,0 +1,210 @@
+(function () {
+  const MAX_LIMIT = 200_000_000;
+  const STORAGE_KEY = 'ambis:batas-transaksi-limit';
+
+  const drawer = document.getElementById('drawer');
+  const openBtn = document.getElementById('openLimitDrawerBtn');
+  const closeBtn = document.getElementById('limitDrawerCloseBtn');
+  const confirmBtn = document.getElementById('confirmLimitBtn');
+  const input = document.getElementById('newLimitInput');
+  const errorEl = document.getElementById('newLimitError');
+  const drawerMaxEl = document.getElementById('drawerMaxLimit');
+  const drawerCurrentEl = document.getElementById('drawerCurrentLimit');
+  const cardCurrentEl = document.getElementById('currentLimitDisplay');
+  const cardMaxEl = document.getElementById('maxLimitDisplay');
+  const progressBar = document.getElementById('limitBar');
+
+  let ignoreOutsideClick = false;
+
+  let currentLimit = 150_000_000;
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!Number.isNaN(parsed) && parsed > 0 && parsed <= MAX_LIMIT) {
+        currentLimit = parsed;
+      }
+    }
+  } catch (err) {
+    // localStorage might be unavailable; ignore.
+  }
+
+  function formatCurrency(value) {
+    return `Rp${value.toLocaleString('id-ID')}`;
+  }
+
+  function updateDisplays() {
+    const formattedCurrent = formatCurrency(currentLimit);
+    const formattedMax = formatCurrency(MAX_LIMIT);
+
+    if (drawerCurrentEl) drawerCurrentEl.textContent = formattedCurrent;
+    if (drawerMaxEl) drawerMaxEl.textContent = formattedMax;
+    if (cardCurrentEl) cardCurrentEl.textContent = formattedCurrent;
+    if (cardMaxEl) cardMaxEl.textContent = formattedMax;
+
+    if (progressBar) {
+      const percent = Math.max(0, Math.min(100, (currentLimit / MAX_LIMIT) * 100));
+      progressBar.style.width = `${percent}%`;
+    }
+  }
+
+  function persistLimit() {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(currentLimit));
+    } catch (err) {
+      // Ignore persistence errors.
+    }
+  }
+
+  function hideError() {
+    if (!errorEl) return;
+    errorEl.textContent = '';
+    errorEl.classList.add('hidden');
+  }
+
+  function showError(message) {
+    if (!errorEl) return;
+    errorEl.textContent = message;
+    errorEl.classList.remove('hidden');
+  }
+
+  function sanitizeInputValue(rawValue) {
+    const digitsOnly = rawValue.replace(/\D/g, '');
+    if (!digitsOnly) return '';
+    const numeric = Number(digitsOnly);
+    if (Number.isNaN(numeric)) return '';
+    return numeric.toLocaleString('id-ID');
+  }
+
+  function getInputValue() {
+    if (!input) return NaN;
+    const digitsOnly = input.value.replace(/\D/g, '');
+    if (!digitsOnly) return NaN;
+    return parseInt(digitsOnly, 10);
+  }
+
+  function validateInput() {
+    if (!input || !confirmBtn) return false;
+
+    const digitsOnly = input.value.replace(/\D/g, '');
+
+    if (!digitsOnly) {
+      confirmBtn.disabled = true;
+      showError('Masukkan batas transaksi harian baru.');
+      return false;
+    }
+
+    const numericValue = parseInt(digitsOnly, 10);
+
+    if (Number.isNaN(numericValue)) {
+      confirmBtn.disabled = true;
+      showError('Masukkan angka yang valid.');
+      return false;
+    }
+
+    if (numericValue <= 0) {
+      confirmBtn.disabled = true;
+      showError('Batas transaksi harus lebih dari 0.');
+      return false;
+    }
+
+    if (numericValue > MAX_LIMIT) {
+      confirmBtn.disabled = true;
+      showError('Nilai tidak boleh melebihi batas maksimum.');
+      return false;
+    }
+
+    confirmBtn.disabled = false;
+    hideError();
+    return true;
+  }
+
+  function openDrawer() {
+    if (!drawer) return;
+    ignoreOutsideClick = true;
+
+    if (input) {
+      input.value = '';
+      input.focus();
+    }
+
+    hideError();
+
+    if (confirmBtn) confirmBtn.disabled = true;
+
+    updateDisplays();
+    drawer.classList.add('open');
+
+    if (typeof window.sidebarCollapseForDrawer === 'function') {
+      window.sidebarCollapseForDrawer();
+    }
+
+    // Allow outside click to close on the next tick so the opening click
+    // doesn't immediately trigger a close.
+    setTimeout(() => {
+      ignoreOutsideClick = false;
+    }, 0);
+  }
+
+  function closeDrawer() {
+    if (!drawer) return;
+    drawer.classList.remove('open');
+    if (typeof window.sidebarRestoreForDrawer === 'function') {
+      window.sidebarRestoreForDrawer();
+    }
+  }
+
+  openBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    openDrawer();
+  });
+
+  closeBtn?.addEventListener('click', () => {
+    closeDrawer();
+  });
+
+  confirmBtn?.addEventListener('click', () => {
+    if (!validateInput()) return;
+    const newValue = getInputValue();
+    if (Number.isNaN(newValue)) return;
+
+    currentLimit = newValue;
+    persistLimit();
+    updateDisplays();
+    closeDrawer();
+  });
+
+  input?.addEventListener('input', () => {
+    if (!input) return;
+    const formatted = sanitizeInputValue(input.value);
+    input.value = formatted;
+    validateInput();
+  });
+
+  input?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (validateInput()) {
+        confirmBtn?.click();
+      }
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!drawer || !drawer.classList.contains('open')) return;
+    if (ignoreOutsideClick) return;
+    if (drawer.contains(event.target)) return;
+    if (openBtn && openBtn.contains(event.target)) return;
+    closeDrawer();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && drawer?.classList.contains('open')) {
+      closeDrawer();
+    }
+  });
+
+  updateDisplays();
+})();


### PR DESCRIPTION
## Summary
- add a transaction limit drawer with maximum/current limit display and sticky confirmation action
- validate and persist the entered limit while updating the main card and progress indicator
- enable drawer open/close interactions including outside click and sidebar integration

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c6b0c3f083308fa4991f079bf3b6