### PR TITLE
Add Persetujuan Transaksi section to transfer page

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -184,6 +184,38 @@
           </div>
         </div>
 
+        <!-- Persetujuan Transaksi -->
+        <section class="mt-10 space-y-4">
+          <div>
+            <h2 class="text-lg font-semibold text-slate-900">Persetujuan Transaksi</h2>
+            <p class="text-sm text-slate-500">
+              Jumlah penyetuju per kisaran nominal transfer yang berlaku saat ini.
+            </p>
+          </div>
+
+          <div class="rounded-2xl border border-slate-200 bg-white overflow-hidden">
+            <div class="flex items-center border-b border-slate-200">
+              <button type="button" class="relative px-6 py-3 text-sm font-semibold text-slate-900">
+                Transfer
+                <span class="absolute inset-x-0 bottom-0 h-[2px] bg-cyan-500"></span>
+              </button>
+              <button type="button" class="px-6 py-3 text-sm font-semibold text-slate-500 hover:text-slate-900">
+                Beli &amp; Bayar
+              </button>
+            </div>
+
+            <div class="bg-[#F8F8F8] text-sm font-semibold text-slate-700">
+              <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_180px_auto] items-center gap-3 px-6 py-3">
+                <span class="text-left">Nominal Transaksi</span>
+                <span class="md:text-center">Jumlah Persetujuan</span>
+                <span class="md:text-right">&nbsp;</span>
+              </div>
+            </div>
+
+            <div id="transferApprovalRows" class="bg-white text-sm text-slate-600"></div>
+          </div>
+        </section>
+
       </div>
     </main>
     <!-- ============ /MAIN ============ -->

--- a/transfer.js
+++ b/transfer.js
@@ -60,6 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const summaryFee = document.getElementById('summaryFee');
   const summaryTotal = document.getElementById('summaryTotal');
 
+  // approval list
+  const approvalRowsContainer = document.getElementById('transferApprovalRows');
+
   // generic bottom sheet
   const sheetOverlay = document.getElementById('sheetOverlay');
   const sheet       = document.getElementById('bottomSheet');
@@ -197,6 +200,64 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const formatter = new Intl.NumberFormat('id-ID');
 
+  const transferApprovalRules = [
+    { id: 'transfer-approval-1', min: 1, max: 200_000_000, approvers: 2 },
+    { id: 'transfer-approval-2', min: 200_000_001, max: 500_000_000, approvers: 3 },
+  ];
+
+  function formatApprovalRange(min, max) {
+    const minText = `Rp${formatter.format(min)}`;
+    if (!max) {
+      return `${minText} ke atas`;
+    }
+    const maxText = `Rp${formatter.format(max)}`;
+    return `${minText} – ${maxText}`;
+  }
+
+  function renderTransferApprovalRules() {
+    if (!approvalRowsContainer) return;
+
+    approvalRowsContainer.innerHTML = '';
+
+    transferApprovalRules.forEach((rule, index) => {
+      const row = document.createElement('div');
+      row.className = 'grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_180px_auto] items-center gap-3 px-6 py-4';
+      if (index !== transferApprovalRules.length - 1) {
+        row.classList.add('border-b', 'border-slate-200');
+      }
+
+      const amountEl = document.createElement('p');
+      amountEl.className = 'text-sm text-slate-900';
+      amountEl.textContent = formatApprovalRange(rule.min, rule.max);
+
+      const approverEl = document.createElement('p');
+      approverEl.className = 'text-sm font-semibold text-slate-500 md:text-center';
+      approverEl.textContent = `${rule.approvers} Penyetuju`;
+
+      const actionWrapper = document.createElement('div');
+      actionWrapper.className = 'md:text-right md:justify-self-end';
+
+      const actionBtn = document.createElement('button');
+      actionBtn.type = 'button';
+      actionBtn.className = 'rounded-lg border border-cyan-500 px-4 py-2 text-sm font-semibold text-cyan-600 transition-colors hover:bg-cyan-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400';
+      actionBtn.textContent = 'Ubah';
+      actionBtn.dataset.approvalId = rule.id;
+      actionBtn.addEventListener('click', () => {
+        const event = new CustomEvent('transfer-approval:edit', { detail: rule });
+        window.dispatchEvent(event);
+      });
+
+      actionWrapper.appendChild(actionBtn);
+
+      row.appendChild(amountEl);
+      row.appendChild(approverEl);
+      row.appendChild(actionWrapper);
+
+      approvalRowsContainer.appendChild(row);
+    });
+  }
+
+  renderTransferApprovalRules();
 
   function isBusinessDay(date) {
     const day = date.getDay();


### PR DESCRIPTION
## Summary
- add the Persetujuan Transaksi table layout to the Transfer tab with the specified tabs and styling
- populate the approval list dynamically with predefined ranges and hook the edit button to emit an event stub for future drawer integration

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da3262f6108330b2de98051ba8bcf9