### PR TITLE
Add confirmation dialog and drawer for approval edits

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -158,7 +158,7 @@
 
         <!-- Table -->
         <div class="overflow-x-auto rounded-xl border border-slate-200">
-          <table class="min-w-full  ">
+          <table class="min-w-full">
             <thead class="bg-slate-50 text-slate-600">
               <tr>
                 <th class="text-left px-4 py-3 font-medium">Nominal Transaksi</th>
@@ -167,18 +167,35 @@
               </tr>
             </thead>
             <tbody class="divide-y">
-              <tr class="hover:bg-slate-50">
-                <td class="px-4 py-3">Rp0 - 200.000.000</td>
-                <td class="px-4 py-3">2 Approver</td>
+              <tr class="hover:bg-slate-50" data-approval-row="top">
+                <td class="px-4 py-3" data-range-cell>Rp 1 – Rp 200.000.000</td>
+                <td class="px-4 py-3" data-approver-cell>2 Penyetuju</td>
                 <td class="px-4 py-3 text-right">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Ubah</button>
+                  <button
+                    type="button"
+                    class="approval-edit-btn px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50"
+                    data-requires-confirm="true"
+                    data-min="1"
+                    data-max="200000000"
+                    data-approvers="2"
+                  >
+                    Ubah
+                  </button>
                 </td>
               </tr>
               <tr class="hover:bg-slate-50">
-                <td class="px-4 py-3">Rp200.000.001 - 500.000.000</td>
-                <td class="px-4 py-3">3 Approver</td>
+                <td class="px-4 py-3">Rp 200.000.001 – Rp 500.000.000</td>
+                <td class="px-4 py-3">3 Penyetuju</td>
                 <td class="px-4 py-3 text-right">
-                  <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Ubah</button>
+                  <button
+                    type="button"
+                    class="approval-edit-btn px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50"
+                    data-min="200000001"
+                    data-max="500000000"
+                    data-approvers="3"
+                  >
+                    Ubah
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -188,8 +205,114 @@
       </div>
     </main>
     <!-- ============ /MAIN ============ -->
