### PR TITLE
Use bottom sheet module for limit confirmation

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -188,17 +188,18 @@
     <!-- ============ /MAIN ============ -->
 
     <!-- Drawer -->
-    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100">
+    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100" aria-hidden="true">
       <div class="flex items-start justify-between gap-4 border-b px-6 py-5">
         <div>
-          <h2 class="text-xl font-semibold">Ubah Batas Transaksi Harian</h2>
+          <h2 class="text-xl font-semibold" data-drawer-title>Ubah Batas Transaksi Harian</h2>
         </div>
-        <button type="button" id="limitDrawerCloseBtn" class="text-2xl leading-none" aria-label="Tutup">
+        <button type="button" id="limitDrawerCloseBtn" class="text-2xl leading-none" aria-label="Tutup" data-drawer-close>
           &times;
         </button>
       </div>
 
-      <div id="limitFormSection" class="flex-1 flex flex-col">
+        <div data-drawer-content class="relative flex-1 flex flex-col">
+          <div id="limitFormSection" class="flex-1 flex flex-col">
         <div class="flex-1 overflow-y-auto px-6 py-6 space-y-6">
           <div class="space-y-2">
             <label class="block text-sm text-slate-500">Batas Transaksi Harian Maksimum</label>
@@ -231,7 +232,7 @@
         </div>
       </div>
 
-      <div id="limitPendingSection" class="hidden flex-1 flex-col">
+          <div id="limitPendingSection" class="hidden flex-1 flex-col">
         <div class="flex-1 overflow-y-auto px-6 py-6 h-full">
           <div class="flex flex-col items-center text-center gap-4">
             <img src="img/illustration-2.svg" alt="Menunggu persetujuan" class="w-16 h-auto" />
@@ -260,102 +261,89 @@
         </div>
       </div>
 
-      <div id="limitConfirmContainer" class="pointer-events-none absolute inset-0">
-        <div
-          id="limitConfirmOverlay"
-          class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"
-        ></div>
-        <div
-          id="limitConfirmSheet"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="limitConfirmTitle"
-          aria-hidden="true"
-          class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto"
-        >
-          <div class="sticky top-0 p-4 pb-4 border-b border-slate-200 bg-white rounded-t-3xl text-center">
-            <h3 id="limitConfirmTitle" class="text-base font-semibold text-slate-900">Konfirmasi Ubah Batas Transaksi Harian</h3>
-          </div>
-
-          <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
-            <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
-              <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
-              <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
-            </div>
-
-            <section class="space-y-4">
-              <p class="text-sm font-semibold text-slate-900">Ubah Batas Transaksi</p>
-              <dl class="mt-3 space-y-4 text-sm">
-                <!-- Row 1 -->
-                <div class="flex items-baseline justify-between">
-                  <dt class="text-slate-600">Batas Transaksi Harian Sebelumnya</dt>
-                  <dd id="limitConfirmPreviousValue" class="text-base font-semibold text-slate-900">
-                    Rp200.000.000
-                  </dd>
-                </div>
-              
-                <!-- Row 2 -->
-                <div class="flex items-baseline justify-between">
-                  <dt class="text-slate-600">Perubahan Batas Transaksi Harian Baru</dt>
-                  <dd id="limitConfirmNewValue" class="text-base font-semibold text-slate-900">
-                    Rp100.000.000
-                  </dd>
-                </div>
-              </dl>
-            </section>
-
-            <div id="limitOtpSection" class="hidden border-t border-slate-200 pt-6 space-y-4">
-              <div class="space-y-2 text-center">
-                <h4 class="text-base font-semibold text-slate-900">Masukkan Kode OTP</h4>
-                <p class="text-sm text-slate-600">Silakan login & cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi. </p>
-              </div>
-
-              <div class="flex justify-center gap-2">
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-              </div>
-
-              <div id="limitOtpCountdown" class="text-sm text-slate-500 text-center">
-                <span id="limitOtpCountdownMessage">Sesi akan berakhir dalam</span>
-                <span id="limitOtpTimer" class="ml-1 text-cyan-500 font-semibold">00:30</span>
-              </div>
-
-              <button
-                id="limitOtpResend"
-                type="button"
-                class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50"
-              >
-                Kirim Ulang Kode OTP
-              </button>
-
-              <p id="limitOtpError" class="hidden text-center text-sm text-rose-600"></p>
-            </div>
-          </div>
-
-          <div class="sticky bottom-0 border-t border-slate-200 bg-white p-4 flex flex-col gap-3 sm:flex-row">
-            <button
-              type="button"
-              id="limitConfirmCancelBtn"
-              class="w-full rounded-xl border border-slate-300 text-slate-700 font-semibold py-3 hover:bg-slate-50"
+          <template id="limitConfirmTemplate">
+            <div
+              role="dialog"
+              aria-modal="true"
+              data-bottom-sheet
+              class="w-full max-w-md bg-white rounded-t-3xl shadow-2xl flex flex-col"
             >
