### PR TITLE
Remove biller header from payment confirmation sheet

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -375,10 +375,6 @@
             <p class="inline-block font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 px-3 py-2 text-[11px] w-full">Rincian Transaksi</p>
             <div class="space-y-4">
               <div class="flex items-start justify-between gap-4">
-                <span id="paymentSheetTypeLabel" class="text-sm text-slate-500">Pembayaran</span>
-                <span id="paymentSheetBiller" class="text-sm font-semibold text-slate-900 text-right max-w-[60%]">-</span>
-              </div>
-              <div class="flex items-start justify-between gap-4">
                 <span class="text-sm text-slate-500">Sumber Rekening</span>
                 <span id="paymentSheetAccountValue" class="text-sm font-semibold text-slate-900 text-right max-w-[60%]">-</span>
               </div>

--- a/biller.js
+++ b/biller.js
@@ -336,8 +336,6 @@
     const paymentSheetCancel = document.getElementById('paymentSheetCancel');
     const paymentSheetConfirm = document.getElementById('paymentSheetConfirm');
     const paymentSheetTitle = document.getElementById('paymentSheetTitle');
-    const paymentSheetTypeLabel = document.getElementById('paymentSheetTypeLabel');
-    const paymentSheetBiller = document.getElementById('paymentSheetBiller');
     const paymentSheetAccountValue = document.getElementById('paymentSheetAccountValue');
     const paymentSheetIdLabel = document.getElementById('paymentSheetIdLabel');
     const paymentSheetIdValue = document.getElementById('paymentSheetIdValue');
@@ -1518,12 +1516,6 @@
 
       if (paymentSheetTitle) {
         paymentSheetTitle.textContent = headerTitle;
-      }
-      if (paymentSheetTypeLabel) {
-        paymentSheetTypeLabel.textContent = transactionLabel;
-      }
-      if (paymentSheetBiller) {
-        paymentSheetBiller.textContent = displayName;
       }
       if (paymentSheetAccountValue) {
         paymentSheetAccountValue.textContent = formatAccountForPayment(account);


### PR DESCRIPTION
## Summary
- remove the biller-specific header row from the payment confirmation bottom sheet so Token Listrik/Tagihan labels no longer display
- clean up JavaScript references to the removed DOM elements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d60b289b9c8330899415dd75208be9