+    
+    <!-- Drawer -->
+    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100" aria-hidden="true">
+      <div id="approvalPane" class="h-full flex flex-col">
+        <div class="flex items-center justify-between px-6 py-4 border-b">
+          <h2 class="text-lg font-semibold">Ubah Persetujuan Transfer</h2>
+          <button id="approvalDrawerClose" type="button" class="text-2xl leading-none">&times;</button>
+        </div>
+        <div class="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+          <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
+            <span aria-hidden="true" class="text-xl">ℹ️</span>
+            <p class="text-sm leading-relaxed">
+              Buat aturan persetujuan sesuai nominal transaksi, atau tetapkan langsung untuk limit harian Rp500.000.000.
+            </p>
+          </div>
+
+          <div class="space-y-6">
+            <div class="grid gap-4 md:grid-cols-2">
+              <div>
+                <label for="minLimitInput" class="block mb-2 font-medium text-slate-700">Batas Minimal</label>
+                <input
+                  id="minLimitInput"
+                  type="text"
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-right text-slate-500"
+                  placeholder="Rp 1"
+                  value="Rp 1"
+                  disabled
+                />
+              </div>
+              <div>
+                <label for="maxLimitInput" class="block mb-2 font-medium text-slate-700">Batas Maksimal</label>
+                <div class="relative">
+                  <input
+                    id="maxLimitInput"
+                    type="text"
+                    inputmode="numeric"
+                    class="w-full rounded-xl border border-slate-200 px-4 py-3 text-right focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                    placeholder="Rp Maks. 500.000.000"
+                  />
+                </div>
+                <p id="maxLimitError" class="mt-2 text-sm text-red-500 hidden"></p>
+              </div>
+            </div>
+
+            <div>
+              <label for="approverCountInput" class="block mb-2 font-medium text-slate-700">Jumlah Penyetuju</label>
+              <input
+                id="approverCountInput"
+                type="text"
+                inputmode="numeric"
+                class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                placeholder="Minimal 1 penyetuju"
+              />
+              <div class="mt-2 space-y-1">
+                <p class="flex items-start gap-2 text-sm text-slate-500">
+                  <span aria-hidden="true" class="mt-[3px] inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-[12px] font-semibold text-slate-500">i</span>
+                  <span>Jumlah penyetuju harus sesuai dengan yang tersedia di perusahaan Anda.</span>
+                </p>
+                <p id="approverCountError" class="text-sm text-red-500 hidden"></p>
+              </div>
+            </div>
+          </div>
+
+          <div class="pt-6 border-t border-slate-200">
+            <button id="saveChangesBtn" type="button" class="w-full rounded-xl border border-cyan-500 text-cyan-600 font-semibold py-3 hover:bg-cyan-50" disabled>
+              Simpan Perubahan
+            </button>
+          </div>
+        </div>
+        <div class="border-t px-6 py-5 bg-white">
+          <button id="confirmApprovalBtn" type="button" class="w-full rounded-xl bg-cyan-500 text-white font-semibold py-3" disabled>
+            Konfirmasi Persetujuan Transfer
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirmation Dialog -->
+  <div
+    id="topApprovalDialogContainer"
+    class="hidden fixed inset-0 z-40"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="topApprovalDialogTitle"
+  >
+    <div id="topApprovalDialogOverlay" class="absolute inset-0 bg-slate-900/40"></div>
+    <div class="relative flex h-full items-center justify-center px-4">
+      <div id="topApprovalDialog" class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <div class="space-y-2">
+          <h3 id="topApprovalDialogTitle" class="text-lg font-semibold text-slate-900">Ubah Persetujuan Teratas?</h3>
+          <p class="text-sm text-slate-600">
+            Jika Anda mengubah penyetuju di urutan teratas, urutan dan rentang persetujuan harus diatur ulang dari awal.
+          </p>
+        </div>
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button id="topApprovalDialogCancel" type="button" class="w-full rounded-xl border border-slate-200 px-4 py-2 text-slate-700 sm:w-auto">
+            Batal
+          </button>
+          <button id="topApprovalDialogProceed" type="button" class="w-full rounded-xl bg-cyan-500 px-4 py-2 font-semibold text-white sm:w-auto">
+            Ubah Sekarang
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="sidebar.js"></script>
+  <script src="atur-persetujuan.js"></script>
 </body>
 </html>

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -1,0 +1,396 @@
+(function () {
+  const MIN_LIMIT = 1;
+  const MAX_LIMIT = 500_000_000;
+  const DEFAULT_MAX_APPROVERS = 10;
+
+  const drawer = document.getElementById('drawer');
+  const drawerCloseBtn = document.getElementById('approvalDrawerClose');
+  const saveBtn = document.getElementById('saveChangesBtn');
+  const confirmBtn = document.getElementById('confirmApprovalBtn');
+  const maxInput = document.getElementById('maxLimitInput');
+  const maxError = document.getElementById('maxLimitError');
+  const approverInput = document.getElementById('approverCountInput');
+  const approverError = document.getElementById('approverCountError');
+  const editButtons = Array.from(document.querySelectorAll('.approval-edit-btn'));
+
+  const dialogContainer = document.getElementById('topApprovalDialogContainer');
+  const dialogOverlay = document.getElementById('topApprovalDialogOverlay');
+  const dialogCancel = document.getElementById('topApprovalDialogCancel');
+  const dialogProceed = document.getElementById('topApprovalDialogProceed');
+
+  let pendingButton = null;
+  let activeRowButton = null;
+  let formDirty = false;
+  let formSaved = false;
+  let maxTouched = false;
+  let approverTouched = false;
+  let currentInitialData = { min: MIN_LIMIT, max: null, approvers: null, maxApprovers: DEFAULT_MAX_APPROVERS };
+
+  function formatCurrency(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) return '';
+    return `Rp ${value.toLocaleString('id-ID')}`;
+  }
+
+  function parseCurrency(value) {
+    if (!value) return null;
+    const digits = String(value).replace(/[^0-9]/g, '');
+    if (!digits) return null;
+    const parsed = parseInt(digits, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function getMaxValue() {
+    return parseCurrency(maxInput?.value || '');
+  }
+
+  function getApproverValue() {
+    if (!approverInput) return null;
+    const digits = approverInput.value.replace(/[^0-9]/g, '');
+    if (!digits) return null;
+    const parsed = parseInt(digits, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function hideError(el) {
+    if (!el) return;
+    el.classList.add('hidden');
+    el.textContent = '';
+  }
+
+  function showError(el, message) {
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove('hidden');
+  }
+
+  function isMaxValid() {
+    const value = getMaxValue();
+    return value !== null && value >= MIN_LIMIT && value <= MAX_LIMIT;
+  }
+
+  function isApproverValid() {
+    const value = getApproverValue();
+    const maxAllowed = currentInitialData.maxApprovers || DEFAULT_MAX_APPROVERS;
+    return value !== null && value >= 1 && value <= maxAllowed;
+  }
+
+  function updateButtonStates() {
+    if (saveBtn) {
+      const valid = isMaxValid() && isApproverValid();
+      saveBtn.disabled = !(valid && formDirty);
+    }
+    if (confirmBtn) {
+      confirmBtn.disabled = !formSaved;
+    }
+  }
+
+  function clearErrors() {
+    hideError(maxError);
+    hideError(approverError);
+  }
+
+  function hasChanges() {
+    const currentMax = getMaxValue();
+    const currentApprovers = getApproverValue();
+    const initialMax = currentInitialData.max;
+    const initialApprovers = currentInitialData.approvers;
+    const normalizedCurrentMax = currentMax === null ? null : currentMax;
+    const normalizedInitialMax = typeof initialMax === 'number' ? initialMax : null;
+    const normalizedCurrentApprovers = currentApprovers === null ? null : currentApprovers;
+    const normalizedInitialApprovers = typeof initialApprovers === 'number' ? initialApprovers : null;
+    return (
+      normalizedCurrentMax !== normalizedInitialMax ||
+      normalizedCurrentApprovers !== normalizedInitialApprovers
+    );
+  }
+
+  function markDirty() {
+    formDirty = hasChanges();
+    if (formDirty) {
+      formSaved = false;
+    }
+    updateButtonStates();
+  }
+
+  function setMaxValue(value) {
+    if (!maxInput) return;
+    if (value === null || typeof value === 'undefined') {
+      maxInput.value = '';
+    } else {
+      maxInput.value = formatCurrency(value);
+      requestAnimationFrame(() => {
+        maxInput.setSelectionRange(maxInput.value.length, maxInput.value.length);
+      });
+    }
+  }
+
+  function setApproverValue(value) {
+    if (!approverInput) return;
+    if (value === null || typeof value === 'undefined') {
+      approverInput.value = '';
+    } else {
+      approverInput.value = String(value);
+    }
+  }
+
+  function applyInitialData(data) {
+    currentInitialData = {
+      min: typeof data.min === 'number' ? data.min : MIN_LIMIT,
+      max: typeof data.max === 'number' ? data.max : null,
+      approvers: typeof data.approvers === 'number' ? data.approvers : null,
+      maxApprovers: typeof data.maxApprovers === 'number' ? data.maxApprovers : DEFAULT_MAX_APPROVERS,
+    };
+
+    setMaxValue(currentInitialData.max);
+    setApproverValue(currentInitialData.approvers);
+
+    formDirty = false;
+    formSaved = false;
+    maxTouched = false;
+    approverTouched = false;
+    clearErrors();
+    updateButtonStates();
+  }
+
+  function openDrawer(button) {
+    if (!drawer || !button) return;
+
+    activeRowButton = button;
+    const min = parseCurrency(button.getAttribute('data-min')) ?? MIN_LIMIT;
+    const max = parseCurrency(button.getAttribute('data-max'));
+    const approvers = parseCurrency(button.getAttribute('data-approvers'));
+    const maxApprovers = parseCurrency(button.getAttribute('data-max-approvers')) || DEFAULT_MAX_APPROVERS;
+
+    applyInitialData({ min, max, approvers, maxApprovers });
+
+    drawer.classList.add('open');
+    drawer.setAttribute('aria-hidden', 'false');
+
+    requestAnimationFrame(() => {
+      maxInput?.focus();
+    });
+  }
+
+  function resetDrawerState() {
+    applyInitialData({
+      min: MIN_LIMIT,
+      max: null,
+      approvers: null,
+      maxApprovers: DEFAULT_MAX_APPROVERS,
+    });
+    activeRowButton = null;
+  }
+
+  function closeDrawer({ force = false } = {}) {
+    if (!drawer) return;
+    if (!force && formDirty && !window.confirm('Perubahan belum disimpan. Anda yakin ingin menutup tanpa menyimpan?')) {
+      return;
+    }
+    drawer.classList.remove('open');
+    drawer.setAttribute('aria-hidden', 'true');
+    resetDrawerState();
+  }
+
+  function isDialogOpen() {
+    return dialogContainer && !dialogContainer.classList.contains('hidden');
+  }
+
+  function openDialog(button) {
+    if (!dialogContainer) {
+      openDrawer(button);
+      return;
+    }
+    pendingButton = button;
+    dialogContainer.classList.remove('hidden');
+  }
+
+  function closeDialog() {
+    if (!dialogContainer) return;
+    dialogContainer.classList.add('hidden');
+    pendingButton = null;
+  }
+
+  function handleSave() {
+    const maxValid = isMaxValid();
+    const approverValid = isApproverValid();
+
+    if (!maxValid) {
+      const message = !getMaxValue()
+        ? 'Batas maksimal wajib diisi.'
+        : `Batas maksimal harus antara Rp1 hingga Rp${MAX_LIMIT.toLocaleString('id-ID')}.`;
+      showError(maxError, message);
+    }
+
+    if (!approverValid) {
+      const maxAllowed = currentInitialData.maxApprovers || DEFAULT_MAX_APPROVERS;
+      const message = !getApproverValue()
+        ? 'Jumlah penyetuju wajib diisi.'
+        : `Jumlah penyetuju harus antara 1 hingga ${maxAllowed}.`;
+      showError(approverError, message);
+    }
+
+    if (!maxValid || !approverValid) {
+      maxTouched = true;
+      approverTouched = true;
+      return;
+    }
+
+    currentInitialData = {
+      ...currentInitialData,
+      max: getMaxValue(),
+      approvers: getApproverValue(),
+    };
+
+    formDirty = false;
+    formSaved = true;
+    updateButtonStates();
+  }
+
+  function updateRowValues() {
+    if (!activeRowButton) return;
+    const row = activeRowButton.closest('tr');
+    if (!row) return;
+    const rangeCell = row.querySelector('[data-range-cell]');
+    const approverCell = row.querySelector('[data-approver-cell]');
+
+    const minValue = currentInitialData.min ?? MIN_LIMIT;
+    const maxValue = getMaxValue();
+    const approverValue = getApproverValue();
+
+    if (rangeCell && maxValue !== null) {
+      rangeCell.textContent = `${formatCurrency(minValue)} – ${formatCurrency(maxValue)}`;
+    }
+
+    if (approverCell && approverValue !== null) {
+      const suffix = approverValue === 1 ? 'Penyetuju' : 'Penyetuju';
+      approverCell.textContent = `${approverValue} ${suffix}`;
+    }
+
+    if (maxValue !== null) {
+      activeRowButton.setAttribute('data-max', String(maxValue));
+    }
+    if (approverValue !== null) {
+      activeRowButton.setAttribute('data-approvers', String(approverValue));
+    }
+  }
+
+  function handleConfirmSubmission() {
+    if (!formSaved) return;
+    updateRowValues();
+    closeDrawer({ force: true });
+  }
+
+  function handleMaxInput(event) {
+    if (!maxInput) return;
+    const value = event.target.value;
+    const digits = value.replace(/[^0-9]/g, '');
+    if (!digits) {
+      maxInput.value = '';
+    } else {
+      const parsed = parseInt(digits, 10);
+      maxInput.value = formatCurrency(parsed);
+      requestAnimationFrame(() => {
+        maxInput.setSelectionRange(maxInput.value.length, maxInput.value.length);
+      });
+    }
+    hideError(maxError);
+    markDirty();
+  }
+
+  function handleMaxBlur() {
+    maxTouched = true;
+    if (!isMaxValid()) {
+      const message = !getMaxValue()
+        ? 'Batas maksimal wajib diisi.'
+        : `Batas maksimal harus antara Rp1 hingga Rp${MAX_LIMIT.toLocaleString('id-ID')}.`;
+      showError(maxError, message);
+    }
+  }
+
+  function handleApproverInput(event) {
+    if (!approverInput) return;
+    const digits = event.target.value.replace(/[^0-9]/g, '');
+    approverInput.value = digits;
+    hideError(approverError);
+    markDirty();
+  }
+
+  function handleApproverBlur() {
+    approverTouched = true;
+    if (!isApproverValid()) {
+      const maxAllowed = currentInitialData.maxApprovers || DEFAULT_MAX_APPROVERS;
+      const message = !getApproverValue()
+        ? 'Jumlah penyetuju wajib diisi.'
+        : `Jumlah penyetuju harus antara 1 hingga ${maxAllowed}.`;
+      showError(approverError, message);
+    }
+  }
+
+  function handleEditButtonClick(button) {
+    const requiresConfirm = button.getAttribute('data-requires-confirm') === 'true';
+    if (requiresConfirm) {
+      openDialog(button);
+    } else {
+      openDrawer(button);
+    }
+  }
+
+  function handleKeyDown(event) {
+    if (event.key !== 'Escape') return;
+    if (isDialogOpen()) {
+      event.preventDefault();
+      closeDialog();
+      return;
+    }
+    if (drawer && drawer.classList.contains('open')) {
+      event.preventDefault();
+      closeDrawer();
+    }
+  }
+
+  editButtons.forEach((button) => {
+    button.addEventListener('click', () => handleEditButtonClick(button));
+  });
+
+  if (drawerCloseBtn) {
+    drawerCloseBtn.addEventListener('click', () => closeDrawer());
+  }
+
+  if (saveBtn) {
+    saveBtn.addEventListener('click', handleSave);
+  }
+
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', handleConfirmSubmission);
+  }
+
+  if (maxInput) {
+    maxInput.addEventListener('input', handleMaxInput);
+    maxInput.addEventListener('blur', handleMaxBlur);
+  }
+
+  if (approverInput) {
+    approverInput.addEventListener('input', handleApproverInput);
+    approverInput.addEventListener('blur', handleApproverBlur);
+  }
+
+  if (dialogCancel) {
+    dialogCancel.addEventListener('click', () => closeDialog());
+  }
+
+  if (dialogOverlay) {
+    dialogOverlay.addEventListener('click', () => closeDialog());
+  }
+
+  if (dialogProceed) {
+    dialogProceed.addEventListener('click', () => {
+      const button = pendingButton;
+      closeDialog();
+      if (button) {
+        openDrawer(button);
+      }
+    });
+  }
+
+  document.addEventListener('keydown', handleKeyDown);
+})();


### PR DESCRIPTION
## Summary
- add confirmation dialog before editing the top approval rule and update the approval table labels
- build a transfer approval drawer with disabled defaults, helper messaging, and sticky confirmation button
- implement page logic to manage modal visibility, validation, save-and-confirm states, and table updates

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68da2241ee488330a20168cbb87e753f