### PR TITLE
Refactor UI logic into reusable modules

### DIFF
--- a/ui/bottomsheet.js
+++ b/ui/bottomsheet.js
@@ -1,0 +1,170 @@
+import { getOverlay, showOverlay, hideOverlay } from './overlay.js';
+
+const ACTIVE_CLASS = 'open';
+const ENTER_CLASSES = ['translate-y-0'];
+const EXIT_CLASSES = ['translate-y-full'];
+
+let activeSheet = null;
+
+function resolveSheet(target) {
+  if (target instanceof Element) return target;
+  if (typeof target === 'string') {
+    const el = document.querySelector(target);
+    if (!el) {
+      throw new Error(`Bottom sheet selector \"${target}\" did not match any element.`);
+    }
+    return el;
+  }
+  return null;
+}
+
+function bindCloseTargets(targets, handler) {
+  if (!targets) return () => {};
+  const list = Array.isArray(targets) ? targets : [targets];
+  const bindings = [];
+  list.filter(Boolean).forEach((target) => {
+    if (typeof target === 'string') {
+      document.querySelectorAll(target).forEach((el) => {
+        const listener = () => handler();
+        el.addEventListener('click', listener);
+        bindings.push({ el, listener });
+      });
+      return;
+    }
+    if (target instanceof Element) {
+      const listener = () => handler();
+      target.addEventListener('click', listener);
+      bindings.push({ el: target, listener });
+    }
+  });
+  return () => {
+    bindings.forEach(({ el, listener }) => el.removeEventListener('click', listener));
+  };
+}
+
+export function openBottomSheet(options = {}) {
+  const {
+    sheet,
+    overlayKey,
+    overlayContainer,
+    overlayClass,
+    overlayZIndex = 50,
+    closeSelectors,
+    onOpen,
+    onClose,
+    trapFocus = false,
+    initialFocus,
+  } = options;
+
+  const sheetEl = resolveSheet(sheet);
+  if (!sheetEl) {
+    throw new Error('openBottomSheet requires a valid sheet element.');
+  }
+
+  const overlay = getOverlay(overlayKey || sheetEl, {
+    container: overlayContainer || sheetEl.parentElement || document.body,
+    className: overlayClass,
+    zIndex: overlayZIndex,
+    clickHandler: () => closeBottomSheet(),
+  });
+
+  const previous = activeSheet;
+  if (previous && previous.sheetEl !== sheetEl) {
+    closeBottomSheet({ immediate: true });
+  }
+
+  const cleanup = bindCloseTargets(closeSelectors, () => closeBottomSheet());
+
+  sheetEl.classList.add(ACTIVE_CLASS);
+  sheetEl.classList.remove(...EXIT_CLASSES);
+  sheetEl.classList.add(...ENTER_CLASSES);
+  showOverlay(overlay);
+
+  const state = {
+    sheetEl,
+    overlay,
+    onClose,
+    cleanup,
+    trapFocus,
+    initialFocus,
+    focusTrapListeners: [],
+  };
+
+  if (trapFocus) {
+    const focusHandler = (event) => {
+      if (!sheetEl.contains(event.target)) {
+        const focusable = sheetEl.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0];
+        if (first) first.focus();
+      }
+    };
+    document.addEventListener('focusin', focusHandler);
+    state.focusTrapListeners.push(['focusin', focusHandler]);
+  }
+
+  activeSheet = state;
+
+  if (typeof onOpen === 'function') {
+    onOpen(state);
+  }
+
+  if (initialFocus instanceof Element) {
+    initialFocus.focus();
+  } else if (typeof initialFocus === 'string') {
+    sheetEl.querySelector(initialFocus)?.focus();
+  }
+
+  return state;
+}
+
+export function closeBottomSheet(options = {}) {
+  if (!activeSheet) return;
+  const { immediate = false } = options;
+  const {
+    sheetEl,
+    overlay,
+    onClose,
+    cleanup,
+    trapFocus,
+    focusTrapListeners,
+  } = activeSheet;
+
+  const finish = () => {
+    sheetEl.classList.remove(ACTIVE_CLASS, ...ENTER_CLASSES);
+    sheetEl.classList.add(...EXIT_CLASSES);
+    hideOverlay(overlay);
+    cleanup?.();
+    if (trapFocus) {
+      focusTrapListeners.forEach(([event, handler]) => document.removeEventListener(event, handler));
+    }
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+    activeSheet = null;
+  };
+
+  if (immediate) {
+    finish();
+    return;
+  }
+
+  sheetEl.classList.remove(...ENTER_CLASSES);
+  sheetEl.classList.add(...EXIT_CLASSES);
+  hideOverlay(overlay);
+
+  const duration = parseFloat(getComputedStyle(sheetEl).transitionDuration || '0');
+  const delay = Math.max(0, duration * 1000);
+  window.setTimeout(finish, delay || 200);
+}
+
+export function isBottomSheetOpen() {
+  return Boolean(activeSheet);
+}
+
+export default {
+  openBottomSheet,
+  closeBottomSheet,
+  isBottomSheetOpen,
+};

