### PR TITLE
Refactor bottom sheet to live inside drawer

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -262,9 +262,14 @@
       </div>
     <div
       id="limitConfirmContainer"
-      class="hidden pointer-events-none absolute inset-0"
+      class="hidden pointer-events-none absolute inset-0 z-50"
       aria-hidden="true"
     >
+      <div
+        data-bottom-sheet-overlay
+        class="absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity"
+        aria-hidden="true"
+      ></div>
       <div
         id="limitConfirmSheet"
         role="dialog"

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -28,6 +28,7 @@ const successMessageEl = document.getElementById('limitSuccessMessage');
 const confirmElements = {
   container: document.getElementById('limitConfirmContainer'),
   sheet: document.getElementById('limitConfirmSheet'),
+  overlay: document.querySelector('#limitConfirmContainer [data-bottom-sheet-overlay]'),
   previousValue: document.getElementById('limitConfirmPreviousValue'),
   newValue: document.getElementById('limitConfirmNewValue'),
   cancelBtn: document.getElementById('limitConfirmCancelBtn'),
@@ -345,6 +346,7 @@ async function openConfirmSheet(newLimitValue) {
   await openBottomSheet({
     container,
     sheet,
+    drawerRoot: drawer,
     closeSelectors: ['#limitConfirmCancelBtn'],
     focusTarget: '#limitConfirmProceedBtn',
     onOpen: () => {
@@ -499,12 +501,6 @@ document.addEventListener('keydown', (event) => {
 
 confirmElements.cancelBtn?.addEventListener('click', () => {
   closeConfirmSheet();
-});
-
-confirmElements.overlay?.addEventListener('click', (event) => {
-  if (event.target === confirmElements.overlay) {
-    closeConfirmSheet();
-  }
 });
 
 const otpFlow = ensureOtpFlow();


### PR DESCRIPTION
## Summary
- refactor the bottom sheet helper to manage its overlay inside the drawer context and ensure proper stacking
- add an in-drawer overlay element for the confirm sheet markup and wire the JS to use the drawer as the host
- clean up the batas-transaksi flow to rely on the refactored helper without manual overlay listeners

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d7906491808330851067e91c253e59