### PR TITLE
Ensure approval confirmation button waits for complete matrix coverage

### DIFF
--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -38,15 +38,7 @@
 
   let currentInitial = { min: MIN_LIMIT, max: null, approvers: null };
 
-  state.approvals = [
-    {
-      id: `matrix-${nextId}`,
-      min: MIN_LIMIT,
-      max: MAX_LIMIT,
-      approvers: 2,
-    },
-  ];
-  nextId += 1;
+  state.approvals = [];
 
   let matrixGenerated = false;
 


### PR DESCRIPTION
## Summary
- start the approval matrix in an empty state so the confirmation action begins disabled
- rely on existing coverage checks to re-enable "Konfirmasi Persetujuan Transfer" only after ranges fill the maximum limit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab20ff5708330975426fdef91e00f