--- a/ui/drawer.js
+++ b/ui/drawer.js
@@ -1,0 +1,221 @@
+import { getOverlay, showOverlay, hideOverlay } from './overlay.js';
+
+const defaultClasses = {
+  open: ['open'],
+  enter: ['opacity-100', 'translate-x-0'],
+  exit: ['opacity-0', 'translate-x-4'],
+};
+
+let activeDrawer = null;
+
+function ensureElement(target, fallbackSelector) {
+  if (!target && !fallbackSelector) return null;
+  if (target instanceof Element) return target;
+  if (typeof target === 'string') {
+    const el = document.querySelector(target);
+    if (!el) {
+      throw new Error(`Drawer selector \"${target}\" did not match any element.`);
+    }
+    return el;
+  }
+  if (!target && fallbackSelector) {
+    const el = fallbackSelector instanceof Element
+      ? fallbackSelector
+      : document.querySelector(fallbackSelector);
+    if (!el) {
+      throw new Error(`Drawer fallback selector \"${fallbackSelector}\" did not match any element.`);
+    }
+    return el;
+  }
+  return null;
+}
+
+function applyContent(target, content) {
+  if (!target || content === undefined || content === null) return;
+  if (typeof content === 'string') {
+    target.innerHTML = content;
+    return;
+  }
+  if (content instanceof Node) {
+    target.innerHTML = '';
+    target.appendChild(content);
+    return;
+  }
+  if (typeof content === 'function') {
+    const result = content(target);
+    if (result !== undefined && result !== null) {
+      applyContent(target, result);
+    }
+  }
+}
+
+function bindCloseHandlers(closeTargets, handler) {
+  const listeners = [];
+  const targets = Array.isArray(closeTargets) ? closeTargets : [closeTargets];
+  targets.filter(Boolean).forEach((target) => {
+    if (typeof target === 'string') {
+      document.querySelectorAll(target).forEach((el) => {
+        const listener = () => handler();
+        el.addEventListener('click', listener);
+        listeners.push({ el, listener });
+      });
+      return;
+    }
+    if (target instanceof Element) {
+      const listener = () => handler();
+      target.addEventListener('click', listener);
+      listeners.push({ el: target, listener });
+    }
+  });
+  return () => {
+    listeners.forEach(({ el, listener }) => {
+      el.removeEventListener('click', listener);
+    });
+  };
+}
+
+function resetListeners(state) {
+  if (state?.unbindClose) {
+    state.unbindClose();
+    state.unbindClose = null;
+  }
+}
+
+export function openDrawer(options = {}) {
+  const {
+    drawer,
+    inner,
+    title,
+    titleElement,
+    content,
+    contentElement,
+    closeSelectors = [],
+    closeOnOverlay = true,
+    overlayKey,
+    overlayContainer,
+    overlayClass,
+    overlayZIndex = 40,
+    onOpen,
+    onClose,
+    autoFocus,
+    classes = {},
+  } = options;
+
+  const drawerEl = ensureElement(drawer, '#drawer');
+  if (!drawerEl) {
+    throw new Error('openDrawer requires a valid drawer element.');
+  }
+  const innerEl = ensureElement(inner, drawerEl.querySelector('[data-drawer-inner]') || '#drawerInner');
+  const titleEl = ensureElement(titleElement, drawerEl.querySelector('[data-drawer-title]') || '#drawerTitle');
+  const contentEl = ensureElement(contentElement, drawerEl.querySelector('[data-drawer-content]'));
+
+  const mergedClasses = {
+    open: classes.open || defaultClasses.open,
+    enter: classes.enter || defaultClasses.enter,
+    exit: classes.exit || defaultClasses.exit,
+  };
+
+  if (title !== undefined) {
+    applyContent(titleEl, title);
+  }
+  if (content !== undefined) {
+    applyContent(contentEl, content);
+  }
+
+  const overlay = closeOnOverlay
+    ? getOverlay(overlayKey || drawerEl, {
+        container: overlayContainer || drawerEl.parentElement || document.body,
+        className: overlayClass,
+        zIndex: overlayZIndex,
+      })
+    : null;
+
+  const state = {
+    drawerEl,
+    innerEl,
+    overlay,
+    onClose,
+    autoFocus,
+    classes: mergedClasses,
+  };
+
+  resetListeners(activeDrawer);
+
+  const closeHandler = () => closeDrawer();
+  const unbindClose = bindCloseHandlers(closeSelectors, closeHandler);
+  state.unbindClose = () => {
+    if (unbindClose) unbindClose();
+    if (overlay && closeOnOverlay) {
+      overlay.removeEventListener('click', closeHandler);
+    }
+  };
+
+  if (overlay && closeOnOverlay) {
+    overlay.addEventListener('click', closeHandler);
+  }
+
+  drawerEl.classList.add(...mergedClasses.open);
+  if (innerEl) {
+    innerEl.classList.remove(...mergedClasses.exit);
+    innerEl.classList.add(...mergedClasses.enter);
+  }
+
+  if (overlay) {
+    showOverlay(overlay);
+  }
+
+  activeDrawer = state;
+
+  if (typeof onOpen === 'function') {
+    onOpen(state);
+  }
+
+  if (autoFocus instanceof Element) {
+    autoFocus.focus();
+  } else if (typeof autoFocus === 'string') {
+    const focusTarget = drawerEl.querySelector(autoFocus);
+    focusTarget?.focus();
+  }
+
+  return state;
+}
+
+export function closeDrawer() {
+  if (!activeDrawer) return;
+  const {
+    drawerEl,
+    innerEl,
+    overlay,
+    onClose,
+    classes,
+  } = activeDrawer;
+
+  if (innerEl) {
+    innerEl.classList.remove(...classes.enter);
+    innerEl.classList.add(...classes.exit);
+  }
+
+  const finish = () => {
+    drawerEl.classList.remove(...classes.open);
+    if (overlay) hideOverlay(overlay);
+    resetListeners(activeDrawer);
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+    activeDrawer = null;
+  };
+
+  const duration = parseFloat(getComputedStyle(innerEl || drawerEl).transitionDuration || '0');
+  const delay = Math.max(0, duration * 1000);
+  window.setTimeout(finish, delay || 200);
+}
+
+export function isDrawerOpen() {
+  return Boolean(activeDrawer);
+}
+
+export default {
+  openDrawer,
+  closeDrawer,
+  isDrawerOpen,
+};

