### PR TITLE
Refactor UI components into reusable modules

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -359,7 +359,7 @@
     </div>
   </div>
 
-  <script src="batas-transaksi.js"></script>
+  <script type="module" src="batas-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -1,689 +1,530 @@
-(function () {
-  const MAX_LIMIT = 200_000_000;
-  const STORAGE_KEY = 'ambis:batas-transaksi-limit';
+import { openDrawer as showDrawer, closeDrawer as hideDrawer, openBottomSheet, closeBottomSheet, createOtpFlow } from './ui-components.js';
 
-  const drawer = document.getElementById('drawer');
-  const openBtn = document.getElementById('openLimitDrawerBtn');
-  const closeBtn = document.getElementById('limitDrawerCloseBtn');
-  const confirmBtn = document.getElementById('confirmLimitBtn');
-  const formSection = document.getElementById('limitFormSection');
-  const pendingSection = document.getElementById('limitPendingSection');
-  const pendingPreviousValueEl = document.getElementById('limitPendingPreviousValue');
-  const pendingNewValueEl = document.getElementById('limitPendingNewValue');
-  const pendingCloseBtn = document.getElementById('limitPendingCloseBtn');
-  const input = document.getElementById('newLimitInput');
-  const errorEl = document.getElementById('newLimitError');
-  const drawerMaxEl = document.getElementById('drawerMaxLimit');
-  const drawerCurrentEl = document.getElementById('drawerCurrentLimit');
-  const cardCurrentEl = document.getElementById('currentLimitDisplay');
-  const cardMaxEl = document.getElementById('maxLimitDisplay');
-  const progressBar = document.getElementById('limitBar');
-  const infoBtn = document.getElementById('limitInfoBtn');
-  const infoOverlay = document.getElementById('limitInfoOverlay');
-  const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
-  const successMessageEl = document.getElementById('limitSuccessMessage');
-  const confirmElements = {
-    container: document.getElementById('limitConfirmContainer'),
-    overlay: document.getElementById('limitConfirmOverlay'),
-    sheet: document.getElementById('limitConfirmSheet'),
-    previousValue: document.getElementById('limitConfirmPreviousValue'),
-    newValue: document.getElementById('limitConfirmNewValue'),
-    cancelBtn: document.getElementById('limitConfirmCancelBtn'),
-    proceedBtn: document.getElementById('limitConfirmProceedBtn'),
-  };
+const MAX_LIMIT = 200_000_000;
+const STORAGE_KEY = 'ambis:batas-transaksi-limit';
 
-  const otpElements = {
-    section: document.getElementById('limitOtpSection'),
-    inputs: Array.from(document.querySelectorAll('#limitOtpSection .otp-input')),
-    countdown: document.getElementById('limitOtpCountdown'),
-    countdownMessage: document.getElementById('limitOtpCountdownMessage'),
-    timer: document.getElementById('limitOtpTimer'),
-    resendBtn: document.getElementById('limitOtpResend'),
-    error: document.getElementById('limitOtpError'),
-  };
+const drawer = document.getElementById('drawer');
+const openBtn = document.getElementById('openLimitDrawerBtn');
+const closeBtn = document.getElementById('limitDrawerCloseBtn');
+const confirmBtn = document.getElementById('confirmLimitBtn');
+const formSection = document.getElementById('limitFormSection');
+const pendingSection = document.getElementById('limitPendingSection');
+const pendingPreviousValueEl = document.getElementById('limitPendingPreviousValue');
+const pendingNewValueEl = document.getElementById('limitPendingNewValue');
+const pendingCloseBtn = document.getElementById('limitPendingCloseBtn');
+const input = document.getElementById('newLimitInput');
+const errorEl = document.getElementById('newLimitError');
+const drawerMaxEl = document.getElementById('drawerMaxLimit');
+const drawerCurrentEl = document.getElementById('drawerCurrentLimit');
+const cardCurrentEl = document.getElementById('currentLimitDisplay');
+const cardMaxEl = document.getElementById('maxLimitDisplay');
+const progressBar = document.getElementById('limitBar');
+const infoBtn = document.getElementById('limitInfoBtn');
+const infoOverlay = document.getElementById('limitInfoOverlay');
+const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
+const successMessageEl = document.getElementById('limitSuccessMessage');
+const confirmElements = {
+  container: document.getElementById('limitConfirmContainer'),
+  overlay: document.getElementById('limitConfirmOverlay'),
+  sheet: document.getElementById('limitConfirmSheet'),
+  previousValue: document.getElementById('limitConfirmPreviousValue'),
+  newValue: document.getElementById('limitConfirmNewValue'),
+  cancelBtn: document.getElementById('limitConfirmCancelBtn'),
+  proceedBtn: document.getElementById('limitConfirmProceedBtn'),
+};
 
-  const OTP_DURATION_SECONDS = 30;
-  const OTP_DEFAULT_COUNTDOWN_MESSAGE = 'Sesi akan berakhir dalam';
-  const OTP_EXPIRED_MESSAGE = 'Kode OTP kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.';
-  const otpCountdownDefaultMessage =
-    otpElements.countdownMessage?.textContent?.trim() || OTP_DEFAULT_COUNTDOWN_MESSAGE;
+const otpElements = {
+  section: document.getElementById('limitOtpSection'),
+  inputs: Array.from(document.querySelectorAll('#limitOtpSection .otp-input')),
+  countdown: document.getElementById('limitOtpCountdown'),
+  countdownMessage: document.getElementById('limitOtpCountdownMessage'),
+  timer: document.getElementById('limitOtpTimer'),
+  resendBtn: document.getElementById('limitOtpResend'),
+  error: document.getElementById('limitOtpError'),
+};
 
-  let otpActive = false;
-  let otpIntervalId = null;
-  let otpTimeLeft = OTP_DURATION_SECONDS;
+const OTP_DURATION_SECONDS = 30;
+const OTP_DEFAULT_COUNTDOWN_MESSAGE = 'Sesi akan berakhir dalam';
+const OTP_EXPIRED_MESSAGE = 'Kode OTP kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.';
+const otpCountdownDefaultMessage =
+  otpElements.countdownMessage?.textContent?.trim() || OTP_DEFAULT_COUNTDOWN_MESSAGE;
 
-  let infoOverlayOpen = false;
+let otpState = 'idle';
+let otpFlowInstance = null;
 
-  let currentLimit = 150_000_000;
-  let pendingNewLimit = null;
-  let confirmSheetOpen = false;
-  let successTimer = null;
+let infoOverlayOpen = false;
 
+let currentLimit = 150_000_000;
+let pendingNewLimit = null;
+let confirmSheetOpen = false;
+let successTimer = null;
+
+try {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    const parsed = parseInt(stored, 10);
+    if (!Number.isNaN(parsed) && parsed > 0 && parsed <= MAX_LIMIT) {
+      currentLimit = parsed;
+    }
+  }
+} catch (err) {
+  // localStorage might be unavailable; ignore.
+}
+
+function closeInfoOverlay() {
+  infoOverlayOpen = false;
+  if (infoOverlay) {
+    infoOverlay.classList.add('hidden');
+  }
+  if (infoBtn) {
+    infoBtn.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function openInfoOverlay() {
+  if (!infoOverlay || !infoBtn) return;
+  infoOverlay.classList.remove('hidden');
+  infoBtn.setAttribute('aria-expanded', 'true');
+  infoOverlayOpen = true;
+}
+
+function formatCurrency(value) {
+  return `Rp${value.toLocaleString('id-ID')}`;
+}
+
+function updateDisplays() {
+  const formattedCurrent = formatCurrency(currentLimit);
+  const formattedMax = formatCurrency(MAX_LIMIT);
+
+  if (drawerCurrentEl) drawerCurrentEl.textContent = formattedCurrent;
+  if (drawerMaxEl) drawerMaxEl.textContent = formattedMax;
+  if (cardCurrentEl) cardCurrentEl.textContent = formattedCurrent;
+  if (cardMaxEl) cardMaxEl.textContent = formattedMax;
+
+  if (progressBar) {
+    const percent = Math.max(0, Math.min(100, (currentLimit / MAX_LIMIT) * 100));
+    progressBar.style.width = `${percent}%`;
+  }
+}
+
+function persistLimit() {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const parsed = parseInt(stored, 10);
-      if (!Number.isNaN(parsed) && parsed > 0 && parsed <= MAX_LIMIT) {
-        currentLimit = parsed;
-      }
-    }
+    localStorage.setItem(STORAGE_KEY, String(currentLimit));
   } catch (err) {
-    // localStorage might be unavailable; ignore.
+    // Ignore persistence errors.
   }
+}
 
-  function closeInfoOverlay() {
-    infoOverlayOpen = false;
-    if (infoOverlay) {
-      infoOverlay.classList.add('hidden');
-    }
-    if (infoBtn) {
-      infoBtn.setAttribute('aria-expanded', 'false');
-    }
+function hideSuccessMessage() {
+  if (!successMessageEl) return;
+  successMessageEl.classList.add('hidden');
+}
+
+function showSuccessMessage(message) {
+  if (!successMessageEl) return;
+  successMessageEl.textContent = message;
+  successMessageEl.classList.remove('hidden');
+  if (successTimer) {
+    clearTimeout(successTimer);
+    successTimer = null;
   }
+  successTimer = setTimeout(() => {
+    hideSuccessMessage();
+    successTimer = null;
+  }, 4000);
+}
 
-  function openInfoOverlay() {
-    if (!infoOverlay || !infoBtn) return;
-    infoOverlay.classList.remove('hidden');
-    infoBtn.setAttribute('aria-expanded', 'true');
-    infoOverlayOpen = true;
-  }
+function hideError() {
+  if (!errorEl) return;
+  errorEl.textContent = '';
+  errorEl.classList.add('hidden');
+}
 
-  function formatCurrency(value) {
-    return `Rp${value.toLocaleString('id-ID')}`;
-  }
+function showError(message) {
+  if (!errorEl) return;
+  errorEl.textContent = message;
+  errorEl.classList.remove('hidden');
+}
 
-  function updateDisplays() {
-    const formattedCurrent = formatCurrency(currentLimit);
-    const formattedMax = formatCurrency(MAX_LIMIT);
-
-    if (drawerCurrentEl) drawerCurrentEl.textContent = formattedCurrent;
-    if (drawerMaxEl) drawerMaxEl.textContent = formattedMax;
-    if (cardCurrentEl) cardCurrentEl.textContent = formattedCurrent;
-    if (cardMaxEl) cardMaxEl.textContent = formattedMax;
-
-    if (progressBar) {
-      const percent = Math.max(0, Math.min(100, (currentLimit / MAX_LIMIT) * 100));
-      progressBar.style.width = `${percent}%`;
-    }
-  }
-
-  function persistLimit() {
-    try {
-      localStorage.setItem(STORAGE_KEY, String(currentLimit));
-    } catch (err) {
-      // Ignore persistence errors.
-    }
-  }
-
-  function hideSuccessMessage() {
-    if (!successMessageEl) return;
-    successMessageEl.classList.add('hidden');
-  }
-
-  function showSuccessMessage(message) {
-    if (!successMessageEl) return;
-    successMessageEl.textContent = message;
-    successMessageEl.classList.remove('hidden');
-    if (successTimer) {
-      clearTimeout(successTimer);
-      successTimer = null;
-    }
-    successTimer = setTimeout(() => {
-      hideSuccessMessage();
-      successTimer = null;
-    }, 4000);
-  }
-
-  function hideError() {
-    if (!errorEl) return;
-    errorEl.textContent = '';
-    errorEl.classList.add('hidden');
-  }
-
-  function showError(message) {
-    if (!errorEl) return;
-    errorEl.textContent = message;
-    errorEl.classList.remove('hidden');
-  }
-
-  function hideOtpError() {
-    if (!otpElements.error) return;
-    otpElements.error.textContent = '';
-    otpElements.error.classList.add('hidden');
-  }
-
-  function showOtpError(message) {
-    if (!otpElements.error) return;
-    otpElements.error.textContent = message;
-    otpElements.error.classList.remove('hidden');
-  }
-
-  function resetOtpInputs() {
-    otpElements.inputs.forEach((input) => {
-      input.value = '';
-    });
-  }
-
-  function isOtpFilled() {
-    if (!otpElements.inputs.length) return false;
-    return otpElements.inputs.every((input) => input.value && input.value.trim() !== '');
-  }
-
-  function clearOtpTimer() {
-    if (otpIntervalId) {
-      clearInterval(otpIntervalId);
-      otpIntervalId = null;
-    }
-  }
-
-  function formatOtpTime(seconds) {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-  }
-
-  function updateOtpCountdownDisplay() {
-    if (otpElements.timer) {
-      otpElements.timer.textContent = formatOtpTime(otpTimeLeft);
-    }
-  }
-
-  function showOtpCountdownDefaultMessage() {
-    if (otpElements.countdownMessage) {
-      otpElements.countdownMessage.textContent = otpCountdownDefaultMessage;
-    }
-    if (otpElements.timer) {
-      otpElements.timer.classList.remove('hidden');
-    }
-  }
-
-  function showOtpExpiredMessage() {
-    if (otpElements.countdownMessage) {
-      otpElements.countdownMessage.textContent = OTP_EXPIRED_MESSAGE;
-    }
-    if (otpElements.timer) {
-      otpElements.timer.classList.add('hidden');
-    }
-  }
-
-  function updateOtpVerifyState() {
-    if (!confirmElements.proceedBtn) return;
-    if (!otpActive) {
-      confirmElements.proceedBtn.disabled = false;
-      return;
-    }
-
-    if (otpTimeLeft <= 0) {
-      confirmElements.proceedBtn.disabled = true;
-      return;
-    }
-
-    confirmElements.proceedBtn.disabled = !isOtpFilled();
-  }
-
-  function startOtpTimer() {
-    if (!otpActive) return;
-
-    if (otpElements.countdown) {
-      otpElements.countdown.classList.remove('hidden');
-    }
-    showOtpCountdownDefaultMessage();
-    hideOtpError();
-    if (otpElements.resendBtn) {
-      otpElements.resendBtn.classList.add('hidden');
-    }
-    otpTimeLeft = OTP_DURATION_SECONDS;
-    updateOtpCountdownDisplay();
-    clearOtpTimer();
-
-    otpIntervalId = setInterval(() => {
-      otpTimeLeft -= 1;
-      if (otpTimeLeft <= 0) {
-        otpTimeLeft = 0;
-        updateOtpCountdownDisplay();
-        clearOtpTimer();
-        showOtpExpiredMessage();
-        if (otpElements.resendBtn) {
-          otpElements.resendBtn.classList.remove('hidden');
-        }
-        showOtpError('Kode OTP kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.');
-        updateOtpVerifyState();
-        return;
+function ensureOtpFlow() {
+  if (otpFlowInstance) return otpFlowInstance;
+  otpFlowInstance = createOtpFlow({
+    container: otpElements.section,
+    inputs: otpElements.inputs,
+    countdownElement: otpElements.countdown,
+    countdownMessageElement: otpElements.countdownMessage,
+    timerElement: otpElements.timer,
+    errorElement: otpElements.error,
+    resendButton: otpElements.resendBtn,
+    duration: OTP_DURATION_SECONDS,
+    countdownMessage: otpCountdownDefaultMessage,
+    expiredMessage: OTP_EXPIRED_MESSAGE,
+    onRequest: () => {
+      console.info('OTP requested for limit change');
+    },
+    onResend: () => {
+      console.info('OTP resent for limit change');
+    },
+    onChange: ({ filled }) => {
+      if (confirmElements.proceedBtn && otpState === 'active') {
+        confirmElements.proceedBtn.disabled = !filled;
       }
+    },
+    onError: () => {
+      if (confirmElements.proceedBtn && otpState === 'active') {
+        confirmElements.proceedBtn.disabled = true;
+      }
+    },
+    onExpire: () => {
+      if (confirmElements.proceedBtn && otpState === 'active') {
+        confirmElements.proceedBtn.disabled = true;
+      }
+      ensureOtpFlow().setError(OTP_EXPIRED_MESSAGE);
+    },
+  });
+  return otpFlowInstance;
+}
 
-      updateOtpCountdownDisplay();
-    }, 1000);
-  }
+function showOtpError(message) {
+  ensureOtpFlow().setError(message);
+}
 
-  function resetOtpState() {
-    otpActive = false;
-    clearOtpTimer();
-    otpTimeLeft = OTP_DURATION_SECONDS;
-    if (otpElements.section) {
-      otpElements.section.classList.add('hidden');
-    }
-    resetOtpInputs();
-    if (otpElements.countdown) {
-      otpElements.countdown.classList.remove('hidden');
-    }
-    showOtpCountdownDefaultMessage();
-    if (otpElements.timer) {
-      otpElements.timer.textContent = formatOtpTime(OTP_DURATION_SECONDS);
-      otpElements.timer.classList.remove('hidden');
-    }
-    if (otpElements.resendBtn) {
-      otpElements.resendBtn.classList.add('hidden');
-    }
-    hideOtpError();
-    if (confirmElements.proceedBtn) {
-      confirmElements.proceedBtn.textContent = 'Lanjut Ubah Batas Transaksi';
-      confirmElements.proceedBtn.disabled = false;
-    }
-    if (confirmElements.cancelBtn) {
-      confirmElements.cancelBtn.textContent = 'Batal';
-    }
-    updateOtpVerifyState();
-  }
+function hideOtpError() {
+  ensureOtpFlow().setError('');
+}
 
-  function showOtpSection() {
-    if (!otpElements.section || !confirmElements.proceedBtn) return;
-
-    otpActive = true;
+function activateOtpFlow() {
+  const flow = ensureOtpFlow();
+  if (otpState === 'active') return flow;
+  otpState = 'active';
+  if (otpElements.section) {
     otpElements.section.classList.remove('hidden');
+  }
+  if (confirmElements.proceedBtn) {
     confirmElements.proceedBtn.textContent = 'Verifikasi';
     confirmElements.proceedBtn.disabled = true;
-    if (confirmElements.cancelBtn) {
-      confirmElements.cancelBtn.textContent = 'Batalkan';
-    }
-    resetOtpInputs();
-    hideOtpError();
-    otpElements.inputs[0]?.focus();
-    startOtpTimer();
-    updateOtpVerifyState();
+  }
+  if (confirmElements.cancelBtn) {
+    confirmElements.cancelBtn.textContent = 'Batalkan';
+  }
+  flow.start();
+  return flow;
+}
+
+function resetOtpFlow() {
+  const flow = ensureOtpFlow();
+  otpState = 'idle';
+  flow.reset();
+  if (otpElements.section) {
+    otpElements.section.classList.add('hidden');
+  }
+  if (confirmElements.proceedBtn) {
+    confirmElements.proceedBtn.textContent = 'Lanjut Ubah Batas Transaksi';
+    confirmElements.proceedBtn.disabled = false;
+  }
+  if (confirmElements.cancelBtn) {
+    confirmElements.cancelBtn.textContent = 'Batal';
+  }
+}
+
+function getOtpValue() {
+  return ensureOtpFlow().getValue();
+}
+
+function sanitizeInputValue(rawValue) {
+  const digitsOnly = rawValue.replace(/\D/g, '');
+  if (!digitsOnly) return '';
+  const numeric = Number(digitsOnly);
+  if (Number.isNaN(numeric)) return '';
+  return numeric.toLocaleString('id-ID');
+}
+
+function getInputValue() {
+  if (!input) return NaN;
+  const digitsOnly = input.value.replace(/\D/g, '');
+  if (!digitsOnly) return NaN;
+  return parseInt(digitsOnly, 10);
+}
+
+function showFormView() {
+  if (formSection) {
+    formSection.classList.remove('hidden');
+  }
+  if (pendingSection) {
+    pendingSection.classList.add('hidden');
+  }
+}
+
+function showPendingView(previousLimit, newLimitValue) {
+  if (pendingPreviousValueEl) {
+    pendingPreviousValueEl.textContent = formatCurrency(previousLimit);
+  }
+  if (pendingNewValueEl) {
+    pendingNewValueEl.textContent = formatCurrency(newLimitValue);
   }
 
-  function getOtpValue() {
-    return otpElements.inputs.map((input) => input.value).join('');
+  if (pendingSection) {
+    pendingSection.classList.remove('hidden');
+  }
+  if (formSection) {
+    formSection.classList.add('hidden');
   }
 
-  function sanitizeInputValue(rawValue) {
-    const digitsOnly = rawValue.replace(/\D/g, '');
-    if (!digitsOnly) return '';
-    const numeric = Number(digitsOnly);
-    if (Number.isNaN(numeric)) return '';
-    return numeric.toLocaleString('id-ID');
+  pendingCloseBtn?.focus?.();
+}
+
+function validateInput() {
+  if (!input || !confirmBtn) return false;
+
+  const digitsOnly = input.value.replace(/\D/g, '');
+
+  if (!digitsOnly) {
+    confirmBtn.disabled = true;
+    showError('Masukkan batas transaksi harian baru.');
+    return false;
   }
 
-  function getInputValue() {
-    if (!input) return NaN;
-    const digitsOnly = input.value.replace(/\D/g, '');
-    if (!digitsOnly) return NaN;
-    return parseInt(digitsOnly, 10);
+  const numericValue = parseInt(digitsOnly, 10);
+
+  if (Number.isNaN(numericValue)) {
+    confirmBtn.disabled = true;
+    showError('Masukkan angka yang valid.');
+    return false;
   }
 
-  function showFormView() {
-    if (formSection) {
-      formSection.classList.remove('hidden');
-    }
-    if (pendingSection) {
-      pendingSection.classList.add('hidden');
-    }
+  if (numericValue <= 0) {
+    confirmBtn.disabled = true;
+    showError('Batas transaksi harus lebih dari 0.');
+    return false;
   }
 
-  function showPendingView(previousLimit, newLimitValue) {
-    if (pendingPreviousValueEl) {
-      pendingPreviousValueEl.textContent = formatCurrency(previousLimit);
-    }
-    if (pendingNewValueEl) {
-      pendingNewValueEl.textContent = formatCurrency(newLimitValue);
-    }
-
-    if (pendingSection) {
-      pendingSection.classList.remove('hidden');
-    }
-    if (formSection) {
-      formSection.classList.add('hidden');
-    }
-
-    pendingCloseBtn?.focus?.();
+  if (numericValue > MAX_LIMIT) {
+    confirmBtn.disabled = true;
+    showError('Nilai tidak boleh melebihi batas maksimum.');
+    return false;
   }
 
-  function validateInput() {
-    if (!input || !confirmBtn) return false;
+  confirmBtn.disabled = false;
+  hideError();
+  return true;
+}
 
-    const digitsOnly = input.value.replace(/\D/g, '');
+async function openConfirmSheet(newLimitValue) {
+  const { container, overlay, sheet, previousValue, newValue } = confirmElements;
+  if (!sheet) return;
 
-    if (!digitsOnly) {
-      confirmBtn.disabled = true;
-      showError('Masukkan batas transaksi harian baru.');
-      return false;
-    }
+  pendingNewLimit = newLimitValue;
+  confirmSheetOpen = true;
 
-    const numericValue = parseInt(digitsOnly, 10);
+  resetOtpFlow();
 
-    if (Number.isNaN(numericValue)) {
-      confirmBtn.disabled = true;
-      showError('Masukkan angka yang valid.');
-      return false;
-    }
-
-    if (numericValue <= 0) {
-      confirmBtn.disabled = true;
-      showError('Batas transaksi harus lebih dari 0.');
-      return false;
-    }
-
-    if (numericValue > MAX_LIMIT) {
-      confirmBtn.disabled = true;
-      showError('Nilai tidak boleh melebihi batas maksimum.');
-      return false;
-    }
-
-    confirmBtn.disabled = false;
-    hideError();
-    return true;
+  if (previousValue) {
+    previousValue.textContent = formatCurrency(currentLimit);
+  }
+  if (newValue) {
+    newValue.textContent = formatCurrency(newLimitValue);
   }
 
-  function openConfirmSheet(newLimitValue) {
-    const { container, overlay, sheet, previousValue, newValue } = confirmElements;
-    if (!overlay || !sheet) return;
-
-    pendingNewLimit = newLimitValue;
-    confirmSheetOpen = true;
-
-    resetOtpState();
-
-    if (previousValue) {
-      previousValue.textContent = formatCurrency(currentLimit);
-    }
-    if (newValue) {
-      newValue.textContent = formatCurrency(newLimitValue);
-    }
-
-    sheet.setAttribute('aria-hidden', 'false');
-
-    container?.classList.remove('pointer-events-none');
-
-    overlay.classList.remove('hidden');
-    overlay.classList.add('opacity-0');
-    overlay.classList.remove('opacity-100');
-
-    sheet.classList.add('translate-y-full');
-    sheet.classList.remove('translate-y-0');
-
-    requestAnimationFrame(() => {
-      overlay.classList.remove('opacity-0');
-      overlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-      sheet.classList.add('translate-y-0');
-    });
+  if (overlay) {
+    overlay.classList.add('hidden');
   }
 
-  function closeConfirmSheet(options = {}) {
-    const { container, overlay, sheet } = confirmElements;
-    if (!overlay || !sheet) return;
-    if (!confirmSheetOpen && !options.force) return;
+  await openBottomSheet({
+    container,
+    sheet,
+    closeSelectors: ['#limitConfirmCancelBtn'],
+    focusTarget: '#limitConfirmProceedBtn',
+    onOpen: () => {
+      confirmSheetOpen = true;
+    },
+    onClose: () => {
+      confirmSheetOpen = false;
+      pendingNewLimit = null;
+      resetOtpFlow();
+    },
+  });
+}
 
-    confirmSheetOpen = false;
-    pendingNewLimit = null;
-    resetOtpState();
-    sheet.setAttribute('aria-hidden', 'true');
+async function closeConfirmSheet(options = {}) {
+  const { container, overlay, sheet } = confirmElements;
+  if (!sheet) return;
+  if (!confirmSheetOpen && !options.force) return;
 
-    const finishClose = () => {
-      overlay.classList.add('hidden');
-      container?.classList.add('pointer-events-none');
-    };
+  confirmSheetOpen = false;
+  pendingNewLimit = null;
+  resetOtpFlow();
 
-    if (options.immediate) {
-      overlay.classList.add('opacity-0');
-      overlay.classList.remove('opacity-100');
-      finishClose();
-      sheet.classList.add('translate-y-full');
-      sheet.classList.remove('translate-y-0');
-      return;
-    }
+  await closeBottomSheet({ immediate: Boolean(options.immediate) });
 
-    overlay.classList.remove('opacity-100');
-    overlay.classList.add('opacity-0');
-    sheet.classList.add('translate-y-full');
-    sheet.classList.remove('translate-y-0');
+  if (overlay) {
+    overlay.classList.add('hidden');
+  }
+  container?.classList.add('pointer-events-none');
+}
 
-    const handleTransitionEnd = (event) => {
-      if (event.target !== sheet) return;
-      finishClose();
-      sheet.removeEventListener('transitionend', handleTransitionEnd);
-    };
+function openDrawer() {
+  if (!drawer) return;
 
-    sheet.addEventListener('transitionend', handleTransitionEnd);
+  closeConfirmSheet({ immediate: true });
+
+  showFormView();
+
+  if (input) {
+    input.value = '';
   }
 
-  function openDrawer() {
-    if (!drawer) return;
+  hideError();
+  closeInfoOverlay();
 
-    closeConfirmSheet({ immediate: true });
-
-    showFormView();
-
-    if (input) {
-      input.value = '';
-    }
-
-    hideError();
-    closeInfoOverlay();
-
-    if (confirmBtn) confirmBtn.disabled = true;
-
-    updateDisplays();
-    drawer.classList.add('open');
-
-    if (typeof window.sidebarCollapseForDrawer === 'function') {
-      window.sidebarCollapseForDrawer();
-    }
-  }
-
-  function closeDrawer() {
-    if (!drawer) return;
-    closeConfirmSheet({ immediate: true });
-    drawer.classList.remove('open');
-    closeInfoOverlay();
-    showFormView();
-    if (typeof window.sidebarRestoreForDrawer === 'function') {
-      window.sidebarRestoreForDrawer();
-    }
-  }
-
-  openBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    openDrawer();
-  });
-
-  closeBtn?.addEventListener('click', () => {
-    closeDrawer();
-  });
-
-  confirmBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    if (!validateInput()) return;
-    const newValue = getInputValue();
-    if (Number.isNaN(newValue)) return;
-
-    openConfirmSheet(newValue);
-  });
-
-  input?.addEventListener('input', () => {
-    if (!input) return;
-    const formatted = sanitizeInputValue(input.value);
-    input.value = formatted;
-    validateInput();
-  });
-
-  infoBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (infoOverlayOpen) {
-      closeInfoOverlay();
-    } else {
-      openInfoOverlay();
-    }
-  });
-
-  infoCloseBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    closeInfoOverlay();
-  });
-
-  input?.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      if (validateInput()) {
-        confirmBtn?.click();
-      }
-    }
-  });
-
-  document.addEventListener('click', (event) => {
-    if (!infoOverlayOpen) return;
-    if (infoOverlay?.contains(event.target)) return;
-    if (infoBtn?.contains(event.target)) return;
-    closeInfoOverlay();
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key !== 'Escape') return;
-    if (confirmSheetOpen) {
-      closeConfirmSheet();
-      return;
-    }
-    if (drawer?.classList.contains('open')) {
-      closeDrawer();
-    }
-  });
-
-  confirmElements.cancelBtn?.addEventListener('click', () => {
-    closeConfirmSheet();
-  });
-
-  confirmElements.overlay?.addEventListener('click', (event) => {
-    if (event.target === confirmElements.overlay) {
-      closeConfirmSheet();
-    }
-  });
-
-  otpElements.resendBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    if (!otpActive) return;
-    resetOtpInputs();
-    hideOtpError();
-    otpElements.inputs[0]?.focus();
-    startOtpTimer();
-    updateOtpVerifyState();
-  });
-
-  otpElements.inputs.forEach((input, index) => {
-    input.addEventListener('input', (event) => {
-      const target = event.target;
-      if (!(target instanceof HTMLInputElement)) return;
-      const digits = target.value.replace(/\D/g, '');
-      target.value = digits.slice(-1);
-      if (target.value && index < otpElements.inputs.length - 1) {
-        otpElements.inputs[index + 1]?.focus();
-      }
-      hideOtpError();
-      updateOtpVerifyState();
-    });
-
-    input.addEventListener('keydown', (event) => {
-      if (event.key === 'Backspace' && !input.value && index > 0) {
-        event.preventDefault();
-        const previous = otpElements.inputs[index - 1];
-        previous.value = '';
-        previous.focus();
-        updateOtpVerifyState();
-        return;
-      }
-      if (event.key === 'ArrowLeft' && index > 0) {
-        event.preventDefault();
-        otpElements.inputs[index - 1]?.focus();
-        return;
-      }
-      if (event.key === 'ArrowRight' && index < otpElements.inputs.length - 1) {
-        event.preventDefault();
-        otpElements.inputs[index + 1]?.focus();
-      }
-    });
-
-    input.addEventListener('paste', (event) => {
-      event.preventDefault();
-      const clipboard = event.clipboardData || window.clipboardData;
-      const text = clipboard?.getData('text') || '';
-      const digits = text.replace(/\D/g, '');
-      if (!digits) return;
-      resetOtpInputs();
-      const chars = digits.split('').slice(0, otpElements.inputs.length);
-      chars.forEach((char, charIndex) => {
-        otpElements.inputs[charIndex].value = char;
-      });
-      const focusIndex = Math.min(chars.length - 1, otpElements.inputs.length - 1);
-      if (focusIndex >= 0) {
-        otpElements.inputs[focusIndex].focus();
-      }
-      hideOtpError();
-      updateOtpVerifyState();
-    });
-
-    input.addEventListener('focus', () => {
-      if (input.value) {
-        input.select();
-      }
-    });
-  });
-
-  confirmElements.proceedBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-
-    if (!otpActive) {
-      showOtpSection();
-      return;
-    }
-
-    if (!confirmElements.proceedBtn || confirmElements.proceedBtn.disabled) {
-      return;
-    }
-
-    if (otpTimeLeft <= 0) {
-      showOtpError('Kode OTP kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.');
-      confirmElements.proceedBtn.disabled = true;
-      return;
-    }
-
-    if (!isOtpFilled()) {
-      showOtpError('Masukkan kode OTP lengkap.');
-      confirmElements.proceedBtn.disabled = true;
-      return;
-    }
-
-    if (typeof pendingNewLimit !== 'number' || Number.isNaN(pendingNewLimit)) {
-      closeConfirmSheet({ immediate: true, force: true });
-      return;
-    }
-
-    const previousLimitValue = currentLimit;
-    const newLimitValue = pendingNewLimit;
-
-    const otpValue = getOtpValue();
-    hideOtpError();
-    console.log('OTP submitted:', otpValue);
-
-    closeConfirmSheet();
-    showPendingView(previousLimitValue, newLimitValue);
-  });
-
-  pendingCloseBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    closeDrawer();
-  });
+  if (confirmBtn) confirmBtn.disabled = true;
 
   updateDisplays();
