### PR TITLE
Auto-increment approval matrix minimum when adding rules

### DIFF
--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -124,7 +124,11 @@
     ) {
       const lastEntry = state.matrixEntries[state.matrixEntries.length - 1];
       if (lastEntry && typeof lastEntry.max === 'number') {
-        derivedMin = lastEntry.max;
+        if (lastEntry.max >= MAX_LIMIT) {
+          derivedMin = MAX_LIMIT;
+        } else {
+          derivedMin = lastEntry.max + 1;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- update the approval drawer logic so new approval rules default the minimum value to the previous card’s maximum plus one
- keep the confirm transfer button gated to only allow confirmation when a single approval matrix covers the full limit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2c8931848330b14e7b652c663efe