### PR TITLE
Add confirmation bottom sheet for daily limit update

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -141,6 +141,10 @@
         </div>
         <!-- ============ HEADER ============ -->
 
+        <div id="limitSuccessMessage" role="status" class="hidden mb-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-700">
+          Batas transaksi harian berhasil diperbarui.
+        </div>
+
         <!-- Card -->
         <div class="relative rounded-2xl border border-slate-200 p-5 max-w-md bg-white">
           <div class="flex items-center mb-3">
@@ -220,6 +224,63 @@
         <button id="confirmLimitBtn" type="button" class="w-full rounded-xl bg-cyan-500 text-white py-3 font-semibold" disabled>
           Konfirmasi Perubahan Batas Transaksi
         </button>
+      </div>
+
+      <div id="limitConfirmContainer" class="pointer-events-none absolute inset-0">
+        <div
+          id="limitConfirmOverlay"
+          class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"
+        ></div>
+        <div
+          id="limitConfirmSheet"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="limitConfirmTitle"
+          aria-hidden="true"
+          class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto"
+        >
+          <div class="sticky top-0 p-4 pb-4 border-b border-slate-200 bg-white rounded-t-3xl text-center">
+            <h3 id="limitConfirmTitle" class="text-base font-semibold text-slate-900">Konfirmasi Ubah Batas Transaksi Harian</h3>
+          </div>
+
+          <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
+            <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+              <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
+              <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
+            </div>
+
+            <section class="space-y-4">
+              <p class="text-sm font-semibold text-slate-900">Ubah Batas Transaksi</p>
+              <dl class="grid grid-cols-1 gap-4 text-sm text-slate-600 sm:grid-cols-2">
+                <div class="space-y-1">
+                  <dt class="font-medium text-slate-500">Batas Transaksi Harian Sebelumnya</dt>
+                  <dd id="limitConfirmPreviousValue" class="text-base font-semibold text-slate-900">Rp200.000.000</dd>
+                </div>
+                <div class="space-y-1">
+                  <dt class="font-medium text-slate-500">Perubahan Batas Transaksi Harian Baru</dt>
+                  <dd id="limitConfirmNewValue" class="text-base font-semibold text-slate-900">Rp100.000.000</dd>
+                </div>
+              </dl>
+            </section>
+          </div>
+
+          <div class="sticky bottom-0 border-t border-slate-200 bg-white p-4 flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              id="limitConfirmCancelBtn"
+              class="w-full rounded-xl border border-slate-300 text-slate-700 font-semibold py-3 hover:bg-slate-50"
+            >
+              Batal
+            </button>
+            <button
+              type="button"
+              id="limitConfirmProceedBtn"
+              class="w-full rounded-xl bg-cyan-600 text-white font-semibold py-3 hover:bg-cyan-700"
+            >
+              Lanjut Ubah Batas Transaksi
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a confirmation bottom sheet inside the daily limit drawer with overlay, helper notice, and detail fields
- wire drawer logic to populate the confirmation sheet, support cancel/continue actions, and close on escape or overlay click
- display a transient success banner after the new limit is applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3835385cc83309b5ef01a38d56873