-              Batal
-            </button>
-            <button
-              type="button"
-              id="limitConfirmProceedBtn"
-              class="w-full rounded-xl bg-cyan-600 text-white font-semibold py-3 hover:bg-cyan-700"
-            >
-              Lanjut Ubah Batas Transaksi
-            </button>
-          </div>
-        </div>
-      </div>
+              <div class="sticky top-0 p-4 pb-4 border-b border-slate-200 bg-white rounded-t-3xl text-center">
+                <h3 class="text-base font-semibold text-slate-900" data-limit-confirm-title>Konfirmasi Ubah Batas Transaksi Harian</h3>
+              </div>
+
+              <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
+                <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+                  <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
+                  <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
+                </div>
+
+                <section class="space-y-4">
+                  <p class="text-sm font-semibold text-slate-900">Ubah Batas Transaksi</p>
+                  <dl class="mt-3 space-y-4 text-sm">
+                    <div class="flex items-baseline justify-between">
+                      <dt class="text-slate-600">Batas Transaksi Harian Sebelumnya</dt>
+                      <dd data-limit-confirm-previous class="text-base font-semibold text-slate-900">Rp200.000.000</dd>
+                    </div>
+                    <div class="flex items-baseline justify-between">
+                      <dt class="text-slate-600">Perubahan Batas Transaksi Harian Baru</dt>
+                      <dd data-limit-confirm-new class="text-base font-semibold text-slate-900">Rp100.000.000</dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <div data-limit-otp-section class="hidden border-t border-slate-200 pt-6 space-y-4">
+                  <div class="space-y-2 text-center">
+                    <h4 class="text-base font-semibold text-slate-900">Masukkan Kode OTP</h4>
+                    <p class="text-sm text-slate-600">Silakan login & cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi. </p>
+                  </div>
+
+                  <div class="flex justify-center gap-2">
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                    <input data-limit-otp-input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+                  </div>
+
+                  <div data-limit-otp-countdown class="text-sm text-slate-500 text-center">
+                    <span data-limit-otp-countdown-message>Sesi akan berakhir dalam</span>
+                    <span data-limit-otp-timer class="ml-1 text-cyan-500 font-semibold">00:30</span>
+                  </div>
+
+                  <button
+                    data-limit-otp-resend
+                    type="button"
+                    class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50"
+                  >
+                    Kirim Ulang Kode OTP
+                  </button>
+
+                  <p data-limit-otp-error class="hidden text-center text-sm text-rose-600"></p>
+                </div>
+              </div>
+
+              <div class="sticky bottom-0 border-t border-slate-200 bg-white p-4 flex flex-col gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  data-limit-confirm-cancel
+                  class="w-full rounded-xl border border-slate-300 text-slate-700 font-semibold py-3 hover:bg-slate-50"
+                >
+                  Batal
+                </button>
+                <button
+                  type="button"
+                  data-limit-confirm-proceed
+                  class="w-full rounded-xl bg-cyan-600 text-white font-semibold py-3 hover:bg-cyan-700"
+                >
+                  Konfirmasi
+                </button>
+              </div>
+            </div>
+          </template>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- replace the inline limit confirmation markup with a reusable template rendered through the shared bottom sheet module
- update the transaction limit confirmation flow to rely on openBottomSheet callbacks, including OTP handling and success cleanup that closes the drawer
- persist the new limit and refresh success feedback when the confirmation completes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d76992bba08330a9282bb49a81bdf5