### PR TITLE
Ensure source account bottom sheet reflects selection state

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -281,7 +281,7 @@
         </div>
         <div class="sticky bottom-0 bg-white p-4 border-t flex gap-3">
           <button id="sheetCancel" type="button" class="flex-1 rounded-xl border border-slate-200 py-3 text-sm font-medium text-slate-700 focus:outline-none hover:bg-slate-100">Batalkan</button>
-          <button id="sheetConfirm" type="button" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 text-sm font-semibold opacity-50 cursor-not-allowed focus:outline-none" disabled>Pilih Rekening</button>
+          <button id="sheetConfirm" type="button" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 text-sm font-semibold opacity-50 cursor-not-allowed focus:outline-none" disabled>Pilih</button>
         </div>
       </div>
     </div>

--- a/biller.js
+++ b/biller.js
@@ -306,7 +306,8 @@
       }
       if (accountNameEl) {
         if (account) {
-          accountNameEl.textContent = account.displayName || '';
+          const nickname = account.name || account.displayName || '';
+          accountNameEl.textContent = nickname;
           accountNameEl.classList.remove('hidden');
         } else {
           accountNameEl.textContent = '';
@@ -315,9 +316,9 @@
       }
       if (accountSubtitleEl) {
         if (account) {
-          const subtitle = account.subtitle || [account.company, account.number].filter(Boolean).join(' • ');
-          accountSubtitleEl.textContent = subtitle;
-          accountSubtitleEl.classList.toggle('hidden', !subtitle);
+          const accountNumber = account.number || formatAccountNumber(account.numberRaw) || '';
+          accountSubtitleEl.textContent = accountNumber;
+          accountSubtitleEl.classList.toggle('hidden', !accountNumber);
         } else {
           accountSubtitleEl.textContent = '';
           accountSubtitleEl.classList.add('hidden');
@@ -339,25 +340,15 @@
       return 'Rp0';
     }
 
-    function resolveRadioDotClass(account) {
-      const color = typeof account?.color === 'string' ? account.color.trim() : '';
-      if (!color) {
-        return 'bg-cyan-500';
-      }
-      const backgroundClass = color
-        .split(/\s+/)
-        .find((cls) => cls.startsWith('bg-'));
-      if (!backgroundClass) {
-        return 'bg-cyan-500';
-      }
-      return backgroundClass.replace(/-\d{2,3}$/u, '-500');
+    function resolveRadioDotClass() {
+      return 'bg-cyan-500';
     }
 
     function renderAccountOptions(selectedId) {
       if (!accountSheetList) return;
       const items = accountDisplayList.map((account) => {
         const avatarClasses = account.color || 'bg-cyan-100 text-cyan-600';
-        const radioDotClass = resolveRadioDotClass(account);
+        const radioDotClass = resolveRadioDotClass();
         const isSelected = account.id === selectedId;
         const selectedClasses = isSelected ? ` ${SHEET_SELECTED_CLASSES.join(' ')}` : '';
         const checkedAttr = isSelected ? ' checked' : '';


### PR DESCRIPTION
## Summary
- show the selected source account in the drawer using the nickname and formatted account number
- keep the account picker visuals consistent by forcing the active radio dot to cyan and aligning the confirm button label with the flow

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3e3d1b214833086fd20de51997529