### PR TITLE
Add hints to biller drawer form

### DIFF
--- a/biller.html
+++ b/biller.html
@@ -367,12 +367,16 @@
                 <label id="idInputLabel" for="billerIdInput" class="block text-sm text-slate-600">ID Pelanggan</label>
               </div>
               <input id="billerIdInput" type="text" inputmode="numeric" autocomplete="off" class="w-full border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-500" placeholder="Masukkan ID Pelanggan" />
+              <p id="idInputHint" class="text-xs text-slate-500 hidden"></p>
               <p id="idInputError" class="hidden text-sm text-rose-500"></p>
             </div>
 
             <div class="space-y-2">
-              <button id="savedNumberButton" type="button" class="text-left rounded-xl border border-cyan-500 text-cyan-600 px-4 py-3 text-sm font-medium hover:bg-cyan-50">
-               Nomor Tersimpan
+              <button id="savedNumberButton" type="button" class="text-left rounded-xl border border-cyan-500 px-4 py-3 text-sm font-medium text-cyan-600 hover:bg-cyan-50">
+                <div class="flex flex-col gap-1">
+                  <span class="text-sm font-semibold">Nomor Tersimpan</span>
+                  <span id="savedNumberDisplay" class="text-sm font-normal text-slate-400">Pilih nomor tersimpan</span>
+                </div>
               </button>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- expose a dedicated hint element under the biller ID input for dynamic helper text
- restructure the saved number button to show the selected number placeholder inside the drawer

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d882fa52b08330930a252c02263eeb