### PR TITLE
Update source account display layout

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -242,8 +242,11 @@
               <span class="block text-sm text-slate-600">Sumber Rekening</span>
               <button id="moveSourceButton" type="button" class="w-full text-left border border-slate-200 rounded-xl px-4 py-3 flex items-center gap-3">
                 <div class="flex-1 min-w-0">
-                  <p id="sourceAccountName" class="text-sm font-semibold text-slate-900 truncate hidden"></p>
-                  <p id="sourceAccountSubtitle" class="text-xs text-slate-500 truncate hidden"></p>
+                  <div id="sourceAccountDisplay" class="hidden min-w-0 flex items-center gap-2 text-sm font-semibold text-slate-900">
+                    <span id="sourceAccountName" class="truncate flex-1 min-w-0"></span>
+                    <span id="sourceAccountSeparator" class="text-slate-300 flex-shrink-0">-</span>
+                    <span id="sourceAccountSubtitle" class="truncate text-sm font-semibold text-slate-900"></span>
+                  </div>
                   <span id="sourceAccountPlaceholder" class="text-sm text-slate-400">Pilih Sumber Rekening</span>
                 </div>
               </button>

--- a/biller.js
+++ b/biller.js
@@ -152,7 +152,9 @@
     const idHint = document.getElementById('idInputHint');
     const idInput = document.getElementById('billerIdInput');
     const idError = document.getElementById('idInputError');
+    const accountDisplayEl = document.getElementById('sourceAccountDisplay');
     const accountNameEl = document.getElementById('sourceAccountName');
+    const accountSeparatorEl = document.getElementById('sourceAccountSeparator');
     const accountSubtitleEl = document.getElementById('sourceAccountSubtitle');
     const accountPlaceholderEl = document.getElementById('sourceAccountPlaceholder');
     const confirmBtn = document.getElementById('confirmPaymentBtn');
@@ -301,28 +303,40 @@
       pendingAccountId = resolvedId;
       const account = resolvedId ? accountMap.get(resolvedId) : null;
 
+      if (accountDisplayEl) {
+        accountDisplayEl.classList.toggle('hidden', !account);
+      }
       if (accountPlaceholderEl) {
         accountPlaceholderEl.classList.toggle('hidden', Boolean(account));
       }
+
+      const nickname = account ? account.name || account.displayName || '' : '';
+      const accountNumber = account
+        ? account.number || formatAccountNumber(account.numberRaw) || ''
+        : '';
+
       if (accountNameEl) {
-        if (account) {
-          const nickname = account.name || account.displayName || '';
-          accountNameEl.textContent = nickname;
-          accountNameEl.classList.remove('hidden');
+        accountNameEl.textContent = nickname;
+        if (nickname) {
+          accountNameEl.setAttribute('title', nickname);
         } else {
-          accountNameEl.textContent = '';
-          accountNameEl.classList.add('hidden');
+          accountNameEl.removeAttribute('title');
         }
       }
+
       if (accountSubtitleEl) {
-        if (account) {
-          const accountNumber = account.number || formatAccountNumber(account.numberRaw) || '';
-          accountSubtitleEl.textContent = accountNumber;
-          accountSubtitleEl.classList.toggle('hidden', !accountNumber);
+        accountSubtitleEl.textContent = accountNumber;
+        const shouldHideNumber = !account || !accountNumber;
+        accountSubtitleEl.classList.toggle('hidden', shouldHideNumber);
+        if (!shouldHideNumber) {
+          accountSubtitleEl.setAttribute('title', accountNumber);
         } else {
-          accountSubtitleEl.textContent = '';
-          accountSubtitleEl.classList.add('hidden');
+          accountSubtitleEl.removeAttribute('title');
         }
+      }
+
+      if (accountSeparatorEl) {
+        accountSeparatorEl.classList.toggle('hidden', !account || !accountNumber);
       }
 
       updateConfirmState();


### PR DESCRIPTION
## Summary
- restyle the selected source account display so the name and number appear inline with a hyphen separator
- adjust the selection logic to manage the new inline display, separator, and placeholder visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3e6b5456c8330bcd60e5b45da4b8b