--- a/ui/filter.js
+++ b/ui/filter.js
@@ -1,0 +1,284 @@
+const DEFAULT_LABELS = {
+  date: 'Semua Tanggal',
+  category: 'Semua Kategori',
+};
+
+function resolveRoot(root) {
+  if (!root) return document;
+  if (root instanceof Element) return root;
+  if (typeof root === 'string') {
+    const el = document.querySelector(root);
+    if (!el) {
+      throw new Error(`initFilter root selector \"${root}\" did not match any element.`);
+    }
+    return el;
+  }
+  return document;
+}
+
+function getFilterType(filterEl) {
+  const type = filterEl.dataset.filter;
+  if (type === 'date' || type === 'category') return type;
+  return filterEl.getAttribute('data-filter-type') || 'generic';
+}
+
+function formatCustomRange(startInput, endInput) {
+  const start = startInput?.value?.trim();
+  const end = endInput?.value?.trim();
+  if (start && end) return `${start} - ${end}`;
+  if (start) return `${start} -`;
+  if (end) return `- ${end}`;
+  return '';
+}
+
+function collectOptionValue(option) {
+  if (!option) return null;
+  if (option.type === 'checkbox') {
+    return option.checked;
+  }
+  if (option.type === 'radio') {
+    return option.value;
+  }
+  if (option instanceof HTMLInputElement || option instanceof HTMLSelectElement) {
+    return option.value;
+  }
+  return option.textContent;
+}
+
+function createFilterState(filterEl, defaults) {
+  const trigger = filterEl.querySelector('.filter-trigger');
+  const panel = filterEl.querySelector('.filter-panel');
+  const labelEl = trigger?.querySelector('.filter-label');
+  const applyBtn = panel?.querySelector('.apply');
+  const cancelBtn = panel?.querySelector('.cancel');
+  const options = panel ? panel.querySelectorAll('input[type="radio"], input[type="checkbox"]') : [];
+  const type = getFilterType(filterEl);
+
+  const customRange = panel?.querySelector('.custom-range');
+  const customStart = customRange?.querySelector('[data-date-start]');
+  const customEnd = customRange?.querySelector('[data-date-end]');
+
+  const defaultLabel = filterEl.dataset.default || defaults[type] || filterEl.dataset.label || '';
+  const applied = {
+    value: null,
+    label: defaultLabel,
+  };
+
+  const state = {
+    element: filterEl,
+    trigger,
+    panel,
+    labelEl,
+    applyBtn,
+    cancelBtn,
+    options,
+    type,
+    customRange,
+    customStart,
+    customEnd,
+    applied,
+    pending: null,
+  };
+
+  if (labelEl && defaultLabel) {
+    labelEl.textContent = defaultLabel;
+  }
+
+  return state;
+}
+
+function openPanel(state, allStates) {
+  allStates.forEach((other) => {
+    if (other !== state) {
+      other.panel?.classList.add('hidden');
+      other.trigger?.classList.remove('active');
+    }
+  });
+  state.panel?.classList.remove('hidden');
+  state.trigger?.classList.add('active');
+}
+
+function closePanel(state) {
+  state.panel?.classList.add('hidden');
+  state.trigger?.classList.remove('active');
+}
+
+function applySelection(state, callbacks) {
+  const { labelEl, type, pending, applied, customStart, customEnd } = state;
+  if (!pending) return;
+  applied.value = pending.value;
+  applied.label = pending.label;
+  if (labelEl && pending.label) {
+    labelEl.textContent = pending.label;
+  }
+  if (type === 'date' && pending.value === 'custom' && customStart && customEnd) {
+    labelEl.textContent = pending.customLabel || pending.label || DEFAULT_LABELS.date;
+  }
+  if (type === 'category' && !pending.label && labelEl) {
+    labelEl.textContent = DEFAULT_LABELS.category;
+  }
+  if (pending.customLabel && labelEl) {
+    labelEl.textContent = pending.customLabel;
+  }
+  state.pending = null;
+
+  if (type === 'date' && typeof callbacks.onDateChange === 'function') {
+    callbacks.onDateChange(applied.value, { label: applied.label, state });
+  }
+  if (type === 'category' && typeof callbacks.onCategoryChange === 'function') {
+    callbacks.onCategoryChange(applied.value, { label: applied.label, state });
+  }
+  if (typeof callbacks.onChange === 'function') {
+    callbacks.onChange(type, applied.value, { label: applied.label, state });
+  }
+}
+
+function cancelSelection(state) {
+  state.pending = null;
+  closePanel(state);
+}
+
+function handleOptionInput(state, callbacks) {
+  const { options, type, customRange, customStart, customEnd } = state;
+  const current = { value: null, label: null };
+
+  const selectedOptions = Array.from(options).filter((option) => {
+    if (option.type === 'checkbox') return option.checked;
+    if (option.type === 'radio') return option.checked;
+    return false;
+  });
+
+  if (type === 'date') {
+    const selected = selectedOptions[0];
+    if (selected) {
+      current.value = selected.value;
+      current.label = selected.closest('label')?.textContent?.trim() || selected.value;
+      if (selected.value === 'custom' && customRange) {
+        customRange.classList.remove('hidden');
+        const customLabel = formatCustomRange(customStart, customEnd);
+        current.customLabel = customLabel || current.label;
+      } else if (customRange) {
+        customRange.classList.add('hidden');
+      }
+    }
+  } else if (type === 'category') {
+    const selected = selectedOptions[0];
+    if (selected) {
+      current.value = selected.value;
+      current.label = selected.closest('label')?.textContent?.trim() || selected.value;
+    }
+  } else {
+    current.value = selectedOptions.map((option) => collectOptionValue(option));
+    current.label = Array.isArray(current.value) ? current.value.join(', ') : current.value;
+  }
+
+  state.pending = current;
+  if (state.applyBtn) {
+    const isValid = type !== 'date'
+      || current.value !== 'custom'
+      || Boolean(formatCustomRange(customStart, customEnd));
+    state.applyBtn.disabled = !isValid;
+  }
+}
+
+function bindEvents(state, allStates, callbacks) {
+  const { trigger, panel, applyBtn, cancelBtn, options, customStart, customEnd } = state;
+
+  trigger?.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (panel?.classList.contains('hidden')) {
+      openPanel(state, allStates);
+    } else {
+      closePanel(state);
+    }
+  });
+
+  applyBtn?.addEventListener('click', () => {
+    applySelection(state, callbacks);
+    closePanel(state);
+  });
+
+  cancelBtn?.addEventListener('click', () => {
+    cancelSelection(state);
+  });
+
+  if (options && options.length) {
+    options.forEach((option) => {
+      option.addEventListener('change', () => {
+        handleOptionInput(state, callbacks);
+      });
+    });
+  }
+
+  const customInputs = [customStart, customEnd].filter(Boolean);
+  customInputs.forEach((input) => {
+    input.addEventListener('input', () => {
+      if (!state.pending || state.pending.value !== 'custom') {
+        state.pending = {
+          value: 'custom',
+          label: DEFAULT_LABELS.date,
+        };
+      }
+      state.pending.customLabel = formatCustomRange(customStart, customEnd) || DEFAULT_LABELS.date;
+      if (state.applyBtn) {
+        const hasRange = Boolean(formatCustomRange(customStart, customEnd));
+        state.applyBtn.disabled = !hasRange;
+      }
+    });
+  });
+}
+
+export function initFilter(config = {}) {
+  const root = resolveRoot(config.root);
+  const defaults = { ...DEFAULT_LABELS, ...(config.defaults || {}) };
+  const callbacks = {
+    onChange: config.onChange,
+    onDateChange: config.onDateChange,
+    onCategoryChange: config.onCategoryChange,
+  };
+
+  const filters = Array.from(root.querySelectorAll('.filter'));
+  const states = filters.map((filterEl) => createFilterState(filterEl, defaults));
+  states.forEach((state) => bindEvents(state, states, callbacks));
+
+  function reset() {
+    states.forEach((state) => {
+      state.applied.value = null;
+      state.applied.label = defaults[state.type] || '';
+      if (state.labelEl && state.applied.label) {
+        state.labelEl.textContent = state.applied.label;
+      }
+      if (state.options) {
+        state.options.forEach((option) => {
+          if (option.type === 'checkbox' || option.type === 'radio') {
+            option.checked = false;
+          }
+        });
+      }
+      if (state.customRange) {
+        state.customRange.classList.add('hidden');
+      }
+    });
+  }
+
+  function getState() {
+    const snapshot = {};
+    states.forEach((state) => {
+      snapshot[state.type] = {
+        value: state.applied.value,
+        label: state.applied.label,
+      };
+    });
+    return snapshot;
+  }
+
+  return {
+    states,
+    reset,
+    getState,
+  };
+}
+
+export default {
+  initFilter,
+};

