### PR TITLE
Refactor limit change confirmation to bottom sheet

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -261,11 +261,11 @@
         </div>
       </div>
 
-          <div id="limitConfirmContainer" class="pointer-events-none absolute inset-0">
-        <div
-          id="limitConfirmOverlay"
-          class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"
-        ></div>
+      <div
+        id="limitConfirmContainer"
+        class="hidden pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      >
         <div
           id="limitConfirmSheet"
           role="dialog"

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -27,7 +27,6 @@ const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
 const successMessageEl = document.getElementById('limitSuccessMessage');
 const confirmElements = {
   container: document.getElementById('limitConfirmContainer'),
-  overlay: document.getElementById('limitConfirmOverlay'),
   sheet: document.getElementById('limitConfirmSheet'),
   previousValue: document.getElementById('limitConfirmPreviousValue'),
   newValue: document.getElementById('limitConfirmNewValue'),
@@ -312,7 +311,7 @@ function validateInput() {
 }
 
 async function openConfirmSheet(newLimitValue) {
-  const { container, overlay, sheet, previousValue, newValue } = confirmElements;
+  const { container, sheet, previousValue, newValue } = confirmElements;
   if (!sheet) return;
 
   pendingNewLimit = newLimitValue;
@@ -325,10 +324,6 @@ async function openConfirmSheet(newLimitValue) {
   }
   if (newValue) {
     newValue.textContent = formatCurrency(newLimitValue);
-  }
-
-  if (overlay) {
-    overlay.classList.add('hidden');
   }
 
   await openBottomSheet({
@@ -348,7 +343,7 @@ async function openConfirmSheet(newLimitValue) {
 }
 
 async function closeConfirmSheet(options = {}) {
-  const { container, overlay, sheet } = confirmElements;
+  const { container, sheet } = confirmElements;
   if (!sheet) return;
   if (!confirmSheetOpen && !options.force) return;
 
@@ -358,9 +353,6 @@ async function closeConfirmSheet(options = {}) {
 
   await closeBottomSheet({ immediate: Boolean(options.immediate) });
 
-  if (overlay) {
-    overlay.classList.add('hidden');
-  }
   container?.classList.add('pointer-events-none');
 }
 


### PR DESCRIPTION
## Summary
- switch the limit change confirmation dialog to use the shared bottom sheet module
- remove the standalone overlay element while keeping existing content and styling intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7759ec02c83309ef0c14ac9997acf