### PR TITLE
Add Ambis UI module initialization to transfer and mutasi

### DIFF
--- a/mutasi.html
+++ b/mutasi.html
@@ -504,6 +504,12 @@
 
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
+  <script type="module">
+    import * as AmbisUI from './ui/ui-components.js';
+
+    const globalAmbis = window.AMBIS = window.AMBIS || {};
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, AmbisUI);
+  </script>
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>

--- a/transfer.html
+++ b/transfer.html
@@ -589,6 +589,12 @@
   </div> <!-- /drawer -->
 </div> <!-- /layout container -->
 
+  <script type="module">
+    import * as AmbisUI from './ui/ui-components.js';
+
+    const globalAmbis = window.AMBIS = window.AMBIS || {};
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, AmbisUI);
+  </script>
   <script src="data/rekening-data.js"></script>
   <script src="transfer.js"></script>
   <script src="sidebar.js"></script>


### PR DESCRIPTION
## Summary
- expose shared UI modules on the transfer page so they can be reused from ui/
- expose shared UI modules on the mutasi page so they can be reused from ui/

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ec5cbc1c8330b78b1f61ae845a0c