### PR TITLE
Adjust limit confirmation bottom sheet behavior

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -261,11 +261,11 @@
         </div>
       </div>
 
-          <div id="limitConfirmContainer" class="pointer-events-none absolute inset-0">
-        <div
-          id="limitConfirmOverlay"
-          class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"
-        ></div>
+      <div
+        id="limitConfirmContainer"
+        class="hidden pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      >
         <div
           id="limitConfirmSheet"
           role="dialog"

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -27,7 +27,6 @@ const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
 const successMessageEl = document.getElementById('limitSuccessMessage');
 const confirmElements = {
   container: document.getElementById('limitConfirmContainer'),
-  overlay: document.getElementById('limitConfirmOverlay'),
   sheet: document.getElementById('limitConfirmSheet'),
   previousValue: document.getElementById('limitConfirmPreviousValue'),
   newValue: document.getElementById('limitConfirmNewValue'),
@@ -60,6 +59,8 @@ let currentLimit = 150_000_000;
 let pendingNewLimit = null;
 let confirmSheetOpen = false;
 let successTimer = null;
+let drawerTransitionDisabled = false;
+let drawerPreviousTransition = '';
 
 try {
   const stored = localStorage.getItem(STORAGE_KEY);
@@ -195,6 +196,20 @@ function hideOtpError() {
   ensureOtpFlow().setError('');
 }
 
+function disableDrawerTransition() {
+  if (!drawer || drawerTransitionDisabled) return;
+  drawerPreviousTransition = drawer.style.transition;
+  drawer.style.transition = 'none';
+  drawerTransitionDisabled = true;
+}
+
+function restoreDrawerTransition() {
+  if (!drawer || !drawerTransitionDisabled) return;
+  drawer.style.transition = drawerPreviousTransition || '';
+  drawerPreviousTransition = '';
+  drawerTransitionDisabled = false;
+}
+
 function activateOtpFlow() {
   const flow = ensureOtpFlow();
   if (otpState === 'active') return flow;
@@ -312,7 +327,7 @@ function validateInput() {
 }
 
 async function openConfirmSheet(newLimitValue) {
-  const { container, overlay, sheet, previousValue, newValue } = confirmElements;
+  const { container, sheet, previousValue, newValue } = confirmElements;
   if (!sheet) return;
 
   pendingNewLimit = newLimitValue;
@@ -327,28 +342,31 @@ async function openConfirmSheet(newLimitValue) {
     newValue.textContent = formatCurrency(newLimitValue);
   }
 
-  if (overlay) {
-    overlay.classList.add('hidden');
-  }
-
   await openBottomSheet({
     container,
     sheet,
     closeSelectors: ['#limitConfirmCancelBtn'],
     focusTarget: '#limitConfirmProceedBtn',
+    overlayRoot: container || drawer,
     onOpen: () => {
       confirmSheetOpen = true;
+      disableDrawerTransition();
+      container?.classList.remove('pointer-events-none');
+      container?.setAttribute('aria-hidden', 'false');
     },
     onClose: () => {
       confirmSheetOpen = false;
       pendingNewLimit = null;
       resetOtpFlow();
+      restoreDrawerTransition();
+      container?.classList.add('pointer-events-none');
+      container?.setAttribute('aria-hidden', 'true');
     },
   });
 }
 
 async function closeConfirmSheet(options = {}) {
-  const { container, overlay, sheet } = confirmElements;
+  const { container, sheet } = confirmElements;
   if (!sheet) return;
   if (!confirmSheetOpen && !options.force) return;
 
@@ -358,10 +376,9 @@ async function closeConfirmSheet(options = {}) {
 
   await closeBottomSheet({ immediate: Boolean(options.immediate) });
 
-  if (overlay) {
-    overlay.classList.add('hidden');
-  }
   container?.classList.add('pointer-events-none');
+  container?.setAttribute('aria-hidden', 'true');
+  restoreDrawerTransition();
 }
 
 function openLimitDrawer() {

--- a/overlay.js
+++ b/overlay.js
@@ -51,6 +51,10 @@ export function showOverlay(options = {}) {
     root.appendChild(overlay);
   }
 
+  const isDocumentRoot = root === document.body || root === document.documentElement;
+  overlay.style.position = isDocumentRoot ? 'fixed' : 'absolute';
+  overlay.style.inset = '0';
+
   overlay.style.zIndex = String(zIndex);
   overlay.style.pointerEvents = 'auto';
   overlay.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- ensure the limit confirmation bottom sheet overlay renders within the drawer container for proper scoping
- disable drawer width transitions while the confirmation sheet is visible so the drawer stays static

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7759ec02c83309ef0c14ac9997acf