### PR TITLE
Seed default approval matrix with closed drawer

### DIFF
--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -26,6 +26,8 @@
 
   const numberFormatter = new Intl.NumberFormat('id-ID');
 
+  let nextId = 1;
+
   const state = {
     approvals: [],
     mode: 'create',
@@ -34,7 +36,16 @@
   };
 
   let currentInitial = { min: MIN_LIMIT, max: null, approvers: null };
-  let nextId = 1;
+
+  state.approvals = [
+    {
+      id: `matrix-${nextId}`,
+      min: MIN_LIMIT,
+      max: MAX_LIMIT,
+      approvers: 2,
+    },
+  ];
+  nextId += 1;
 
   function formatNumber(value) {
     if (typeof value !== 'number' || Number.isNaN(value)) return '';
@@ -618,7 +629,6 @@
   function init() {
     renderAll();
     setModeCreate();
-    openDrawer();
     updateButtonStates();
   }
 


### PR DESCRIPTION
## Summary
- seed the approval matrix with a default 1-500.000.000 range requiring two approvers
- keep the approval drawer closed on load and only open it when interacting with edit actions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da7954ad608330bf90ac95e2089eee