### PR TITLE
Add confirmation dialog for editing top transfer approval

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -278,10 +278,10 @@
           </p>
         </div>
         <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <button id="topApprovalDialogCancel" type="button" class="w-full rounded-xl border border-slate-200 px-4 py-2 text-slate-700 sm:w-auto">
-            Batal
+          <button id="topApprovalDialogCancel" type="button" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-50 sm:w-auto">
+            Batalkan
           </button>
-          <button id="topApprovalDialogProceed" type="button" class="w-full rounded-xl bg-cyan-500 px-4 py-2 font-semibold text-white sm:w-auto">
+          <button id="topApprovalDialogProceed" type="button" class="w-full rounded-xl bg-cyan-500 px-4 py-2 font-semibold text-white transition hover:bg-cyan-600 sm:w-auto">
             Ubah Sekarang
           </button>
         </div>


### PR DESCRIPTION
## Summary
- prompt users with a confirmation dialog before editing the first transfer approval row
- launch the drawer with placeholder inputs and no autofocus after confirming top-row edits
- keep existing edit flow for other rows while wiring dialog controls and escape key handling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da4a1e56048330b12fee2b555142c9