### PR TITLE
Add pending approval drawer after OTP verification

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -342,6 +342,56 @@
           </div>
         </div>
       </div>
+      <div id="approvalPendingPane" class="hidden h-full flex flex-col">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+          <h2 class="text-lg font-semibold text-slate-900">Ubah Persetujuan Transfer</h2>
+          <button id="approvalPendingClose" type="button" class="text-2xl leading-none text-slate-500 hover:text-slate-700">&times;</button>
+        </div>
+        <div class="flex-1 overflow-y-auto px-6 py-8">
+          <div class="max-w-xl mx-auto space-y-10">
+            <div class="space-y-4 text-center">
+              <img src="img/illustration-2.svg" alt="Menunggu persetujuan" class="mx-auto h-20 w-20" />
+              <h3 class="text-2xl font-semibold text-slate-900">Menunggu Persetujuan Admin Lain</h3>
+            </div>
+
+            <section class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-500">DAFTAR PERSETUJUAN TRANSFER</p>
+              <div class="rounded-2xl border border-slate-200 overflow-hidden">
+                <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 bg-slate-50 px-5 py-3 text-[13px] font-semibold uppercase tracking-[.16em] text-slate-500">
+                  <span class="text-left">Nominal Transaksi</span>
+                  <span class="text-right">Jumlah Persetujuan</span>
+                </div>
+                <div id="approvalPendingList" class="divide-y divide-slate-100"></div>
+              </div>
+            </section>
+
+            <div class="flex items-start gap-3 px-4 py-4 rounded-xl border border-amber-200 bg-amber-50 text-left">
+              <span class="inline-flex h-10 w-10 flex-none items-center justify-center rounded-full bg-amber-100 text-xl leading-none text-amber-500">!</span>
+              <p class="text-sm font-medium text-amber-800">
+                Proses ini selesai diajukan. Sekarang Anda perlu menunggu persetujuan dari admin lain.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="sticky bottom-0 border-t border-slate-200 bg-white px-6 py-5">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <button
+              id="approvalPendingDismiss"
+              type="button"
+              class="rounded-xl border border-cyan-500 bg-white px-4 py-3 font-semibold text-slate-900 transition hover:bg-cyan-50 sm:flex-1"
+            >
+              Tutup
+            </button>
+            <button
+              id="approvalPendingViewProcess"
+              type="button"
+              class="rounded-xl bg-cyan-500 px-4 py-3 font-semibold text-white transition hover:bg-cyan-600 sm:ml-auto sm:flex-1"
+            >
+              Lihat Proses Persetujuan
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add a pending approval drawer layout after OTP verification that mirrors the success drawer structure
- populate the drawer with the submitted approval ranges, warning banner, and sticky actions
- hook up the OTP completion event to toggle the pending drawer and wire close/navigation handlers

## Testing
- Manual via `python3 -m http.server 8000` and triggering the `approval:confirm-transfer` event in the browser console

------
https://chatgpt.com/codex/tasks/task_e_68db8eaa5fd883309e72e1513b091763