### PR TITLE
Refactor drawer interactions to use shared controller

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -425,6 +425,7 @@
   </div>
 
   <script src="sidebar.js"></script>
+  <script src="drawer.js"></script>
   <script src="atur-persetujuan.js"></script>
 </body>
 </html>

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -31,6 +31,10 @@
   const resolvedDailyMaxLimit = resolveDailyMaxLimit();
 
   const drawer = document.getElementById('drawer');
+  const drawerController =
+    window.drawerManager && typeof window.drawerManager.register === 'function'
+      ? window.drawerManager.register(drawer, { manageAria: true })
+      : null;
   const approvalPane = document.getElementById('approvalPane');
   const drawerCloseBtn = document.getElementById('approvalDrawerClose');
   const drawerTitle = document.getElementById('approvalDrawerTitle');
@@ -154,7 +158,15 @@
     if (!drawer || state.isDrawerOpen) {
       return;
     }
-    drawer.classList.add('open');
+    if (drawerController) {
+      drawerController.open();
+    } else {
+      drawer.classList.add('open');
+      drawer.setAttribute('aria-hidden', 'false');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    }
     drawer.setAttribute('aria-hidden', 'false');
     state.isDrawerOpen = true;
   }
@@ -170,7 +182,15 @@
     if (approvalPane) {
       approvalPane.classList.remove('hidden');
     }
-    drawer.classList.remove('open');
+    if (drawerController) {
+      drawerController.close();
+    } else {
+      drawer.classList.remove('open');
+      drawer.setAttribute('aria-hidden', 'true');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    }
     drawer.setAttribute('aria-hidden', 'true');
     state.isDrawerOpen = false;
     state.drawerContext = null;

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -359,6 +359,7 @@
     </div>
   </div>
 
+  <script src="drawer.js"></script>
   <script src="batas-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -3,6 +3,10 @@
   const STORAGE_KEY = 'ambis:batas-transaksi-limit';
 
   const drawer = document.getElementById('drawer');
+  const drawerController =
+    window.drawerManager && typeof window.drawerManager.register === 'function'
+      ? window.drawerManager.register(drawer)
+      : null;
   const openBtn = document.getElementById('openLimitDrawerBtn');
   const closeBtn = document.getElementById('limitDrawerCloseBtn');
   const confirmBtn = document.getElementById('confirmLimitBtn');
@@ -474,22 +478,29 @@
     if (confirmBtn) confirmBtn.disabled = true;
 
     updateDisplays();
