### PR TITLE
Load UI modules on biller and transaction limit pages

### DIFF
--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -359,6 +359,17 @@
     </div>
   </div>
 
+  <script type="module">
+    import { openDrawer, closeDrawer } from './ui/drawer.js';
+    import { initOtpFlow } from './ui/otp.js';
+
+    const globalAmbis = (window.AMBIS = window.AMBIS || {});
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, {
+      openDrawer,
+      closeDrawer,
+      initOtpFlow,
+    });
+  </script>
   <script src="batas-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/biller.html
+++ b/biller.html
@@ -556,6 +556,20 @@
   </div>
   </div>
 
+  <script type="module">
+    import { openDrawer, closeDrawer } from './ui/drawer.js';
+    import { openBottomSheet, closeBottomSheet } from './ui/bottomsheet.js';
+    import { initOtpFlow } from './ui/otp.js';
+
+    const globalAmbis = (window.AMBIS = window.AMBIS || {});
+    globalAmbis.ui = Object.assign(globalAmbis.ui || {}, {
+      openDrawer,
+      closeDrawer,
+      openBottomSheet,
+      closeBottomSheet,
+      initOtpFlow,
+    });
+  </script>
   <script src="data/rekening-data.js"></script>
   <script src="biller.js"></script>
   <script src="sidebar.js"></script>


### PR DESCRIPTION
## Summary
- expose drawer, bottom sheet, and OTP helpers on the Beli & Bayar page via ES module imports
- expose drawer and OTP helpers on the Batas Transaksi page via ES module imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f2693c6c833080dc66a66bfff5d4