### PR TITLE
Align bottom sheet behavior with informasi rekening

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -272,6 +272,7 @@
       ></div>
       <div
         id="limitConfirmSheet"
+        data-bottom-sheet
         role="dialog"
         aria-modal="true"
         aria-labelledby="limitConfirmTitle"

--- a/biller.html
+++ b/biller.html
@@ -448,8 +448,8 @@
           </div>
         </div>
 
-      <div id="sheetOverlay" class="hidden absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity duration-200 z-10"></div>
-      <div id="bottomSheet" class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-3/4 z-20">
+      <div id="sheetOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity duration-200 z-10"></div>
+      <div id="bottomSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-3/4 z-20">
         <div class="p-4 border-b flex items-center justify-between">
           <h3 class="text-base font-semibold text-slate-900">Sumber Rekening</h3>
           <button id="sheetClose" type="button" class="text-2xl leading-none text-slate-500 hover:text-slate-700 focus:outline-none" aria-label="Tutup pilihan sumber rekening">&times;</button>
@@ -462,8 +462,8 @@
           <button id="sheetConfirm" type="button" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 text-sm font-semibold opacity-50 cursor-not-allowed focus:outline-none" disabled>Pilih</button>
         </div>
       </div>
-      <div id="savedSheetOverlay" class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-20"></div>
-      <div id="savedBottomSheet" class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-3/4 z-30">
+      <div id="savedSheetOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-20"></div>
+      <div id="savedBottomSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-3/4 z-30">
         <div class="relative flex items-center justify-center px-5 pt-5 pb-4 border-b border-slate-100">
           <h3 class="text-base font-semibold text-slate-900 text-center">Nomor Tersimpan</h3>
           <button id="savedSheetClose" type="button" class="absolute right-5 top-5 text-2xl leading-none text-slate-500 hover:text-slate-700 focus:outline-none" aria-label="Tutup pilihan nomor tersimpan">&times;</button>
@@ -477,8 +477,8 @@
           <button id="savedSheetConfirm" type="button" class="flex-1 rounded-xl bg-cyan-500 text-white py-3 text-sm font-semibold opacity-50 cursor-not-allowed" disabled>Pilih Nomor</button>
         </div>
       </div>
-      <div id="paymentSheetOverlay" class="hidden absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity duration-200 z-40"></div>
-      <div id="paymentBottomSheet" class="absolute inset-x-0 bottom-0 bg-white rounded-t-2xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-full z-50">
+      <div id="paymentSheetOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-slate-900/40 opacity-0 transition-opacity duration-200 z-40"></div>
+      <div id="paymentBottomSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 bg-white rounded-t-2xl shadow-xl translate-y-full transition-transform duration-200 max-h-full flex flex-col h-full z-50">
         <div class="p-4 pb-4 border-b border-slate-100">
           <div class="text-center justify-between">
             <h3 id="paymentSheetTitle" class="text-lg text-center font-semibold text-slate-900">Konfirmasi Pembayaran</h3>

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -282,8 +282,8 @@
         <button type="submit" id="confirmAddAccountBtn" form="addAccountForm" class="w-full rounded-xl bg-cyan-600 py-3 text-center font-semibold text-white transition hover:bg-cyan-700 disabled:opacity-50" disabled>Konfirmasi Tambah Rekening</button>
       </div>
       <div class="pointer-events-none absolute inset-0">
-        <div id="addAccountConfirmOverlay" class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"></div>
-        <div id="addAccountConfirmSheet" class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto">
+        <div id="addAccountConfirmOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-slate-900/30 opacity-0 transition-opacity duration-200 z-40 pointer-events-auto"></div>
+        <div id="addAccountConfirmSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 z-50 h-full bg-white rounded-t-3xl shadow-2xl translate-y-full transition-transform duration-300 flex flex-col pointer-events-auto">
           <div class="sticky top-0 p-4 pb-4 text-center border-b border-slate-200 bg-white rounded-t-3xl">
             <h3 class="text-base font-semibold">Konfirmasi Tambah Rekening</h3>
           </div>
@@ -770,10 +770,11 @@
           </div>
         </div>
 
-        <div id="mutasiDetailOverlay" class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
+        <div id="mutasiDetailOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
 
         <div
           id="mutasiDetailSheet"
+          data-bottom-sheet
           class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col overflow-hidden"
         >
           <div class="relative px-4 pt-6 pb-4 border-b border-slate-200">

--- a/mutasi.html
+++ b/mutasi.html
@@ -407,10 +407,11 @@
         </div>
       </div>
 
-      <div id="mutasiDetailOverlay" class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
+      <div id="mutasiDetailOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
 
       <div
         id="mutasiDetailSheet"
+        data-bottom-sheet
         class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col overflow-hidden"
       >
         <div class="relative px-4 pt-6 pb-4 border-b border-slate-200">

--- a/transfer.html
+++ b/transfer.html
@@ -397,8 +397,8 @@
       </div>
 
     <!-- Bottom Sheet Overlay & Panel -->
-    <div id="sheetOverlay" class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
-    <div id="bottomSheet" class="absolute inset-x-0 bottom-0 w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 h-3/4 z-20 flex flex-col">
+    <div id="sheetOverlay" data-bottom-sheet-overlay class="hidden absolute inset-0 bg-black/20 opacity-0 transition-opacity duration-200 z-10"></div>
+    <div id="bottomSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 w-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 h-3/4 z-20 flex flex-col">
       <div class="relative p-4 border-b">
         <h3 id="sheetTitle" class="text-base font-semibold">Sumber Rekening</h3>
         <button id="sheetClose" type="button" class="absolute top-4 right-4 text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup lembar bawah">&times;</button>
@@ -413,7 +413,7 @@
     </div>
 
     <!-- Destination Account Bottom Sheet -->
-    <div id="destSheet" class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
+    <div id="destSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
       <div class="relative p-4 border-b">
         <h3 class="text-base font-semibold">Daftar Rekening Tujuan</h3>
         <button id="destClose" type="button" class="absolute top-4 right-4 text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup lembar bawah">&times;</button>
@@ -474,7 +474,7 @@
     </div>
 
     <!-- Confirmation Bottom Sheet -->
-    <div id="confirmSheet" class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
+    <div id="confirmSheet" data-bottom-sheet class="absolute inset-x-0 bottom-0 w-full h-full bg-white rounded-t-2xl shadow-lg translate-y-full transition-transform duration-200 z-20 flex flex-col">
       <div class="relative px-4 pt-6 pb-4 text-center border-b">
         <h3 id="confirmTitle" class="text-lg font-semibold">Transfer Saldo</h3>
         <button id="confirmClose" type="button" class="absolute top-6 right-6 text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup lembar bawah">&times;</button>


### PR DESCRIPTION
## Summary
- update the bottom sheet module to preserve inline typography styles and respect existing overlay classes
- improve overlay fade handling to match the informasi-rekening implementation and restore original styles after close
- add `data-bottom-sheet` and `data-bottom-sheet-overlay` markers across pages so the shared module can manage every sheet consistently

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d79a681b488330b703c6e0acf6f6e6