### PR TITLE
Add daily max limit validation to approval drawer

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -192,7 +192,8 @@
           <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-sky-100 bg-sky-50 text-sky-800">
             <span aria-hidden="true" class="text-xl">ℹ️</span>
             <p class="text-sm leading-relaxed">
-              Buat aturan persetujuan sesuai nominal transaksi, atau tetapkan langsung untuk limit harian Rp200.000.000.
+              Buat aturan persetujuan sesuai nominal transaksi, atau tetapkan langsung untuk limit harian
+              <span id="dailyMaxLimitValue" class="font-semibold">Rp200.000.000</span>.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- show the configurable daily maximum value in the drawer helper text
- enforce the daily maximum limit when editing the Batas Maksimal field, including inline error feedback

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db5780bdd483309523c69d1d9c93e8