### PR TITLE
Adjust limit confirmation bottom sheet layering

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -261,101 +261,101 @@
         </div>
       </div>
 
-          <div id="limitConfirmContainer" class="pointer-events-none absolute inset-0">
-        <div
-          id="limitConfirmOverlay"
-          class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"
-        ></div>
-        <div
-          id="limitConfirmSheet"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="limitConfirmTitle"
-          aria-hidden="true"
-          class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto"
-        >
-          <div class="sticky top-0 p-4 pb-4 border-b border-slate-200 bg-white rounded-t-3xl text-center">
-            <h3 id="limitConfirmTitle" class="text-base font-semibold text-slate-900">Konfirmasi Ubah Batas Transaksi Harian</h3>
+    </div>
+
+    <div
+      id="limitConfirmContainer"
+      class="hidden pointer-events-none absolute inset-0"
+      aria-hidden="true"
+    >
+      <div
+        id="limitConfirmSheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="limitConfirmTitle"
+        aria-hidden="true"
+        class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto"
+      >
+        <div class="sticky top-0 p-4 pb-4 border-b border-slate-200 bg-white rounded-t-3xl text-center">
+          <h3 id="limitConfirmTitle" class="text-base font-semibold text-slate-900">Konfirmasi Ubah Batas Transaksi Harian</h3>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
+          <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+            <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
+            <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
           </div>
 
-          <div class="flex-1 overflow-y-auto px-4 py-6 space-y-6">
-            <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
-              <img class="w-6 h-6" src="img/icon/info-2.svg" alt="Informasi">
-              <p class="text-sm leading-relaxed">Mohon pastikan data sudah sesuai</p>
+          <section class="space-y-4">
+            <p class="text-sm font-semibold text-slate-900">Ubah Batas Transaksi</p>
+            <dl class="mt-3 space-y-4 text-sm">
+              <!-- Row 1 -->
+              <div class="flex items-baseline justify-between">
+                <dt class="text-slate-600">Batas Transaksi Harian Sebelumnya</dt>
+                <dd id="limitConfirmPreviousValue" class="text-base font-semibold text-slate-900">
+                  Rp200.000.000
+                </dd>
+              </div>
+
+              <!-- Row 2 -->
+              <div class="flex items-baseline justify-between">
+                <dt class="text-slate-600">Perubahan Batas Transaksi Harian Baru</dt>
+                <dd id="limitConfirmNewValue" class="text-base font-semibold text-slate-900">
+                  Rp100.000.000
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <div id="limitOtpSection" class="hidden border-t border-slate-200 pt-6 space-y-4">
+            <div class="space-y-2 text-center">
+              <h4 class="text-base font-semibold text-slate-900">Masukkan Kode OTP</h4>
+              <p class="text-sm text-slate-600">Silakan login & cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi. </p>
             </div>
 
-            <section class="space-y-4">
-              <p class="text-sm font-semibold text-slate-900">Ubah Batas Transaksi</p>
-              <dl class="mt-3 space-y-4 text-sm">
-                <!-- Row 1 -->
-                <div class="flex items-baseline justify-between">
-                  <dt class="text-slate-600">Batas Transaksi Harian Sebelumnya</dt>
-                  <dd id="limitConfirmPreviousValue" class="text-base font-semibold text-slate-900">
-                    Rp200.000.000
-                  </dd>
-                </div>
-              
-                <!-- Row 2 -->
-                <div class="flex items-baseline justify-between">
-                  <dt class="text-slate-600">Perubahan Batas Transaksi Harian Baru</dt>
-                  <dd id="limitConfirmNewValue" class="text-base font-semibold text-slate-900">
-                    Rp100.000.000
-                  </dd>
-                </div>
-              </dl>
-            </section>
-
-            <div id="limitOtpSection" class="hidden border-t border-slate-200 pt-6 space-y-4">
-              <div class="space-y-2 text-center">
-                <h4 class="text-base font-semibold text-slate-900">Masukkan Kode OTP</h4>
-                <p class="text-sm text-slate-600">Silakan login & cek aplikasi Amar Bank Bisnis pada handphone Anda untuk mendapatkan kode verifikasi. </p>
-              </div>
-
-              <div class="flex justify-center gap-2">
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-                <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
-              </div>
-
-              <div id="limitOtpCountdown" class="text-sm text-slate-500 text-center">
-                <span id="limitOtpCountdownMessage">Sesi akan berakhir dalam</span>
-                <span id="limitOtpTimer" class="ml-1 text-cyan-500 font-semibold">00:30</span>
-              </div>
-
-              <button
-                id="limitOtpResend"
-                type="button"
-                class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50"
-              >
-                Kirim Ulang Kode OTP
-              </button>
-
-              <p id="limitOtpError" class="hidden text-center text-sm text-rose-600"></p>
+            <div class="flex justify-center gap-2">
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-12 h-14 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
             </div>