-})();
+
+  showDrawer({
+    drawer,
+    closeSelectors: ['#limitDrawerCloseBtn'],
+    focusTarget: '#newLimitInput',
+    onOpen: () => {
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    },
+    onClose: () => {
+      closeConfirmSheet({ immediate: true });
+      closeInfoOverlay();
+      showFormView();
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    },
+  });
+}
+
+function closeDrawer() {
+  hideDrawer();
+}
+
+openBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  openDrawer();
+});
+
+closeBtn?.addEventListener('click', () => {
+  closeDrawer();
+});
+
+confirmBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+  if (!validateInput()) return;
+  const newValue = getInputValue();
+  if (Number.isNaN(newValue)) return;
+
+  openConfirmSheet(newValue);
+});
+
+input?.addEventListener('input', () => {
+  if (!input) return;
+  const formatted = sanitizeInputValue(input.value);
+  input.value = formatted;
+  validateInput();
+});
+
+infoBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  if (infoOverlayOpen) {
+    closeInfoOverlay();
+  } else {
+    openInfoOverlay();
+  }
+});
+
+infoCloseBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  closeInfoOverlay();
+});
+
+input?.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    if (validateInput()) {
+      confirmBtn?.click();
+    }
+  }
+});
+
+document.addEventListener('click', (event) => {
+  if (!infoOverlayOpen) return;
+  if (infoOverlay?.contains(event.target)) return;
+  if (infoBtn?.contains(event.target)) return;
+  closeInfoOverlay();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  if (confirmSheetOpen) {
+    closeConfirmSheet();
+    return;
+  }
+  if (drawer?.classList.contains('open')) {
+    closeDrawer();
+  }
+});
+
+confirmElements.cancelBtn?.addEventListener('click', () => {
+  closeConfirmSheet();
+});
+
+confirmElements.overlay?.addEventListener('click', (event) => {
+  if (event.target === confirmElements.overlay) {
+    closeConfirmSheet();
+  }
+});
+
+const otpFlow = ensureOtpFlow();
+resetOtpFlow();
+
+confirmElements.proceedBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+
+  if (otpState !== 'active') {
+    activateOtpFlow();
+    return;
+  }
+
+  if (!confirmElements.proceedBtn || confirmElements.proceedBtn.disabled) {
+    return;
+  }
+
+  const otpValue = otpFlow.getValue();
+  if (otpValue.length < otpElements.inputs.length) {
+    showOtpError('Masukkan kode OTP lengkap.');
+    confirmElements.proceedBtn.disabled = true;
+    return;
+  }
+
+  if (typeof pendingNewLimit !== 'number' || Number.isNaN(pendingNewLimit)) {
+    closeConfirmSheet({ immediate: true });
+    return;
+  }
+
+  hideOtpError();
+
+  const previousLimitValue = currentLimit;
+  const newLimitValue = pendingNewLimit;
+
+  console.log('OTP submitted:', otpValue);
+
+  closeConfirmSheet();
+  showPendingView(previousLimitValue, newLimitValue);
+});
+
+
+pendingCloseBtn?.addEventListener('click', (event) => {
+  event.preventDefault();
+  closeDrawer();
+});
+
+updateDisplays();

