### PR TITLE
Add confirmation bottom sheet for transfer approvals

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -261,6 +261,72 @@
           </button>
         </div>
       </div>
+
+      <div
+        id="confirmApprovalSheet"
+        class="pointer-events-none hidden absolute inset-0 z-30"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirmApprovalSheetTitle"
+      >
+        <div class="flex h-full flex-col justify-end">
+          <div
+            id="confirmApprovalSheetOverlay"
+            class="absolute inset-0 bg-slate-900/20 opacity-0 transition-opacity duration-200"
+          ></div>
+
+          <div class="relative z-10 flex h-full flex-col justify-end">
+            <div
+              id="confirmApprovalSheetPanel"
+              class="pointer-events-auto flex max-h-[90%] w-full translate-y-full flex-col overflow-hidden rounded-t-3xl border border-slate-100 bg-white shadow-2xl transition-transform duration-300 ease-out"
+            >
+              <header class="border-b border-slate-200 px-6 py-4 text-center">
+                <h3 id="confirmApprovalSheetTitle" class="text-base font-semibold text-slate-900">
+                  Konfirmasi Ubah Persetujuan Transfer
+                </h3>
+              </header>
+
+              <section class="px-6 py-4">
+                <div class="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-amber-800">
+                  <span
+                    aria-hidden="true"
+                    class="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-amber-100 text-base font-semibold"
+                  >
+                    !
+                  </span>
+                  <p class="text-sm leading-relaxed">
+                    Pastikan kombinasi limit transaksi dan jumlah penyetuju yang Anda tetapkan sudah sesuai demi keamanan perusahaan.
+                  </p>
+                </div>
+              </section>
+
+              <section class="flex-1 overflow-y-auto px-6 pb-6">
+                <h4 class="text-sm font-semibold text-slate-900">Daftar Persetujuan Transfer</h4>
+                <div id="confirmApprovalSheetList" class="mt-4 space-y-3 pb-1"></div>
+              </section>
+
+              <footer class="border-t border-slate-200 px-6 py-4 bg-white">
+                <div class="grid grid-cols-2 gap-3">
+                  <button
+                    id="confirmApprovalSheetBack"
+                    type="button"
+                    class="rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+                  >
+                    Kembali
+                  </button>
+                  <button
+                    id="confirmApprovalSheetProceed"
+                    type="button"
+                    class="rounded-xl bg-cyan-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-cyan-600"
+                  >
+                    Lanjut Ubah Persetujuan
+                  </button>
+                </div>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add an in-drawer bottom sheet to confirm transfer approval updates with warning, summary list, and actions
- wire confirmation flow to update the approval table, dispatch events, and manage the new bottom sheet state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5f466328833088f0ec9287ba3700