-          </div>
 
-          <div class="sticky bottom-0 border-t border-slate-200 bg-white p-4 flex flex-col gap-3 sm:flex-row">
+            <div id="limitOtpCountdown" class="text-sm text-slate-500 text-center">
+              <span id="limitOtpCountdownMessage">Sesi akan berakhir dalam</span>
+              <span id="limitOtpTimer" class="ml-1 text-cyan-500 font-semibold">00:30</span>
+            </div>
+
             <button
+              id="limitOtpResend"
               type="button"
-              id="limitConfirmCancelBtn"
-              class="w-full rounded-xl border border-slate-300 text-slate-700 font-semibold py-3 hover:bg-slate-50"
+              class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-500 hover:bg-slate-50"
             >
-              Batal
+              Kirim Ulang Kode OTP
             </button>
-            <button
-              type="button"
-              id="limitConfirmProceedBtn"
-              class="w-full rounded-xl bg-cyan-600 text-white font-semibold py-3 hover:bg-cyan-700"
-            >
-              Lanjut Ubah Batas Transaksi
-            </button>
+
+            <p id="limitOtpError" class="hidden text-center text-sm text-rose-600"></p>
           </div>
-          </div>
+        </div>
+
+        <div class="sticky bottom-0 border-t border-slate-200 bg-white p-4 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            id="limitConfirmCancelBtn"
+            class="w-full rounded-xl border border-slate-300 text-slate-700 font-semibold py-3 hover:bg-slate-50"
+          >
+            Batal
+          </button>
+          <button
+            type="button"
+            id="limitConfirmProceedBtn"
+            class="w-full rounded-xl bg-cyan-600 text-white font-semibold py-3 hover:bg-cyan-700"
+          >
+            Lanjut Ubah Batas Transaksi
+          </button>
         </div>
       </div>
     </div>

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -27,7 +27,6 @@ const infoCloseBtn = document.getElementById('limitInfoCloseBtn');
 const successMessageEl = document.getElementById('limitSuccessMessage');
 const confirmElements = {
   container: document.getElementById('limitConfirmContainer'),
-  overlay: document.getElementById('limitConfirmOverlay'),
   sheet: document.getElementById('limitConfirmSheet'),
   previousValue: document.getElementById('limitConfirmPreviousValue'),
   newValue: document.getElementById('limitConfirmNewValue'),
@@ -60,6 +59,8 @@ let currentLimit = 150_000_000;
 let pendingNewLimit = null;
 let confirmSheetOpen = false;
 let successTimer = null;
+let drawerTransitionDisabled = false;
+let drawerPreviousTransition = '';
 
 try {
   const stored = localStorage.getItem(STORAGE_KEY);
@@ -195,6 +196,20 @@ function hideOtpError() {
   ensureOtpFlow().setError('');
 }
 
+function disableDrawerTransition() {
+  if (!drawer || drawerTransitionDisabled) return;
+  drawerPreviousTransition = drawer.style.transition;
+  drawer.style.transition = 'none';
+  drawerTransitionDisabled = true;
+}
+
+function restoreDrawerTransition() {
+  if (!drawer || !drawerTransitionDisabled) return;
+  drawer.style.transition = drawerPreviousTransition || '';
+  drawerPreviousTransition = '';
+  drawerTransitionDisabled = false;
+}
+
 function activateOtpFlow() {
   const flow = ensureOtpFlow();
   if (otpState === 'active') return flow;
@@ -312,7 +327,7 @@ function validateInput() {
 }
 
 async function openConfirmSheet(newLimitValue) {
-  const { container, overlay, sheet, previousValue, newValue } = confirmElements;
+  const { container, sheet, previousValue, newValue } = confirmElements;
   if (!sheet) return;
 
   pendingNewLimit = newLimitValue;
@@ -327,28 +342,31 @@ async function openConfirmSheet(newLimitValue) {
     newValue.textContent = formatCurrency(newLimitValue);
   }
 
-  if (overlay) {
-    overlay.classList.add('hidden');
-  }
-
   await openBottomSheet({
     container,
     sheet,
     closeSelectors: ['#limitConfirmCancelBtn'],
     focusTarget: '#limitConfirmProceedBtn',
+    useOverlay: false,
     onOpen: () => {
       confirmSheetOpen = true;
+      disableDrawerTransition();
+      container?.classList.remove('pointer-events-none');
+      container?.setAttribute('aria-hidden', 'false');
     },
     onClose: () => {
       confirmSheetOpen = false;
       pendingNewLimit = null;
       resetOtpFlow();
+      restoreDrawerTransition();
+      container?.classList.add('pointer-events-none');
+      container?.setAttribute('aria-hidden', 'true');
     },
   });
 }
 
 async function closeConfirmSheet(options = {}) {
-  const { container, overlay, sheet } = confirmElements;
+  const { container, sheet } = confirmElements;
   if (!sheet) return;
   if (!confirmSheetOpen && !options.force) return;
 
@@ -358,10 +376,9 @@ async function closeConfirmSheet(options = {}) {
 
   await closeBottomSheet({ immediate: Boolean(options.immediate) });
 
-  if (overlay) {
-    overlay.classList.add('hidden');
-  }
   container?.classList.add('pointer-events-none');
+  container?.setAttribute('aria-hidden', 'true');
+  restoreDrawerTransition();
 }
 
 function openLimitDrawer() {

--- a/bottomsheet.js
+++ b/bottomsheet.js
@@ -106,12 +106,13 @@ export async function openBottomSheet(options = {}) {
     closeOnOverlay = true,
     overlayClass = '',
     overlayRoot = document.body,
+    useOverlay = true,
     animation = {},
   } = options;
 
   state.container = container;
   state.sheet = sheet;
-  state.options = { onClose, focusTarget, animation };
+  state.options = { onClose, focusTarget, animation, useOverlay };
 
   applyAnimation(sheet, animation);
 
@@ -121,11 +122,13 @@ export async function openBottomSheet(options = {}) {
     container.style.pointerEvents = 'auto';
   }
 
-  showOverlay({
-    className: overlayClass,
-    root: overlayRoot,
-    onClick: closeOnOverlay ? () => closeBottomSheet() : null,
-  });
+  if (useOverlay) {
+    showOverlay({
+      className: overlayClass,
+      root: overlayRoot,
+      onClick: closeOnOverlay ? () => closeBottomSheet() : null,
+    });
+  }
 
   state.closeButtons = addCloseHandlers(container || sheet, closeSelectors, closeBottomSheet);
   bindEscHandler();
@@ -165,7 +168,9 @@ export async function closeBottomSheet({ immediate = false } = {}) {
     container.classList.add('hidden');
   }
 
-  hideOverlay();
+  if (options?.useOverlay) {
+    hideOverlay();
+  }
 
   const onClose = options?.onClose;
   if (typeof onClose === 'function') {

--- a/overlay.js
+++ b/overlay.js
@@ -51,6 +51,10 @@ export function showOverlay(options = {}) {
     root.appendChild(overlay);
   }
 
+  const isDocumentRoot = root === document.body || root === document.documentElement;
+  overlay.style.position = isDocumentRoot ? 'fixed' : 'absolute';
+  overlay.style.inset = '0';
+
   overlay.style.zIndex = String(zIndex);
   overlay.style.pointerEvents = 'auto';
   overlay.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- move the limit confirmation sheet container so it overlays the entire drawer, covering the header while still using the shared markup
- add a bottom sheet option to disable the overlay scrim and use it for the limit confirmation flow to keep the drawer visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7759ec02c83309ef0c14ac9997acf