--- a/bottomsheet.js
+++ b/bottomsheet.js
@@ -1,0 +1,183 @@
+import { showOverlay, hideOverlay } from './overlay.js';
+
+const state = {
+  container: null,
+  sheet: null,
+  options: null,
+  closeButtons: [],
+  escHandler: null,
+};
+
+function resolveElement(target, fallbackSelector) {
+  if (!target && fallbackSelector) {
+    return document.querySelector(fallbackSelector);
+  }
+  if (typeof target === 'string') {
+    return document.querySelector(target);
+  }
+  return target || null;
+}
+
+function addCloseHandlers(container, selectors, closeFn) {
+  const result = [];
+  const unique = Array.from(new Set(selectors.filter(Boolean)));
+  unique.forEach((selectorOrEl) => {
+    let elements = [];
+    if (typeof selectorOrEl === 'string') {
+      elements = Array.from(container.querySelectorAll(selectorOrEl));
+    } else if (selectorOrEl instanceof Element) {
+      elements = [selectorOrEl];
+    }
+    elements.forEach((el) => {
+      const handler = (event) => {
+        event.preventDefault();
+        closeFn();
+      };
+      el.addEventListener('click', handler);
+      result.push({ el, handler });
+    });
+  });
+  return result;
+}
+
+function removeCloseHandlers() {
+  state.closeButtons.forEach(({ el, handler }) => {
+    el.removeEventListener('click', handler);
+  });
+  state.closeButtons = [];
+}
+
+function bindEscHandler() {
+  state.escHandler = (event) => {
+    if (event.key === 'Escape') {
+      closeBottomSheet();
+    }
+  };
+  document.addEventListener('keydown', state.escHandler);
+}
+
+function removeEscHandler() {
+  if (!state.escHandler) return;
+  document.removeEventListener('keydown', state.escHandler);
+  state.escHandler = null;
+}
+
+function applyAnimation(sheet, { openDuration = 250, closeDuration = 200 } = {}) {
+  sheet.style.transition = `transform ${openDuration}ms ease, opacity ${openDuration}ms ease`;
+  sheet.style.transform = 'translateY(100%)';
+  sheet.style.opacity = '0';
+}
+
+function playOpenAnimation(sheet, { openDuration = 250 } = {}) {
+  sheet.style.transitionDuration = `${openDuration}ms`;
+  requestAnimationFrame(() => {
+    sheet.style.transform = 'translateY(0)';
+    sheet.style.opacity = '1';
+  });
+}
+
+function playCloseAnimation(sheet, { closeDuration = 200 } = {}) {
+  return new Promise((resolve) => {
+    sheet.style.transitionDuration = `${closeDuration}ms`;
+    sheet.style.transform = 'translateY(100%)';
+    sheet.style.opacity = '0';
+    const handle = () => {
+      sheet.removeEventListener('transitionend', handle);
+      resolve();
+    };
+    sheet.addEventListener('transitionend', handle);
+    setTimeout(handle, closeDuration + 50);
+  });
+}
+
+export async function openBottomSheet(options = {}) {
+  const sheet = resolveElement(options.sheet, '[data-bottom-sheet]');
+  if (!sheet) return null;
+
+  const container = resolveElement(options.container, sheet.parentElement);
+
+  await closeBottomSheet();
+
+  const {
+    closeSelectors = ['[data-bottom-sheet-close]'],
+    onOpen = null,
+    onClose = null,
+    focusTarget = null,
+    closeOnOverlay = true,
+    overlayClass = '',
+    overlayRoot = document.body,
+    animation = {},
+  } = options;
+
+  state.container = container;
+  state.sheet = sheet;
+  state.options = { onClose, focusTarget, animation };
+
+  applyAnimation(sheet, animation);
+
+  if (container) {
+    container.classList.remove('hidden');
+    container.setAttribute('aria-hidden', 'false');
+    container.style.pointerEvents = 'auto';
+  }
+
+  showOverlay({
+    className: overlayClass,
+    root: overlayRoot,
+    onClick: closeOnOverlay ? () => closeBottomSheet() : null,
+  });
+
+  state.closeButtons = addCloseHandlers(container || sheet, closeSelectors, closeBottomSheet);
+  bindEscHandler();
+
+  playOpenAnimation(sheet, animation);
+
+  if (typeof onOpen === 'function') {
+    onOpen({ sheet, container });
+  }
+
+  const focusEl = resolveElement(focusTarget, null);
+  if (focusEl) {
+    requestAnimationFrame(() => focusEl.focus());
+  }
+
+  return sheet;
+}
+
+export async function closeBottomSheet({ immediate = false } = {}) {
+  const { container, sheet, options } = state;
+  if (!sheet) return;
+
+  removeCloseHandlers();
+  removeEscHandler();
+
+  if (immediate) {
+    sheet.style.transitionDuration = '0ms';
+    sheet.style.transform = 'translateY(100%)';
+    sheet.style.opacity = '0';
+  } else {
+    await playCloseAnimation(sheet, options?.animation);
+  }
+
+  if (container) {
+    container.setAttribute('aria-hidden', 'true');
+    container.style.pointerEvents = 'none';
+    container.classList.add('hidden');
+  }
+
+  hideOverlay();
+
+  const onClose = options?.onClose;
+  if (typeof onClose === 'function') {
+    onClose({ sheet, container });
+  }
+
+  state.container = null;
+  state.sheet = null;
+  state.options = null;
+}
+
+export default {
+  openBottomSheet,
+  closeBottomSheet,
+};

