### PR TITLE
Adjust approval drawer input formatting

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -205,21 +205,21 @@
                 <input
                   id="minLimitInput"
                   type="text"
+                  inputmode="numeric"
                   class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-right text-slate-500"
-                  placeholder="Rp 1"
-                  value="Rp 1"
                   disabled
                 />
               </div>
               <div>
                 <label for="maxLimitInput" class="block mb-2 font-medium text-slate-700">Batas Maksimal</label>
                 <div class="relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-slate-500">Rp</span>
                   <input
                     id="maxLimitInput"
                     type="text"
                     inputmode="numeric"
-                    class="w-full rounded-xl border border-slate-200 px-4 py-3 text-right focus:outline-none focus:ring-2 focus:ring-cyan-400"
-                    placeholder="Rp Maks. 500.000.000"
+                    class="w-full rounded-xl border border-slate-200 pl-12 pr-4 py-3 text-right focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                    placeholder="maks Rp500.000.000"
                   />
                 </div>
                 <p id="maxLimitError" class="mt-2 text-sm text-red-500 hidden"></p>
@@ -233,7 +233,7 @@
                 type="text"
                 inputmode="numeric"
                 class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-400"
-                placeholder="Minimal 1 penyetuju"
+                placeholder="minimal 1 penyetuju"
               />
               <div class="mt-2 space-y-1">
                 <p class="flex items-start gap-2 text-sm text-slate-500">

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -38,7 +38,12 @@
 
   function formatCurrency(value) {
     if (typeof value !== 'number' || Number.isNaN(value)) return '';
-    return `Rp ${value.toLocaleString('id-ID')}`;
+    return `Rp${value.toLocaleString('id-ID')}`;
+  }
+
+  function formatNumber(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) return '';
+    return value.toLocaleString('id-ID');
   }
 
   function parseCurrency(value) {
@@ -77,7 +82,7 @@
     if (value === null || typeof value === 'undefined') {
       minInput.value = '';
     } else {
-      minInput.value = formatCurrency(value);
+      minInput.value = formatNumber(value);
     }
   }
 
@@ -86,7 +91,7 @@
     if (value === null || typeof value === 'undefined') {
       maxInput.value = '';
     } else {
-      maxInput.value = formatCurrency(value);
+      maxInput.value = formatNumber(value);
       requestAnimationFrame(() => {
         maxInput.setSelectionRange(maxInput.value.length, maxInput.value.length);
       });
@@ -272,8 +277,8 @@
 
       const range = document.createElement('p');
       range.className = 'text-sm text-slate-700 text-left';
-      const minText = formatCurrency(rule.min).replace('Rp ', 'Rp');
-      const maxText = formatCurrency(rule.max).replace('Rp ', 'Rp');
+      const minText = formatCurrency(rule.min);
+      const maxText = formatCurrency(rule.max);
       range.textContent = `${minText} – ${maxText}`;
 
       const approverDetail = document.createElement('p');
@@ -451,7 +456,7 @@
       maxInput.value = '';
     } else {
       const parsed = parseInt(digits, 10);
-      maxInput.value = formatCurrency(parsed);
+      maxInput.value = formatNumber(parsed);
       requestAnimationFrame(() => {
         maxInput.setSelectionRange(maxInput.value.length, maxInput.value.length);
       });


### PR DESCRIPTION
## Summary
- update the Atur Persetujuan drawer markup to match the new numeric and currency input specifications
- adjust the supporting JavaScript to localize number formatting while keeping validation messaging in Rupiah

## Testing
- Manual - Loaded atur-persetujuan.html and opened the drawer

------
https://chatgpt.com/codex/tasks/task_e_68da4664fa8c8330a55a2734663f2fa4