### PR TITLE
Load shared UI modules on dashboard and account pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,12 @@
     </div>
   </div>
 
+  <script type="module">
+    import * as AmbisUI from './ui/ui-components.js';
+
+    const globalAmbis = window.AMBIS = window.AMBIS || {};
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, AmbisUI);
+  </script>
   <script src="data/rekening-data.js"></script>
   <script src="index.js"></script>
   <script src="sidebar.js"></script>

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -931,6 +931,12 @@
   </div>
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
+  <script type="module">
+    import * as AmbisUI from './ui/ui-components.js';
+
+    const globalAmbis = window.AMBIS = window.AMBIS || {};
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, AmbisUI);
+  </script>
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>


### PR DESCRIPTION
## Summary
- import the shared UI component bundle on the dashboard and account information pages
- expose the module exports on window.AMBIS.ui so legacy scripts can access the new utilities

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7e9cf16d88330bd1241966d657044