--- a/ui/otp.js
+++ b/ui/otp.js
@@ -1,0 +1,250 @@
+function sanitiseDigit(value) {
+  return value.replace(/\D/g, '').slice(0, 1);
+}
+
+function focusNext(inputs, index) {
+  if (index < inputs.length - 1) {
+    inputs[index + 1].focus();
+  }
+}
+
+function focusPrev(inputs, index) {
+  if (index > 0) {
+    inputs[index - 1].focus();
+  }
+}
+
+export function initOtpFlow(config = {}) {
+  const {
+    inputs: rawInputs,
+    startButton,
+    resendButton,
+    submitButton,
+    timerElement,
+    messageElement,
+    errorElement,
+    duration = 300,
+    autoStart = false,
+    onRequest,
+    onValidate,
+    onSuccess,
+    onError,
+    onExpire,
+  } = config;
+
+  const inputs = Array.from(rawInputs || []).filter((input) => input instanceof HTMLInputElement);
+  if (!inputs.length) {
+    throw new Error('initOtpFlow requires at least one OTP input.');
+  }
+
+  let timerId = null;
+  let remaining = duration;
+  let expectedCode = null;
+  let active = false;
+
+  function getValue() {
+    return inputs.map((input) => input.value.trim()).join('');
+  }
+
+  function clearInputs() {
+    inputs.forEach((input) => {
+      input.value = '';
+    });
+    inputs[0]?.focus();
+    updateSubmitState();
+  }
+
+  function setError(message) {
+    if (!errorElement) return;
+    errorElement.textContent = message || '';
+    errorElement.classList.toggle('hidden', !message);
+  }
+
+  function clearError() {
+    setError('');
+  }
+
+  function updateSubmitState() {
+    if (!submitButton) return;
+    const complete = inputs.every((input) => input.value.trim().length === 1);
+    submitButton.disabled = !complete;
+    submitButton.classList.toggle('is-disabled', !complete);
+  }
+
+  function updateTimerDisplay() {
+    if (!timerElement) return;
+    const minutes = String(Math.floor(remaining / 60)).padStart(2, '0');
+    const seconds = String(remaining % 60).padStart(2, '0');
+    timerElement.textContent = `${minutes}:${seconds}`;
+  }
+
+  function setMessage(text) {
+    if (!messageElement) return;
+    messageElement.textContent = text || '';
+  }
+
+  function stopTimer() {
+    if (timerId) {
+      window.clearInterval(timerId);
+      timerId = null;
+    }
+  }
+
+  function handleExpire() {
+    active = false;
+    stopTimer();
+    if (resendButton) {
+      resendButton.disabled = false;
+      resendButton.classList.remove('hidden');
+    }
+    setMessage('Kode verifikasi kedaluwarsa. Kirim ulang untuk melanjutkan.');
+    if (typeof onExpire === 'function') {
+      onExpire();
+    }
+  }
+
+  function tick() {
+    if (remaining <= 0) {
+      handleExpire();
+      return;
+    }
+    remaining -= 1;
+    updateTimerDisplay();
+  }
+
+  async function requestOtp({ restart = false } = {}) {
+    clearError();
+    if (typeof onRequest === 'function') {
+      try {
+        const result = await onRequest({ restart });
+        if (typeof result === 'string') {
+          expectedCode = result;
+        } else if (result && typeof result.code === 'string') {
+          expectedCode = result.code;
+        }
+      } catch (error) {
+        setError(error?.message || 'Gagal meminta kode OTP.');
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+        return;
+      }
+    }
+  }
+
+  async function start({ restart = false } = {}) {
+    clearError();
+    setMessage('Kode verifikasi telah dikirim ke perangkat Anda.');
+    remaining = duration;
+    updateTimerDisplay();
+    stopTimer();
+    await requestOtp({ restart });
+    active = true;
+    timerId = window.setInterval(tick, 1000);
+    if (resendButton) {
+      resendButton.disabled = true;
+      resendButton.classList.add('hidden');
+    }
+    if (submitButton) {
+      submitButton.disabled = true;
+    }
+    clearInputs();
+    inputs[0]?.focus();
+  }
+
+  function validate() {
+    clearError();
+    const value = getValue();
+    if (!active) {
+      setError('Kode verifikasi belum diminta.');
+      return false;
+    }
+    if (value.length !== inputs.length) {
+      setError(`Kode verifikasi harus ${inputs.length} digit.`);
+      return false;
+    }
+    if (typeof onValidate === 'function') {
+      const result = onValidate(value, { expectedCode });
+      if (result === false) {
+        setError('Kode verifikasi salah.');
+        if (typeof onError === 'function') onError(new Error('OTP invalid'));
+        return false;
+      }
+    } else if (expectedCode && value !== expectedCode) {
+      setError('Kode verifikasi salah.');
+      if (typeof onError === 'function') onError(new Error('OTP invalid'));
+      return false;
+    }
+    if (typeof onSuccess === 'function') {
+      onSuccess(value);
+    }
+    stopTimer();
+    active = false;
+    return true;
+  }
+
+  inputs.forEach((input, index) => {
+    input.setAttribute('inputmode', 'numeric');
+    input.setAttribute('maxlength', '1');
+    input.addEventListener('input', (event) => {
+      const value = sanitiseDigit(event.target.value);
+      event.target.value = value;
+      if (value) {
+        focusNext(inputs, index);
+      }
+      clearError();
+      updateSubmitState();
+    });
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Backspace' && !input.value) {
+        focusPrev(inputs, index);
+      }
+      if (event.key === 'ArrowLeft') {
+        focusPrev(inputs, index);
+        event.preventDefault();
+      }
+      if (event.key === 'ArrowRight') {
+        focusNext(inputs, index);
+        event.preventDefault();
+      }
+    });
+  });
+
+  if (startButton) {
+    startButton.addEventListener('click', () => start({ restart: false }));
+  }
+  if (resendButton) {
+    resendButton.addEventListener('click', () => start({ restart: true }));
+  }
+  if (submitButton) {
+    submitButton.addEventListener('click', (event) => {
+      if (!validate()) {
+        event.preventDefault();
+      }
+    });
+  }
+
+  if (autoStart) {
+    start({ restart: false });
+  } else {
+    updateSubmitState();
+  }
+
+  return {
+    start: (opts) => start({ restart: false, ...(opts || {}) }),
+    resend: () => start({ restart: true }),
+    validate,
+    clear: clearInputs,
+    getValue,
+    destroy: () => {
+      stopTimer();
+      inputs.forEach((input) => {
+        input.replaceWith(input.cloneNode(true));
+      });
+    },
+  };
+}
+
+export default {
+  initOtpFlow,
+};