--- a/drawer.js
+++ b/drawer.js
@@ -1,0 +1,192 @@
+import { showOverlay, hideOverlay } from './overlay.js';
+
+const DEFAULT_CLOSE_SELECTORS = ['[data-drawer-close]', '[data-close-drawer]'];
+const OPEN_CLASS = 'open';
+
+const state = {
+  drawer: null,
+  options: null,
+  closeButtons: [],
+  escHandler: null,
+  overlayActive: false,
+};
+
+function resolveElement(target, fallbackSelector) {
+  if (!target && fallbackSelector) {
+    return document.querySelector(fallbackSelector);
+  }
+  if (typeof target === 'string') {
+    return document.querySelector(target);
+  }
+  return target || null;
+}
+
+function setDrawerTitle(drawer, title, titleTarget) {
+  if (!title) return;
+  const titleEl = resolveElement(titleTarget, '[data-drawer-title]')
+    || drawer.querySelector('[data-drawer-title]')
+    || drawer.querySelector('#drawerTitle')
+    || drawer.querySelector('h2, h1');
+  if (titleEl) {
+    titleEl.textContent = title;
+  }
+}
+
+function setDrawerContent(drawer, content, contentTarget) {
+  if (content == null) return;
+  const contentEl = resolveElement(contentTarget, '[data-drawer-content]')
+    || drawer.querySelector('[data-drawer-content]')
+    || drawer.querySelector('#drawerContent');
+  if (!contentEl) return;
+
+  if (typeof content === 'string') {
+    contentEl.innerHTML = content;
+    return;
+  }
+
+  if (typeof content === 'function') {
+    const result = content(contentEl);
+    if (result instanceof Node) {
+      contentEl.innerHTML = '';
+      contentEl.appendChild(result);
+    }
+    return;
+  }
+
+  if (content instanceof Node) {
+    contentEl.innerHTML = '';
+    contentEl.appendChild(content);
+  }
+}
+
+function bindCloseTriggers(drawer, selectors = DEFAULT_CLOSE_SELECTORS) {
+  state.closeButtons = [];
+  const unique = Array.from(new Set(selectors.filter(Boolean)));
+  unique.forEach((selectorOrEl) => {
+    let elements = [];
+    if (typeof selectorOrEl === 'string') {
+      elements = Array.from(drawer.querySelectorAll(selectorOrEl));
+    } else if (selectorOrEl instanceof Element) {
+      elements = [selectorOrEl];
+    }
+
+    elements.forEach((el) => {
+      const handler = (event) => {
+        event.preventDefault();
+        closeDrawer();
+      };
+      el.addEventListener('click', handler);
+      state.closeButtons.push({ el, handler });
+    });
+  });
+}
+
+function removeCloseTriggers() {
+  state.closeButtons.forEach(({ el, handler }) => {
+    el.removeEventListener('click', handler);
+  });
+  state.closeButtons = [];
+}
+
+function bindEscHandler(closeOnEsc) {
+  if (!closeOnEsc) {
+    state.escHandler = null;
+    return;
+  }
+
+  state.escHandler = (event) => {
+    if (event.key === 'Escape') {
+      closeDrawer();
+    }
+  };
+  document.addEventListener('keydown', state.escHandler);
+}
+
+function removeEscHandler() {
+  if (!state.escHandler) return;
+  document.removeEventListener('keydown', state.escHandler);
+  state.escHandler = null;
+}
+
+export function openDrawer(options = {}) {
+  const drawer = resolveElement(options.drawer, '#drawer');
+  if (!drawer) return null;
+
+  closeDrawer();
+
+  const {
+    title = null,
+    content = null,
+    titleTarget = null,
+    contentTarget = null,
+    closeSelectors = DEFAULT_CLOSE_SELECTORS,
+    onOpen = null,
+    onClose = null,
+    focusTarget = null,
+    closeOnEsc = true,
+    overlay = false,
+    overlayClass = '',
+    overlayRoot = document.body,
+    closeOnOverlay = false,
+  } = options;
+
+  state.drawer = drawer;
+  state.options = { onClose, focusTarget };
+  state.overlayActive = Boolean(overlay);
+
+  setDrawerTitle(drawer, title, titleTarget);
+  setDrawerContent(drawer, content, contentTarget);
+  bindCloseTriggers(drawer, closeSelectors);
+  bindEscHandler(closeOnEsc);
+
+  if (overlay) {
+    showOverlay({
+      className: overlayClass,
+      root: overlayRoot,
+      onClick: closeOnOverlay ? () => closeDrawer() : null,
+    });
+  }
+
+  drawer.classList.add(OPEN_CLASS);
+  drawer.setAttribute('aria-hidden', 'false');
+
+  if (typeof onOpen === 'function') {
+    onOpen({ drawer });
+  }
+
+  const focusEl = resolveElement(focusTarget, null);
+  if (focusEl) {
+    requestAnimationFrame(() => focusEl.focus());
+  }
+
+  return drawer;
+}
+
+export function closeDrawer() {
+  const { drawer, overlayActive, options } = state;
+  if (!drawer) return;
+
+  drawer.classList.remove(OPEN_CLASS);
+  drawer.setAttribute('aria-hidden', 'true');
+
+  if (overlayActive) {
+    hideOverlay();
+  }
+
+  removeCloseTriggers();
+  removeEscHandler();
+
+  const onClose = options?.onClose;
+  if (typeof onClose === 'function') {
+    onClose({ drawer });
+  }
+
+  state.drawer = null;
+  state.options = null;
+  state.overlayActive = false;
+}
+
+export default {
+  openDrawer,
+  closeDrawer,
+};

