### PR TITLE
Add account picker bottom sheet for biller source

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -240,13 +240,13 @@
           <section class="space-y-5">
             <div class="space-y-2">
               <span class="block text-sm text-slate-600">Sumber Rekening</span>
-              <div class="w-full border border-slate-200 rounded-xl px-4 py-3 flex items-center justify-between gap-3">
+              <button id="moveSourceButton" type="button" class="w-full text-left border border-slate-200 rounded-xl px-4 py-3 flex items-center gap-3">
                 <div class="flex-1 min-w-0">
                   <p id="sourceAccountName" class="text-sm font-semibold text-slate-900 truncate hidden"></p>
                   <p id="sourceAccountSubtitle" class="text-xs text-slate-500 truncate hidden"></p>
-                  <span id="sourceAccountPlaceholder" class="text-sm text-slate-400">Pilih Rekening</span>
+                  <span id="sourceAccountPlaceholder" class="text-sm text-slate-400">Pilih Sumber Rekening</span>
                 </div>
-              </div>
+              </button>
             </div>
 
             <div class="space-y-2">
@@ -270,9 +270,23 @@
             Konfirmasi Pembayaran
           </button>
         </div>
+      <div id="sheetOverlay" class="hidden absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity duration-200"></div>
+      <div id="bottomSheet" class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col">
+        <div class="px-6 pt-5 pb-4 border-b flex items-center justify-between">
+          <h3 class="text-lg font-semibold text-slate-900">Sumber Rekening</h3>
+          <button id="sheetClose" type="button" class="text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup pilihan sumber rekening">&times;</button>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <ul id="sheetList" class="divide-y"></ul>
+        </div>
+        <div class="px-6 py-4 border-t bg-white flex gap-3">
+          <button id="sheetCancel" type="button" class="flex-1 rounded-xl border border-slate-200 py-3 text-sm font-medium text-slate-600 hover:bg-slate-50">Batalkan</button>
+          <button id="sheetConfirm" type="button" class="flex-1 rounded-xl bg-cyan-600 text-white py-3 text-sm font-semibold opacity-50 cursor-not-allowed" disabled>Pilih Rekening</button>
+        </div>
       </div>
-
     </div>
+
+  </div>
   </div>
 
   <!-- Bottom sheet -->


### PR DESCRIPTION
## Summary
- turn the sumber rekening area into an interactive trigger that opens a drawer-scoped bottom sheet of available accounts
- implement the reusable bottom sheet overlay, list rendering, and confirmation logic so account choices update the drawer state
- wire up listeners to support selecting, cancelling, and confirming accounts and ensure the payment confirmation sheet continues to work

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3c7d552f883308ee9901222673e3b