--- a/ui/overlay.js
+++ b/ui/overlay.js
@@ -1,0 +1,98 @@
+const overlayRegistry = new Map();
+
+function resolveContainer(container) {
+  if (!container) {
+    return document.body;
+  }
+  if (typeof container === 'string') {
+    const el = document.querySelector(container);
+    if (!el) {
+      throw new Error(`Overlay container selector \"${container}\" did not match any element.`);
+    }
+    return el;
+  }
+  if (container instanceof Element) {
+    return container;
+  }
+  throw new Error('Invalid container provided to overlay manager.');
+}
+
+function applyOverlayClasses(overlay, className, zIndex) {
+  overlay.className = '';
+  overlay.classList.add('ui-overlay');
+  overlay.classList.add('pointer-events-none');
+  overlay.classList.add('opacity-0');
+  overlay.classList.add('transition-opacity');
+  overlay.classList.add('duration-200');
+  overlay.style.position = 'absolute';
+  overlay.style.inset = '0';
+  overlay.style.backgroundColor = 'rgba(15, 23, 42, 0.4)';
+  overlay.style.zIndex = typeof zIndex === 'number' ? String(zIndex) : '40';
+  overlay.style.pointerEvents = 'none';
+  overlay.dataset.active = 'false';
+  if (className) {
+    className.split(/\s+/).filter(Boolean).forEach(cls => overlay.classList.add(cls));
+  }
+}
+
+export function getOverlay(key, options = {}) {
+  const {
+    container,
+    className,
+    zIndex,
+    clickHandler,
+  } = options;
+  const containerEl = resolveContainer(container);
+  const overlayKey = key || containerEl;
+  let entry = overlayRegistry.get(overlayKey);
+  if (!entry) {
+    const overlay = document.createElement('div');
+    applyOverlayClasses(overlay, className, zIndex);
+    overlay.addEventListener('click', (event) => {
+      if (overlay.dataset.active !== 'true') return;
+      if (typeof entry?.clickHandler === 'function') {
+        entry.clickHandler(event);
+      }
+    });
+    containerEl.style.position = containerEl.style.position || 'relative';
+    containerEl.appendChild(overlay);
+    entry = { overlay, container: containerEl, clickHandler: clickHandler || null };
+    overlayRegistry.set(overlayKey, entry);
+  } else if (typeof clickHandler === 'function') {
+    entry.clickHandler = clickHandler;
+  }
+  return entry.overlay;
+}
+
+export function showOverlay(overlay) {
+  if (!overlay) return;
+  overlay.dataset.active = 'true';
+  overlay.style.pointerEvents = 'auto';
+  overlay.classList.add('opacity-100');
+  overlay.classList.remove('opacity-0');
+}
+
+export function hideOverlay(overlay) {
+  if (!overlay) return;
+  overlay.dataset.active = 'false';
+  overlay.style.pointerEvents = 'none';
+  overlay.classList.remove('opacity-100');
+  overlay.classList.add('opacity-0');
+}
+
+export function removeOverlay(key) {
+  const entry = overlayRegistry.get(key);
+  if (!entry) return;
+  const { overlay, container } = entry;
+  if (overlay && overlay.parentElement === container) {
+    container.removeChild(overlay);
+  }
+  overlayRegistry.delete(key);
+}
+
+export default {
+  getOverlay,
+  showOverlay,
+  hideOverlay,
+  removeOverlay,
+};

--- a/ui/ui-components.js
+++ b/ui/ui-components.js
@@ -1,0 +1,15 @@
+export { openDrawer, closeDrawer, isDrawerOpen } from './drawer.js';
+export { openBottomSheet, closeBottomSheet, isBottomSheetOpen } from './bottomsheet.js';
+export { initFilter } from './filter.js';
+export { initOtpFlow } from './otp.js';
+
+export default {
+  openDrawer,
+  closeDrawer,
+  isDrawerOpen,
+  openBottomSheet,
+  closeBottomSheet,
+  isBottomSheetOpen,
+  initFilter,
+  initOtpFlow,
+};


### PR DESCRIPTION
## Summary
- add reusable drawer, bottom sheet, filter, and OTP modules behind a unified ui-components entrypoint
- update biller flow to consume the shared modules for drawer/bottom-sheet orchestration and OTP handling
## Testing
- node --check biller.js

------
https://chatgpt.com/codex/tasks/task_e_68d7e2601060833083e5bce19578d164