-    drawer.classList.add('open');
-
-    if (typeof window.sidebarCollapseForDrawer === 'function') {
-      window.sidebarCollapseForDrawer();
+    if (drawerController) {
+      drawerController.open();
+    } else {
+      drawer.classList.add('open');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
     }
   }
 
   function closeDrawer() {
     if (!drawer) return;
     closeConfirmSheet({ immediate: true });
-    drawer.classList.remove('open');
+    if (drawerController) {
+      drawerController.close();
+    } else {
+      drawer.classList.remove('open');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    }
     closeInfoOverlay();
     showFormView();
-    if (typeof window.sidebarRestoreForDrawer === 'function') {
-      window.sidebarRestoreForDrawer();
-    }
   }
 
   openBtn?.addEventListener('click', (event) => {

--- a/biller.html
+++ b/biller.html
@@ -557,6 +557,7 @@
   </div>
 
   <script src="data/rekening-data.js"></script>
+  <script src="drawer.js"></script>
   <script src="biller.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/biller.js
+++ b/biller.js
@@ -1567,6 +1567,11 @@
       paymentSheetOpen = true;
     }
 
+    const drawerController =
+      window.drawerManager && typeof window.drawerManager.register === 'function'
+        ? window.drawerManager.register(drawer)
+        : null;
+
     function openDrawer(key, button) {
       const config = BILLER_CONFIG[key];
       if (!config) return;
@@ -1575,15 +1580,21 @@
       closePaymentSheet({ immediate: true });
       hideSuccessDrawer({ immediate: true });
       setActiveButton(button);
-      const wasClosed = !drawer.classList.contains('open');
+      const wasClosed = drawerController
+        ? !drawerController.isOpen()
+        : !drawer.classList.contains('open');
       applyConfig(key, config);
       if (wasClosed) {
-        drawer.classList.add('open');
+        if (drawerController) {
+          drawerController.open({ trigger: button });
+        } else {
+          drawer.classList.add('open');
+          if (typeof window.sidebarCollapseForDrawer === 'function') {
+            window.sidebarCollapseForDrawer();
+          }
+        }
         drawerInner.classList.remove('opacity-0', 'translate-x-4');
         drawerInner.classList.add('opacity-100', 'translate-x-0');
-        if (typeof window.sidebarCollapseForDrawer === 'function') {
-          window.sidebarCollapseForDrawer();
-        }
       } else {
         drawerInner.classList.remove('opacity-0', 'translate-x-4');
         drawerInner.classList.add('opacity-100', 'translate-x-0');
@@ -1599,9 +1610,13 @@
       closeAccountSheet({ immediate: true });
       closePaymentSheet({ immediate: true });
       setTimeout(() => {
-        drawer.classList.remove('open');
-        if (typeof window.sidebarRestoreForDrawer === 'function') {
-          window.sidebarRestoreForDrawer();
+        if (drawerController) {
+          drawerController.close({ trigger: 'animation' });
+        } else {
+          drawer.classList.remove('open');
+          if (typeof window.sidebarRestoreForDrawer === 'function') {
+            window.sidebarRestoreForDrawer();
+          }
         }
         setActiveButton(null);
       }, 220);

--- a/drawer.js
+++ b/drawer.js
@@ -1,0 +1,134 @@
+(function () {
+  const registry = new WeakMap();
+
+  function getDrawerElement(target) {
+    if (!target) return null;
+    if (typeof target === 'string') {
+      return document.getElementById(target) || null;
+    }
+    if (target instanceof Element) {
+      return target;
+    }
+    return null;
+  }
+
+  function getState(drawer) {
+    if (!registry.has(drawer)) {
+      registry.set(drawer, {
+        isOpen: drawer.classList.contains('open'),
+        manageAria: drawer.hasAttribute('aria-hidden'),
+        openListeners: new Set(),
+        closeListeners: new Set(),
+      });
+    }
+    return registry.get(drawer);
+  }
+
+  function runListeners(listeners, detail) {
+    listeners.forEach((listener) => {
+      try {
+        listener(detail);
+      } catch (err) {
+        console.error('drawerManager listener error', err);
+      }
+    });
+  }
+
+  function updateAria(drawer, state, isOpen) {
+    if (!state.manageAria) return;
+    drawer.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  }
+
+  function openDrawer(target, options = {}) {
+    const drawer = getDrawerElement(target);
+    if (!drawer) return false;
+    const state = getState(drawer);
+    if (!state.isOpen) {
+      drawer.classList.add('open');
+      state.isOpen = true;
+      updateAria(drawer, state, true);
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+      const detail = { drawer, trigger: options.trigger || null };
+      runListeners(state.openListeners, detail);
+      drawer.dispatchEvent(new CustomEvent('drawer:open', { detail }));
+      return true;
+    }
+    return false;
+  }
+
+  function closeDrawer(target, options = {}) {
+    const drawer = getDrawerElement(target);
+    if (!drawer) return false;
+    const state = getState(drawer);
+    if (state.isOpen) {
+      drawer.classList.remove('open');
+      state.isOpen = false;
+      updateAria(drawer, state, false);
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+      const detail = { drawer, trigger: options.trigger || null };
+      runListeners(state.closeListeners, detail);
+      drawer.dispatchEvent(new CustomEvent('drawer:close', { detail }));
+      return true;
+    }
+    return false;
+  }
+
+  function toggleDrawer(target, options = {}) {
+    const drawer = getDrawerElement(target);
+    if (!drawer) return false;
+    const state = getState(drawer);
+    return state.isOpen
+      ? closeDrawer(drawer, options)
+      : openDrawer(drawer, options);
+  }
+
+  function register(target, config = {}) {
+    const drawer = getDrawerElement(target);
+    if (!drawer) return null;
+    const state = getState(drawer);
+    if (typeof config.manageAria === 'boolean') {
+      state.manageAria = config.manageAria;
+    }
+    if (typeof config.onOpen === 'function') {
+      state.openListeners.add(config.onOpen);
+    }
+    if (typeof config.onClose === 'function') {
+      state.closeListeners.add(config.onClose);
+    }
+
+    return {
+      element: drawer,
+      open: (opts) => openDrawer(drawer, opts),
+      close: (opts) => closeDrawer(drawer, opts),
+      toggle: (opts) => toggleDrawer(drawer, opts),
+      isOpen: () => getState(drawer).isOpen,
+      onOpen: (fn) => {
+        if (typeof fn === 'function') state.openListeners.add(fn);
+      },
+      onClose: (fn) => {
+        if (typeof fn === 'function') state.closeListeners.add(fn);
+      },
+      setAriaManaged: (value) => {
+        state.manageAria = Boolean(value);
+      },
+    };
+  }
+
+  function isOpen(target) {
+    const drawer = getDrawerElement(target);
+    if (!drawer) return false;
+    return getState(drawer).isOpen;
+  }
+
+  window.drawerManager = {
+    register,
+    open: openDrawer,
+    close: closeDrawer,
+    toggle: toggleDrawer,
+    isOpen,
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -341,6 +341,7 @@
   </div>
 
   <script src="data/rekening-data.js"></script>
+  <script src="drawer.js"></script>
   <script src="index.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -167,6 +167,10 @@ balanceToggleBtn?.addEventListener('click', () => {
 const drawer = document.getElementById('drawer');
 const openBtn = document.getElementById('ubahAksesBtn');
 const closeBtn = document.getElementById('drawerCloseBtn');
+const drawerController =
+  window.drawerManager && typeof window.drawerManager.register === 'function'
+    ? window.drawerManager.register(drawer)
+    : null;
 const dashboardGrid = document.getElementById('dashboardGrid');
 const pendingSection = document.getElementById('pendingSection');
 
@@ -189,19 +193,32 @@ updateDashboardLayout();
 function openDrawer() {
   tempSelectedAkses = [...selectedAkses];
   renderDrawer();
-  drawer.classList.add('open');
-  updateDashboardLayout();
-  if (typeof window.sidebarCollapseForDrawer === 'function') {
-    window.sidebarCollapseForDrawer();
+  if (drawerController) {
+    drawerController.open();
+  } else if (drawer) {
+    const wasClosed = !drawer.classList.contains('open');
+    if (wasClosed) {
+      drawer.classList.add('open');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    }
   }
+  updateDashboardLayout();
 }
 
 function closeDrawer() {
-  drawer.classList.remove('open');
-  updateDashboardLayout();
-  if (typeof window.sidebarRestoreForDrawer === 'function') {
-    window.sidebarRestoreForDrawer();
+  if (drawerController) {
+    drawerController.close();
+  } else if (drawer) {
+    if (drawer.classList.contains('open')) {
+      drawer.classList.remove('open');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    }
   }
+  updateDashboardLayout();
 }
 
 openBtn?.addEventListener('click', openDrawer);

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -934,6 +934,7 @@
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
+  <script src="drawer.js"></script>
   <script src="mutasi.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -15,6 +15,7 @@
   let accountGridNode = null;
   let emptyStateNode = null;
   let drawerNode = null;
+  let drawerController = null;
   let addAccountPaneNode = null;
   let formNode = null;
   let giroAccordionButton = null;
@@ -649,9 +650,13 @@
     }
     showDrawerPane('addAccount');
     if (drawerNode) {
-      drawerNode.classList.remove('open');
-      if (typeof window.sidebarRestoreForDrawer === 'function') {
-        window.sidebarRestoreForDrawer();
+      if (drawerController) {
+        drawerController.close({ trigger: 'pending' });
+      } else if (drawerNode.classList.contains('open')) {
+        drawerNode.classList.remove('open');
+        if (typeof window.sidebarRestoreForDrawer === 'function') {
+          window.sidebarRestoreForDrawer();
+        }
       }
     }
     if (pendingPaneLastFocusedElement && typeof pendingPaneLastFocusedElement.focus === 'function') {
@@ -1422,9 +1427,11 @@
     }
   }
 
-  function ensureDrawerOpen() {
+  function ensureDrawerOpen(trigger) {
     if (!drawerNode) return;
-    if (!drawerNode.classList.contains('open')) {
+    if (drawerController) {
+      drawerController.open({ trigger: trigger || null });
+    } else if (!drawerNode.classList.contains('open')) {
       drawerNode.classList.add('open');
       if (typeof window.sidebarCollapseForDrawer === 'function') {
         window.sidebarCollapseForDrawer();
@@ -1525,11 +1532,14 @@
 
   function openDrawer() {
     if (!drawerNode) return;
-    if (!drawerNode.classList.contains('open')) {
+    const wasClosed = drawerController
+      ? !drawerController.isOpen()
+      : !drawerNode.classList.contains('open');
+    if (wasClosed) {
       resetFormState();
     }
     showDrawerPane('addAccount');
-    ensureDrawerOpen();
+    ensureDrawerOpen('addAccount');
     if (formNode) {
       const focusTarget = formNode.querySelector('input, textarea, select');
       if (focusTarget) {
@@ -1547,9 +1557,13 @@
     const wasTransferActive = activeDrawerPane === 'transfer';
     const wasMutasiActive = activeDrawerPane === 'mutasi';
     showDrawerPane('addAccount');
-    drawerNode.classList.remove('open');
-    if (typeof window.sidebarRestoreForDrawer === 'function') {
-      window.sidebarRestoreForDrawer();
+    if (drawerController) {
+      drawerController.close({ trigger: 'drawer' });
+    } else if (drawerNode.classList.contains('open')) {
+      drawerNode.classList.remove('open');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
     }
     resetFormState();
 
@@ -1612,6 +1626,9 @@
     accountGridNode = document.getElementById('accountGrid');
     emptyStateNode = document.getElementById('accountEmptyState');
     drawerNode = document.getElementById('drawer');
+    if (drawerNode && window.drawerManager && typeof window.drawerManager.register === 'function') {
+      drawerController = window.drawerManager.register(drawerNode);
+    }
     addAccountPaneNode = document.getElementById('addAccountPane');
     formNode = document.getElementById('addAccountForm');
     giroAccordionButton = document.getElementById('giroSpecToggle');

--- a/mutasi.html
+++ b/mutasi.html
@@ -507,6 +507,7 @@
   <script src="filters.js"></script>
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
+  <script src="drawer.js"></script>
   <script src="mutasi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/transfer.html
+++ b/transfer.html
@@ -590,6 +590,7 @@
 </div> <!-- /layout container -->
 
   <script src="data/rekening-data.js"></script>
+  <script src="drawer.js"></script>
   <script src="transfer.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/transfer.js
+++ b/transfer.js
@@ -3,6 +3,10 @@
 document.addEventListener('DOMContentLoaded', () => {
   const openBtn  = document.getElementById('openTransferDrawer');
   const drawer   = document.getElementById('drawer');
+  const drawerController =
+    window.drawerManager && typeof window.drawerManager.register === 'function'
+      ? window.drawerManager.register(drawer)
+      : null;
   const transferPane = document.getElementById('transferPane');
   const movePane = document.getElementById('movePane');
   const successPane = document.getElementById('successPane');
@@ -653,7 +657,17 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane?.classList.add('hidden');
     movePane?.classList.add('hidden');
     successPane?.classList.remove('hidden');
-    drawer.classList.add('open');
+    if (drawerController) {
+      drawerController.open({ trigger: 'success' });
+    } else if (drawer) {
+      const wasClosed = !drawer.classList.contains('open');
+      if (wasClosed) {
+        drawer.classList.add('open');
+        if (typeof window.sidebarCollapseForDrawer === 'function') {
+          window.sidebarCollapseForDrawer();
+        }
+      }
+    }
     updateCardGridLayout();
     successCloseBtn?.focus();
     const activeType = lastTransactionDetails.type === 'move' ? 'move' : 'transfer';
@@ -1121,15 +1135,19 @@ document.addEventListener('DOMContentLoaded', () => {
     movePane.classList.add('hidden');
     transferPane.classList.remove('hidden');
     successPane?.classList.add('hidden');
-    drawer.classList.add('open');
+    if (drawerController) {
+      drawerController.open({ trigger: 'transfer' });
+    } else if (drawer && !drawer.classList.contains('open')) {
+      drawer.classList.add('open');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    }
     updateCardGridLayout();
     sourceLocked = false;
     setButtonLocked(sourceBtn, false);
     activePaneType = 'transfer';
     updateConfirmSheetContent(activePaneType);
-    if (typeof window.sidebarCollapseForDrawer === 'function') {
-      window.sidebarCollapseForDrawer();
-    }
     setActiveActivityCard('transfer');
   }
 
@@ -1137,7 +1155,14 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.add('hidden');
     movePane.classList.add('hidden');
     successPane?.classList.add('hidden');
-    drawer.classList.remove('open');
+    if (drawerController) {
+      drawerController.close({ trigger: 'close' });
+    } else if (drawer && drawer.classList.contains('open')) {
+      drawer.classList.remove('open');
+      if (typeof window.sidebarRestoreForDrawer === 'function') {
+        window.sidebarRestoreForDrawer();
+      }
+    }
     updateCardGridLayout();
     closeSheet();
     closeDestSheet();
@@ -1145,9 +1170,6 @@ document.addEventListener('DOMContentLoaded', () => {
     lastTransactionDetails = null;
     activePaneType = DEFAULT_ACTIVITY_TYPE;
     updateConfirmSheetContent(activePaneType);
-    if (typeof window.sidebarRestoreForDrawer === 'function') {
-      window.sidebarRestoreForDrawer();
-    }
     clearActiveActivityCard();
     if (isEmbedded && window.parent && window.parent !== window) {
       try {
@@ -1162,7 +1184,14 @@ document.addEventListener('DOMContentLoaded', () => {
     transferPane.classList.add('hidden');
     movePane.classList.remove('hidden');
     successPane?.classList.add('hidden');
-    drawer.classList.add('open');
+    if (drawerController) {
+      drawerController.open({ trigger: 'move' });
+    } else if (drawer && !drawer.classList.contains('open')) {
+      drawer.classList.add('open');
+      if (typeof window.sidebarCollapseForDrawer === 'function') {
+        window.sidebarCollapseForDrawer();
+      }
+    }
     updateCardGridLayout();
     moveSourceLocked = false;
     setButtonLocked(moveSourceBtn, false);
@@ -1189,9 +1218,6 @@ document.addEventListener('DOMContentLoaded', () => {
     updateMoveConfirmState();
     activePaneType = 'move';
     updateConfirmSheetContent(activePaneType);
-    if (typeof window.sidebarCollapseForDrawer === 'function') {
-      window.sidebarCollapseForDrawer();
-    }
     setActiveActivityCard('move');
   }
 


### PR DESCRIPTION
## Summary
- introduce a shared `drawerManager` helper that centralises open/close state handling
- update drawer-enabled pages to call the shared controller instead of toggling classes directly
- ensure every page that uses a drawer loads the new helper script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb41bf5d083308aecf2c5a5ec364d