### PR TITLE
Fix biller drawer activation and remove unused history scripts

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -29,8 +29,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.css">
-
   <!-- Global styles -->
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -556,8 +554,6 @@
   </div>
   </div>
 
-  <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
-  <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="biller.js"></script>
   <script src="sidebar.js"></script>

--- a/biller.js
+++ b/biller.js
@@ -386,6 +386,7 @@
     const successAdmin = document.getElementById('successAdmin');
     const successTotal = document.getElementById('successTotal');
     const successStatusButtonDefaultText = successStatusButton?.textContent?.trim() || 'Cek Status';
+    const billerButtons = document.querySelectorAll('[data-biller]');
 
     function normaliseAccount(account, index) {
       if (!account) return null;


### PR DESCRIPTION
## Summary
- remove the history drawer dependencies from the biller page to stop loading unused scripts
- bind the biller item buttons to the drawer logic so selecting a service opens the panel correctly

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63b3e926883308ecfaf18579ae8db