--- a/filters.js
+++ b/filters.js
@@ -1,4 +1,15 @@
-(function() {
+export function initFilter(config = {}) {
+  const {
+    root = document,
+    defaults = {},
+    onChange = null,
+  } = config;
+
+  const scopeRoot = root instanceof Element ? root : document;
+  const defaultDateLabel = defaults.date || 'Semua tanggal';
+  const defaultCategoryLabel = defaults.category || 'Semua kategori';
+
+
   const MONTH_NAMES = [
     'Januari',
     'Februari',
@@ -115,7 +126,7 @@
     }
   }
 
-  const allFilters = document.querySelectorAll('.filter');
+  const allFilters = scopeRoot.querySelectorAll('.filter');
   let openPanel = null;
 
   allFilters.forEach(filter => {
@@ -182,10 +193,10 @@
     }
 
     if (isDate) {
-      defaultLabel = 'Tanggal';
+      defaultLabel = defaultDateLabel;
       filter.dataset.default = defaultLabel;
     } else if (!defaultLabel) {
-      defaultLabel = name || '';
+      defaultLabel = name || defaultCategoryLabel;
       if (defaultLabel) {
         filter.dataset.default = defaultLabel;
       }
@@ -435,7 +446,11 @@
     }
 
     function emitChange() {
-      document.dispatchEvent(new CustomEvent('filter-change', { detail: { groupId } }));
+      const detail = { groupId, filter, name, value: filter.dataset.applied || '' };
+      document.dispatchEvent(new CustomEvent('filter-change', { detail }));
+      if (typeof onChange === 'function') {
+        onChange(detail);
+      }
     }
 
     function getSelected() {
@@ -591,7 +606,7 @@
         Array.from(groupFilters).forEach(f => {
           f.dataset.applied = '';
           const span = f.querySelector('.filter-label');
-          span.textContent = f.dataset.default;
+          span.textContent = f.dataset.default || (f.dataset.filter === 'date' ? defaultDateLabel : defaultCategoryLabel);
           f.querySelectorAll('input').forEach(inp => {
             if (inp.type === 'radio' || inp.type === 'checkbox') inp.checked = false;
             else {
@@ -659,4 +674,10 @@
       }
     });
   });
-})();
+}
+
+if (typeof window !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    initFilter();
+  });
+}

