### PR TITLE
Delay approval matrix display until changes are saved

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -201,7 +201,7 @@
             <div id="approvalMatrixList" class="space-y-3"></div>
           </div>
 
-          <div class="space-y-6">
+          <div id="approvalFormFields" class="space-y-6">
             <div class="grid gap-4 md:grid-cols-2">
               <div>
                 <label for="minLimitInput" class="block mb-2 font-medium text-slate-700">Batas Minimal</label>
@@ -250,7 +250,7 @@
 
           <div class="pt-6 border-t border-slate-200">
             <button id="saveChangesBtn" type="button" class="w-full rounded-xl border border-cyan-500 text-cyan-600 font-semibold py-3 hover:bg-cyan-50" disabled>
-              Simpan
+              Simpan Perubahan
             </button>
           </div>
         </div>

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -23,6 +23,7 @@
 
   const matrixSection = document.getElementById('approvalMatrixSection');
   const matrixList = document.getElementById('approvalMatrixList');
+  const formFieldsSection = document.getElementById('approvalFormFields');
 
   const numberFormatter = new Intl.NumberFormat('id-ID');
 
@@ -46,6 +47,8 @@
     },
   ];
   nextId += 1;
+
+  let matrixGenerated = false;
 
   function formatNumber(value) {
     if (typeof value !== 'number' || Number.isNaN(value)) return '';
@@ -254,16 +257,28 @@
     });
   }
 
+  function ensureMatrixPlacement() {
+    if (!matrixSection || !formFieldsSection) return;
+    if (matrixSection.nextElementSibling === formFieldsSection) {
+      return;
+    }
+    const parent = matrixSection.parentElement;
+    if (parent) {
+      parent.insertBefore(matrixSection, formFieldsSection);
+    }
+  }
+
   function renderMatrixCards() {
     if (!matrixSection || !matrixList) return;
 
     matrixList.innerHTML = '';
 
-    if (!state.approvals.length) {
+    if (!matrixGenerated || !state.approvals.length) {
       matrixSection.classList.add('hidden');
       return;
     }
 
+    ensureMatrixPlacement();
     matrixSection.classList.remove('hidden');
 
     state.approvals.forEach((rule, index) => {
@@ -587,6 +602,7 @@
 
     const maxValue = getMaxValue();
     const approverValue = getApproverValue();
+    const hadChanges = hasChanges();
 
     if (maxValue == null || approverValue == null) {
       return;
@@ -605,6 +621,10 @@
         max: maxValue,
         approvers: approverValue,
       });
+    }
+
+    if (hadChanges) {
+      matrixGenerated = true;
     }
 
     renderAll();


### PR DESCRIPTION
## Summary
- prevent the approval matrix drawer section from rendering automatically when opening an approval for editing
- show and update the approval matrix only after the user changes key fields and saves, ensuring it remains positioned above the input form
- rename the save action to "Simpan Perubahan" to reflect the new behavior

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa461b9c08330946eb9e9cc82fb90