### PR TITLE
Fix biller drawer initialization errors

### DIFF
--- a/biller.js
+++ b/biller.js
@@ -1,6 +1,22 @@
 (function () {
   'use strict';
 
+  const ambis = window.AMBIS || {};
+  const sanitizeNumber = (value = '') => value.toString().replace(/\D+/g, '');
+  const formatAccountNumber = typeof ambis.formatAccountNumber === 'function'
+    ? (value) => ambis.formatAccountNumber(value)
+    : (value) => {
+        const raw = sanitizeNumber(value);
+        if (!raw) return '';
+        return raw.replace(/(\d{4})(?=\d)/g, '$1 ').trim();
+      };
+  const currencyFormatter = new Intl.NumberFormat('id-ID');
+  const defaultCompanyName = typeof ambis.getBrandName === 'function'
+    ? ambis.getBrandName()
+    : (ambis.brandName || '');
+  const accountMap = new Map();
+  const accountDisplayList = [];
+
   const digitsOnly = (value = '') => value.replace(/\D+/g, '');
 
   const DEFAULT_VALIDATION = {


### PR DESCRIPTION
## Summary
- add fallbacks for AMBIS helpers used by the Beli & Bayar drawer
- initialise shared account collections to avoid runtime failures when opening the drawer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63eaf7d588330941ec0a0255a7144