### PR TITLE
Auto-fill minimum limit after matrix creation

### DIFF
--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -115,13 +115,26 @@
   function setDrawerContext(context, { min, max, approvers, editingIndex = null }) {
     state.drawerContext = context;
     state.editingMatrixIndex = editingIndex;
-    state.initialValues = { min, max, approvers };
+
+    let derivedMin = min;
+    if (
+      context === 'table' &&
+      editingIndex == null &&
+      state.matrixEntries.length > 0
+    ) {
+      const lastEntry = state.matrixEntries[state.matrixEntries.length - 1];
+      if (lastEntry && typeof lastEntry.max === 'number') {
+        derivedMin = lastEntry.max;
+      }
+    }
+
+    state.initialValues = { min: derivedMin, max, approvers };
 
     if (drawerTitle) {
       drawerTitle.textContent = context === 'matrix' ? 'Ubah Approval Matrix' : 'Ubah Persetujuan Transfer';
     }
 
-    setInputValue(minInput, min);
+    setInputValue(minInput, derivedMin);
     setInputValue(maxInput, max);
     setInputValue(approverInput, approvers);
 


### PR DESCRIPTION
## Summary
- auto-fill the "Batas Minimal" input with the most recent approval matrix maximum when creating additional rules in the drawer
- keep the approval matrix list interactions scoped to the drawer while preserving edit behaviour

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db1c5a58d08330a39b77de6e2c22d0