### PR TITLE
Add overlay helper for limit input

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -190,7 +190,25 @@
         </div>
 
         <div class="space-y-2">
-          <label for="newLimitInput" class="block text-sm text-slate-500">Batas Transaksi Harian Baru</label>
+          <div class="flex items-start justify-between gap-2">
+            <label for="newLimitInput" class="block text-sm text-slate-500">Batas Transaksi Harian Baru</label>
+            <div class="relative flex-shrink-0">
+              <button type="button" id="limitInfoBtn" class="p-1 -m-1 rounded-full hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-cyan-500" aria-haspopup="true" aria-expanded="false" aria-controls="limitInfoOverlay">
+                <img src="img/icon/info.svg" alt="Informasi batas transaksi" class="w-5 h-5" />
+              </button>
+              <div id="limitInfoOverlay" role="dialog" aria-modal="false" aria-labelledby="limitInfoTitle" class="hidden absolute right-0 mt-2 w-72 rounded-xl bg-black/80 text-white shadow-lg">
+                <div class="flex items-start gap-3 p-4">
+                  <div class="flex-1">
+                    <p id="limitInfoTitle" class="text-base font-semibold">Batas Transaksi Harian</p>
+                    <p class="mt-2 text-sm leading-relaxed">Batas harian berlaku untuk semua transaksi di perusahaan Anda.<br>Limit Transaksi akan diperbarui otomatis setiap hari.</p>
+                  </div>
+                  <button type="button" id="limitInfoCloseBtn" class="-mr-1 -mt-1 p-1 text-white/70 hover:text-white" aria-label="Tutup bantuan">
+                    &times;
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="flex items-center rounded-xl border border-slate-200 bg-white px-4 py-3">
             <span class="mr-2 font-semibold text-slate-500">Rp</span>
             <input id="newLimitInput" type="text" inputmode="numeric" autocomplete="off" class="w-full border-none p-0 focus:ring-0" placeholder="0" aria-describedby="newLimitError">

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -13,8 +13,12 @@
   const cardCurrentEl = document.getElementById('currentLimitDisplay');
   const cardMaxEl = document.getElementById('maxLimitDisplay');
   const progressBar = document.getElementById('limitBar');
+  const infoBtn = document.getElementById('limitInfoBtn');
+  const infoOverlay = document.getElementById('limitInfoOverlay');
+  const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
 
   let ignoreOutsideClick = false;
+  let infoOverlayOpen = false;
 
   let currentLimit = 150_000_000;
 
@@ -28,6 +32,23 @@
     }
   } catch (err) {
     // localStorage might be unavailable; ignore.
+  }
+
+  function closeInfoOverlay() {
+    infoOverlayOpen = false;
+    if (infoOverlay) {
+      infoOverlay.classList.add('hidden');
+    }
+    if (infoBtn) {
+      infoBtn.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function openInfoOverlay() {
+    if (!infoOverlay || !infoBtn) return;
+    infoOverlay.classList.remove('hidden');
+    infoBtn.setAttribute('aria-expanded', 'true');
+    infoOverlayOpen = true;
   }
 
   function formatCurrency(value) {
@@ -126,10 +147,10 @@
 
     if (input) {
       input.value = '';
-      input.focus();
     }
 
     hideError();
+    closeInfoOverlay();
 
     if (confirmBtn) confirmBtn.disabled = true;
 
@@ -150,6 +171,7 @@
   function closeDrawer() {
     if (!drawer) return;
     drawer.classList.remove('open');
+    closeInfoOverlay();
     if (typeof window.sidebarRestoreForDrawer === 'function') {
       window.sidebarRestoreForDrawer();
     }
@@ -183,6 +205,22 @@
     validateInput();
   });
 
+  infoBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (infoOverlayOpen) {
+      closeInfoOverlay();
+    } else {
+      openInfoOverlay();
+    }
+  });
+
+  infoCloseBtn?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    closeInfoOverlay();
+  });
+
   input?.addEventListener('keydown', (event) => {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -190,6 +228,13 @@
         confirmBtn?.click();
       }
     }
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!infoOverlayOpen) return;
+    if (infoOverlay?.contains(event.target)) return;
+    if (infoBtn?.contains(event.target)) return;
+    closeInfoOverlay();
   });
 
   document.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- add an info button and floating overlay helper to the daily limit input field
- implement open/close behavior for the helper with outside click handling and drawer resets
- stop auto-focusing the input when the drawer opens so the field stays empty until edited

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2ca9282608330a5dc85ebae4b8358