--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
   </div>
 
   <script src="data/rekening-data.js"></script>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { openDrawer as showDrawer, closeDrawer as hideDrawer } from './ui-components.js';
+
 const accountSelect = document.getElementById('accountSelect');
 const balanceEl = document.getElementById('dashBalanceValue');
 const transactionListEl = document.getElementById('transactionList');
@@ -186,26 +188,33 @@ function updateDashboardLayout() {
 
 updateDashboardLayout();
 
-function openDrawer() {
+function handleDrawerOpen() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
-  drawer.classList.add('open');
-  updateDashboardLayout();
-  if (typeof window.sidebarCollapseForDrawer === 'function') {
-    window.sidebarCollapseForDrawer();
-  }
+  showDrawer({
+    drawer,
+    closeSelectors: ['#drawerCloseBtn'],
+    focusTarget: '#saveAksesBtn',
+    onOpen: () => {
+      updateDashboardLayout();
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    },
+    onClose: () => {
+      updateDashboardLayout();
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    },
+  });
 }
 
-function closeDrawer() {
-  drawer.classList.remove('open');
-  updateDashboardLayout();
-  if (typeof window.sidebarRestoreForDrawer === 'function') {
-    window.sidebarRestoreForDrawer();
-  }
+function handleDrawerClose() {
+  hideDrawer();
 }
 
-openBtn?.addEventListener('click', openDrawer);
-closeBtn?.addEventListener('click', closeDrawer);
+openBtn?.addEventListener('click', handleDrawerOpen);
 
 // Quick access configuration
 const aksesContainer = document.getElementById('aksesCepatContainer');
@@ -327,5 +336,5 @@ renderQuickAccess();
 saveBtn?.addEventListener('click', () => {
   selectedAkses = [...tempSelectedAkses];
   renderQuickAccess();
-  closeDrawer();
+  handleDrawerClose();
 });

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -931,7 +931,7 @@
   </div>
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
-  <script src="filters.js"></script>
+  <script type="module" src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
   <script src="mutasi.js"></script>

--- a/mutasi.html
+++ b/mutasi.html
@@ -504,7 +504,7 @@
 
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
-  <script src="filters.js"></script>
+  <script type="module" src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
   <script src="mutasi.js"></script>

--- a/otp.js
+++ b/otp.js
@@ -1,0 +1,323 @@
+const DEFAULT_DURATION = 30;
+const DEFAULT_COUNTDOWN_MESSAGE = 'Sesi akan berakhir dalam';
+const DEFAULT_EXPIRED_MESSAGE = 'Kode OTP kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.';
+
+function resolveElement(target) {
+  if (typeof target === 'string') {
+    return document.querySelector(target);
+  }
+  return target || null;
+}
+
+function formatTime(seconds) {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+export function createOtpFlow(config = {}) {
+  const {
+    container = null,
+    inputs: inputList = null,
+    inputsSelector = '.otp-input',
+    requestButton = null,
+    resendButton = null,
+    submitButton = null,
+    countdownElement = null,
+    countdownMessageElement = null,
+    timerElement = null,
+    errorElement = null,
+    duration = DEFAULT_DURATION,
+    countdownMessage = DEFAULT_COUNTDOWN_MESSAGE,
+    expiredMessage = DEFAULT_EXPIRED_MESSAGE,
+    autoSubmit = false,
+    onRequest = null,
+    onResend = null,
+    onValidate = null,
+    onSuccess = null,
+    onError = null,
+    onExpire = null,
+    onChange = null,
+  } = config;
+
+  const scope = container ? resolveElement(container) : document;
+  const inputs = Array.isArray(inputList) && inputList.length
+    ? inputList.map(resolveElement)
+    : Array.from(scope.querySelectorAll(inputsSelector));
+
+  const requestBtn = resolveElement(requestButton);
+  const resendBtn = resolveElement(resendButton);
+  const submitBtn = resolveElement(submitButton);
+  const countdownEl = resolveElement(countdownElement);
+  const countdownMsgEl = resolveElement(countdownMessageElement);
+  const timerEl = resolveElement(timerElement);
+  const errorEl = resolveElement(errorElement);
+
+  if (!inputs.length) {
+    throw new Error('createOtpFlow requires at least one input element.');
+  }
+
+  let intervalId = null;
+  let timeLeft = duration;
+  let locked = false;
+  let destroyed = false;
+
+  const defaultCountdownMessage = countdownMsgEl?.textContent?.trim() || countdownMessage;
+
+  function setTimerText(value) {
+    if (timerEl) {
+      timerEl.textContent = formatTime(value);
+    }
+  }
+
+  function showCountdownMessage(message) {
+    if (countdownEl) {
+      countdownEl.classList.toggle('hidden', !message);
+    }
+    if (countdownMsgEl) {
+      countdownMsgEl.textContent = message || '';
+    }
+  }
+
+  function setError(message) {
+    if (!errorEl) return;
+    if (message) {
+      errorEl.textContent = message;
+      errorEl.classList.remove('hidden');
+    } else {
+      errorEl.textContent = '';
+      errorEl.classList.add('hidden');
+    }
+  }
+
+  function setResendVisible(visible) {
+    if (!resendBtn) return;
+    resendBtn.classList.toggle('hidden', !visible);
+    resendBtn.disabled = !visible;
+  }
+
+  function stopTimer() {
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+
+  function expire() {
+    stopTimer();
+    showCountdownMessage(expiredMessage);
+    if (timerEl) {
+      timerEl.classList.add('hidden');
+    }
+    setResendVisible(true);
+    locked = true;
+    if (typeof onExpire === 'function') {
+      onExpire();
+    }
+  }
+
+  function startTimer() {
+    stopTimer();
+    locked = false;
+    timeLeft = duration;
+    setTimerText(timeLeft);
+    if (timerEl) {
+      timerEl.classList.remove('hidden');
+    }
+    showCountdownMessage(defaultCountdownMessage);
+    setResendVisible(false);
+    intervalId = setInterval(() => {
+      timeLeft -= 1;
+      if (timeLeft <= 0) {
+        expire();
+        return;
+      }
+      setTimerText(timeLeft);
+    }, 1000);
+  }
+
+  function clearInputs() {
+    inputs.forEach((input) => {
+      input.value = '';
+    });
+  }
+
+  function focusFirstInput() {
+    const first = inputs.find((input) => input && !input.disabled);
+    if (first) {
+      first.focus();
+      first.select?.();
+    }
+  }
+
+  function getValue() {
+    return inputs.map((input) => (input.value || '').trim()).join('');
+  }
+
+  function updateSubmitState() {
+    const value = getValue();
+    const filled = value.length === inputs.length;
+    if (submitBtn) {
+      submitBtn.disabled = !filled;
+    }
+    if (typeof onChange === 'function') {
+      onChange({ value, filled });
+    }
+    if (autoSubmit && filled) {
+      submit();
+    }
+  }
+
+  function handleInput(event) {
+    const input = event.target;
+    const value = input.value.replace(/\D+/g, '');
+    input.value = value.slice(-1);
+
+    const index = inputs.indexOf(input);
+    if (value && index < inputs.length - 1) {
+      inputs[index + 1].focus();
+      inputs[index + 1].select?.();
+    }
+    updateSubmitState();
+  }
+
+  function handleKeyDown(event) {
+    const input = event.target;
+    const index = inputs.indexOf(input);
+    if (event.key === 'Backspace' && !input.value && index > 0) {
+      inputs[index - 1].focus();
+      inputs[index - 1].select?.();
+    }
+  }
+
+  function attachInputHandlers() {
+    inputs.forEach((input) => {
+      input.addEventListener('input', handleInput);
+      input.addEventListener('keydown', handleKeyDown);
+      input.addEventListener('focus', () => input.select?.());
+    });
+  }
+
+  function detachInputHandlers() {
+    inputs.forEach((input) => {
+      input.removeEventListener('input', handleInput);
+      input.removeEventListener('keydown', handleKeyDown);
+    });
+  }
+
+  async function requestOtp(triggerType) {
+    if (locked) return;
+    setError('');
+    clearInputs();
+    focusFirstInput();
+
+    const handler = triggerType === 'resend' ? onResend : onRequest;
+    if (typeof handler === 'function') {
+      try {
+        await handler();
+      } catch (error) {
+        setError(error?.message || 'Gagal meminta kode OTP.');
+        return;
+      }
+    }
+
+    startTimer();
+  }
+
+  async function submit() {
+    if (locked) {
+      setError(expiredMessage);
+      if (typeof onError === 'function') {
+        onError(new Error('expired'), getValue());
+      }
+      return false;
+    }
+
+    const value = getValue();
+    if (value.length < inputs.length) {
+      const error = new Error('Masukkan kode OTP lengkap.');
+      setError(error.message);
+      if (typeof onError === 'function') {
+        onError(error, value);
+      }
+      return false;
+    }
+
+    if (typeof onValidate === 'function') {
+      try {
+        const result = await onValidate(value);
+        if (result === false) {
+          throw new Error('Kode OTP tidak valid.');
+        }
+        if (typeof onSuccess === 'function') {
+          onSuccess(value, result);
+        }
+        return true;
+      } catch (error) {
+        setError(error?.message || 'Kode OTP tidak valid.');
+        if (typeof onError === 'function') {
+          onError(error, value);
+        }
+        return false;
+      }
+    }
+
+    if (typeof onSuccess === 'function') {
+      onSuccess(value);
+    }
+    return true;
+  }
+
+  function destroy() {
+    destroyed = true;
+    stopTimer();
+    detachInputHandlers();
+    requestBtn?.removeEventListener('click', requestClickHandler);
+    resendBtn?.removeEventListener('click', resendClickHandler);
+    submitBtn?.removeEventListener('click', submitClickHandler);
+  }
+
+  const requestClickHandler = (event) => {
+    event.preventDefault();
+    requestOtp('request');
+  };
+  const resendClickHandler = (event) => {
+    event.preventDefault();
+    requestOtp('resend');
+  };
+  const submitClickHandler = async (event) => {
+    event.preventDefault();
+    await submit();
+  };
+
+  attachInputHandlers();
+  updateSubmitState();
+
+  if (requestBtn) requestBtn.addEventListener('click', requestClickHandler);
+  if (resendBtn) resendBtn.addEventListener('click', resendClickHandler);
+  if (submitBtn) submitBtn.addEventListener('click', submitClickHandler);
+
+  return {
+    start: () => requestOtp('request'),
+    resend: () => requestOtp('resend'),
+    submit,
+    stop: stopTimer,
+    reset: () => {
+      stopTimer();
+      clearInputs();
+      setError('');
+      setResendVisible(false);
+      if (timerEl) timerEl.classList.add('hidden');
+      if (countdownEl) countdownEl.classList.add('hidden');
+    },
+    getValue,
+    focus: focusFirstInput,
+    setError,
+    destroy,
+    isDestroyed: () => destroyed,
+  };
+}
+
+export default {
+  createOtpFlow,
+};

--- a/overlay.js
+++ b/overlay.js
@@ -1,0 +1,101 @@
+const OVERLAY_ID = 'ambis-ui-overlay';
+
+let cachedOverlay = null;
+let cachedClickHandler = null;
+let cachedOptions = null;
+
+function resolveOverlayElement(existing) {
+  if (existing) {
+    cachedOverlay = existing;
+    return existing;
+  }
+
+  if (cachedOverlay && cachedOverlay.isConnected) {
+    return cachedOverlay;
+  }
+
+  const overlay = document.createElement('div');
+  overlay.id = OVERLAY_ID;
+  overlay.style.position = 'fixed';
+  overlay.style.inset = '0';
+  overlay.style.backgroundColor = 'rgba(15, 23, 42, 0.35)';
+  overlay.style.opacity = '0';
+  overlay.style.pointerEvents = 'none';
+  overlay.style.transition = 'opacity 200ms ease';
+  overlay.style.zIndex = '40';
+  overlay.setAttribute('aria-hidden', 'true');
+
+  cachedOverlay = overlay;
+  return overlay;
+}
+
+function cleanupOverlayClick() {
+  if (!cachedOverlay || !cachedClickHandler) return;
+  cachedOverlay.removeEventListener('click', cachedClickHandler);
+  cachedClickHandler = null;
+}
+
+export function showOverlay(options = {}) {
+  const {
+    onClick = null,
+    className = '',
+    existing = null,
+    root = document.body,
+    zIndex = 40,
+  } = options;
+
+  const overlay = resolveOverlayElement(existing);
+  cachedOptions = { root };
+
+  if (!overlay.isConnected) {
+    root.appendChild(overlay);
+  }
+
+  overlay.style.zIndex = String(zIndex);
+  overlay.style.pointerEvents = 'auto';
+  overlay.setAttribute('aria-hidden', 'false');
+
+  if (className) {
+    overlay.className = className;
+  }
+
+  if (onClick) {
+    cleanupOverlayClick();
+    cachedClickHandler = onClick;
+    overlay.addEventListener('click', cachedClickHandler);
+  }
+
+  requestAnimationFrame(() => {
+    overlay.style.opacity = '1';
+  });
+
+  return overlay;
+}
+
+export function hideOverlay() {
+  if (!cachedOverlay) return;
+
+  cleanupOverlayClick();
+
+  cachedOverlay.style.opacity = '0';
+  cachedOverlay.style.pointerEvents = 'none';
+  cachedOverlay.setAttribute('aria-hidden', 'true');
+
+  const overlay = cachedOverlay;
+  const { root = document.body } = cachedOptions || {};
+  cachedOptions = null;
+
+  const removeOverlay = () => {
+    overlay.removeEventListener('transitionend', removeOverlay);
+    if (overlay.parentElement === root) {
+      root.removeChild(overlay);
+    }
+  };
+
+  overlay.addEventListener('transitionend', removeOverlay);
+  setTimeout(removeOverlay, 220);
+}
+
+export function getOverlayElement() {
+  return cachedOverlay;
+}

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -447,7 +447,7 @@
   </div>
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
-  <script src="filters.js"></script>
+  <script type="module" src="filters.js"></script>
   <script src="persetujuan-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/ui-components.js
+++ b/ui-components.js
@@ -1,0 +1,13 @@
+export { openDrawer, closeDrawer } from './drawer.js';
+export { openBottomSheet, closeBottomSheet } from './bottomsheet.js';
+export { initFilter } from './filters.js';
+export { createOtpFlow } from './otp.js';
+
+export default {
+  openDrawer,
+  closeDrawer,
+  openBottomSheet,
+  closeBottomSheet,
+  initFilter,
+  createOtpFlow,
+};


### PR DESCRIPTION
## Summary
- add standalone drawer, bottom sheet, overlay, and OTP utility modules with a shared ui-components entry point
- convert the filter utilities into an ES module and auto-initialize filters on page load
- update dashboard and limit-management flows to use the new helpers and wire up module scripts across affected pages

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d749f4ec788330998291c51ab9b079