### PR TITLE
Prevent drawer animation when opening approval sheet

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -272,13 +272,13 @@
         <div class="flex h-full flex-col justify-end">
           <div
             id="confirmApprovalSheetOverlay"
-            class="absolute inset-0 bg-slate-900/20 opacity-0 transition-opacity duration-200"
+            class="absolute inset-0 pointer-events-auto bg-transparent"
           ></div>
 
           <div class="relative z-10 flex h-full flex-col justify-end">
             <div
               id="confirmApprovalSheetPanel"
-              class="pointer-events-auto flex max-h-[90%] w-full translate-y-full flex-col overflow-hidden rounded-t-3xl border border-slate-100 bg-white shadow-2xl transition-transform duration-300 ease-out"
+              class="pointer-events-auto flex max-h-[90%] w-full flex-col overflow-hidden rounded-t-3xl border border-slate-100 bg-white shadow-2xl"
             >
               <header class="border-b border-slate-200 px-6 py-4 text-center">
                 <h3 id="confirmApprovalSheetTitle" class="text-base font-semibold text-slate-900">

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -411,40 +411,28 @@
   }
 
   function openConfirmSheet() {
-    if (!confirmSheet || !confirmSheetPanel || !confirmSheetOverlay) {
+    if (!confirmSheet) {
       return;
     }
 
     confirmSheet.classList.remove('hidden');
     isConfirmSheetOpen = true;
 
-    requestAnimationFrame(() => {
-      confirmSheet.classList.remove('pointer-events-none');
-      confirmSheetOverlay.classList.add('opacity-100');
-      confirmSheetOverlay.classList.remove('opacity-0');
-      confirmSheetPanel.classList.remove('translate-y-full');
-      if (confirmSheetProceedBtn) {
-        confirmSheetProceedBtn.focus();
-      }
-    });
+    confirmSheet.classList.remove('pointer-events-none');
+    if (confirmSheetProceedBtn) {
+      confirmSheetProceedBtn.focus();
+    }
   }
 
   function closeConfirmSheet({ immediate = false } = {}) {
-    if (!confirmSheet || !confirmSheetPanel || !confirmSheetOverlay) {
+    if (!confirmSheet) {
       return;
     }
 
-    const finalize = () => {
+    if (immediate) {
       confirmSheet.classList.add('hidden');
       confirmSheet.classList.add('pointer-events-none');
-      confirmSheetOverlay.classList.remove('opacity-100');
-      confirmSheetOverlay.classList.add('opacity-0');
-      confirmSheetPanel.classList.add('translate-y-full');
       isConfirmSheetOpen = false;
-    };
-
-    if (immediate) {
-      finalize();
       return;
     }
 
@@ -453,24 +441,8 @@
     }
 
     confirmSheet.classList.add('pointer-events-none');
-    confirmSheetOverlay.classList.remove('opacity-100');
-    confirmSheetOverlay.classList.add('opacity-0');
-    confirmSheetPanel.classList.add('translate-y-full');
-
-    const onTransitionEnd = (event) => {
-      if (event.target !== confirmSheetPanel) {
-        return;
-      }
-      confirmSheetPanel.removeEventListener('transitionend', onTransitionEnd);
-      finalize();
-    };
-
-    confirmSheetPanel.addEventListener('transitionend', onTransitionEnd);
-
-    setTimeout(() => {
-      confirmSheetPanel.removeEventListener('transitionend', onTransitionEnd);
-      finalize();
-    }, 350);
+    confirmSheet.classList.add('hidden');
+    isConfirmSheetOpen = false;
   }
 
   function getCurrentInputValues() {


### PR DESCRIPTION
## Summary
- remove dimming and transition styling from the confirmation sheet overlay so the drawer layout stays fixed
- simplify the approval confirmation sheet open/close logic to avoid translate/opacity animations and keep focus on the bottom sheet only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db698a0a0483309cd210b428912ae1