### PR TITLE
Refactor bottom sheet behavior to use shared manager

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,43 +298,49 @@ document.addEventListener('DOMContentLoaded', () => {
     sheetChoose.classList.toggle('hover:bg-cyan-700', enable);
   }
 
+  const rekeningSheetState = {};
+  const rekeningSheetController = window.bottomSheetManager?.create({
+    overlay: sheetBackdrop,
+    sheet: sheetPanel,
+    state: rekeningSheetState,
+    openDuration: 200,
+    closeDuration: 110,
+    onBeforeOpen: () => {
+      ignoreNextOutside = true;
+      sheetPanel.classList.remove('duration-100');
+      sheetPanel.classList.add('duration-200');
+      sheetBackdrop.classList.remove('duration-100');
+      sheetBackdrop.classList.add('duration-200');
+      inner?.classList.add('overflow-hidden');
+      sheet?.classList.remove('hidden');
+      enableChoose(false);
+      sheet?.querySelectorAll('input[name="rek"]').forEach((r) => { r.checked = false; });
+    },
+    onAfterOpen: () => {
+      ignoreNextOutside = false;
+    },
+    onBeforeClose: () => {
+      sheetPanel.classList.remove('duration-200');
+      sheetPanel.classList.add('duration-100');
+      sheetBackdrop.classList.remove('duration-200');
+      sheetBackdrop.classList.add('duration-100');
+    },
+    onAfterClose: () => {
+      sheet?.classList.add('hidden');
+      inner?.classList.remove('overflow-hidden');
+      sheetPanel.classList.remove('duration-100');
+      sheetPanel.classList.add('duration-200');
+      sheetBackdrop.classList.remove('duration-100');
+      sheetBackdrop.classList.add('duration-200');
+    },
+  });
+
   function openSheet() {
-    ignoreNextOutside = true;
-
-    // normal (longer) duration on open
-    sheetPanel.classList.remove('duration-100'); sheetPanel.classList.add('duration-200');
-    sheetBackdrop.classList.remove('duration-100'); sheetBackdrop.classList.add('duration-200');
-
-    inner.classList.add('overflow-hidden'); // lock drawer scroll
-    sheet.classList.remove('hidden');
-
-    // reset state
-    enableChoose(false);
-    sheet.querySelectorAll('input[name="rek"]').forEach(r => { r.checked = false; });
-
-    requestAnimationFrame(() => {
-      sheetBackdrop.classList.remove('opacity-0');     // fade in
-      sheetPanel.classList.remove('translate-y-full'); // slide up
-      setTimeout(() => { ignoreNextOutside = false; }, 0); // allow outside-close next tick
-    });
+    rekeningSheetController?.open();
   }
 
   function closeSheet() {
-    // faster close
-    sheetPanel.classList.remove('duration-200'); sheetPanel.classList.add('duration-100');
-    sheetBackdrop.classList.remove('duration-200'); sheetBackdrop.classList.add('duration-100');
-
-    sheetBackdrop.classList.add('opacity-0');      // fade out
-    sheetPanel.classList.add('translate-y-full');  // slide down
-
-    setTimeout(() => {
-      sheet.classList.add('hidden');
-      inner.classList.remove('overflow-hidden');   // unlock drawer scroll
-
-      // restore normal duration for next open
-      sheetPanel.classList.remove('duration-100'); sheetPanel.classList.add('duration-200');
-      sheetBackdrop.classList.remove('duration-100'); sheetBackdrop.classList.add('duration-200');
-    }, 110);
+    rekeningSheetController?.close();
   }
 
   // Open (prevent immediate outside-close)

--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -426,6 +426,7 @@
 
   <script src="sidebar.js"></script>
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="atur-persetujuan.js"></script>
 </body>
 </html>

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -73,6 +73,14 @@
   const confirmOtpResendBtn = document.getElementById('approvalConfirmOtpResend');
   const confirmOtpError = document.getElementById('approvalConfirmOtpError');
 
+  const confirmSheetState = {};
+  const confirmSheetController = window.bottomSheetManager?.create({
+    overlay: confirmOverlay,
+    sheet: confirmSheet,
+    state: confirmSheetState,
+    closeDuration: 200,
+  });
+
   const numberFormatter = new Intl.NumberFormat('id-ID');
 
   const CONFIRM_BACK_DEFAULT_LABEL = 'Kembali';
@@ -752,15 +760,19 @@
     window.clearTimeout(confirmOverlayHideTimeout);
     confirmOverlayHideTimeout = null;
 
-    confirmOverlay.classList.remove('hidden');
-    confirmOverlay.classList.remove('opacity-100');
-    confirmOverlay.classList.add('opacity-0');
+    if (confirmSheetController) {
+      confirmSheetController.open();
+    } else {
+      confirmOverlay.classList.remove('hidden');
+      confirmOverlay.classList.remove('opacity-100');
+      confirmOverlay.classList.add('opacity-0');
 
-    requestAnimationFrame(() => {
-      confirmOverlay.classList.remove('opacity-0');
-      confirmOverlay.classList.add('opacity-100');
-      confirmSheet.classList.remove('translate-y-full');
-    });
+      requestAnimationFrame(() => {
+        confirmOverlay.classList.remove('opacity-0');
+        confirmOverlay.classList.add('opacity-100');
+        confirmSheet.classList.remove('translate-y-full');
+      });
+    }
 
     isConfirmSheetOpen = true;
 
@@ -777,14 +789,19 @@
     resetConfirmOtpState();
     isConfirmSheetOpen = false;
 
-    confirmSheet.classList.add('translate-y-full');
-    confirmOverlay.classList.remove('opacity-100');
-    confirmOverlay.classList.add('opacity-0');
-
-    confirmOverlayHideTimeout = window.setTimeout(() => {
-      confirmOverlay.classList.add('hidden');
+    if (confirmSheetController) {
+      confirmSheetController.close();
       confirmOverlayHideTimeout = null;
-    }, 200);
+    } else {
+      confirmSheet.classList.add('translate-y-full');
+      confirmOverlay.classList.remove('opacity-100');
+      confirmOverlay.classList.add('opacity-0');
+
+      confirmOverlayHideTimeout = window.setTimeout(() => {
+        confirmOverlay.classList.add('hidden');
+        confirmOverlayHideTimeout = null;
+      }, 200);
+    }
 
     if (focusTrigger && confirmBtn) {
       confirmBtn.focus({ preventScroll: true });

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -360,6 +360,7 @@
   </div>
 
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="batas-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/batas-transaksi.js
+++ b/batas-transaksi.js
@@ -35,6 +35,23 @@
     cancelBtn: document.getElementById('limitConfirmCancelBtn'),
     proceedBtn: document.getElementById('limitConfirmProceedBtn'),
   };
+  const confirmSheetState = {};
+  const confirmSheetController = window.bottomSheetManager?.create({
+    overlay: confirmElements.overlay,
+    sheet: confirmElements.sheet,
+    state: confirmSheetState,
+    sheetVisibleClass: 'translate-y-0',
+    openDuration: 300,
+    closeDuration: 300,
+    onBeforeOpen: () => {
+      confirmElements.sheet?.setAttribute('aria-hidden', 'false');
+      confirmElements.container?.classList.remove('pointer-events-none');
+    },
+    onAfterClose: () => {
+      confirmElements.container?.classList.add('pointer-events-none');
+      confirmElements.sheet?.setAttribute('aria-hidden', 'true');
+    },
+  });
 
   const otpElements = {
     section: document.getElementById('limitOtpSection'),
@@ -404,23 +421,23 @@
       newValue.textContent = formatCurrency(newLimitValue);
     }
 
-    sheet.setAttribute('aria-hidden', 'false');
-
-    container?.classList.remove('pointer-events-none');
-
-    overlay.classList.remove('hidden');
-    overlay.classList.add('opacity-0');
-    overlay.classList.remove('opacity-100');
-
-    sheet.classList.add('translate-y-full');
-    sheet.classList.remove('translate-y-0');
-
-    requestAnimationFrame(() => {
-      overlay.classList.remove('opacity-0');
-      overlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-      sheet.classList.add('translate-y-0');
-    });
+    if (confirmSheetController) {
+      confirmSheetController.open();
+    } else {
+      sheet.setAttribute('aria-hidden', 'false');
+      container?.classList.remove('pointer-events-none');
+      overlay.classList.remove('hidden');
+      overlay.classList.add('opacity-0');
+      overlay.classList.remove('opacity-100');
+      sheet.classList.add('translate-y-full');
+      sheet.classList.remove('translate-y-0');
+      requestAnimationFrame(() => {
+        overlay.classList.remove('opacity-0');
+        overlay.classList.add('opacity-100');
+        sheet.classList.remove('translate-y-full');
+        sheet.classList.add('translate-y-0');
+      });
+    }
   }
 
   function closeConfirmSheet(options = {}) {
@@ -431,6 +448,11 @@
     confirmSheetOpen = false;
     pendingNewLimit = null;
     resetOtpState();
+    if (confirmSheetController) {
+      confirmSheetController.close({ immediate: Boolean(options.immediate) });
+      return;
+    }
+
     sheet.setAttribute('aria-hidden', 'true');
 
     const finishClose = () => {

--- a/biller.html
+++ b/biller.html
@@ -558,6 +558,7 @@
 
   <script src="data/rekening-data.js"></script>
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="biller.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/biller.js
+++ b/biller.js
@@ -404,6 +404,36 @@
     const successStatusButtonDefaultText = successStatusButton?.textContent?.trim() || 'Cek Status';
     const billerButtons = document.querySelectorAll('[data-biller]');
 
+    const accountSheetState = {};
+    const accountSheetController = window.bottomSheetManager?.create({
+      overlay: accountSheetOverlay,
+      sheet: accountBottomSheet,
+      state: accountSheetState,
+      closeDuration: 220,
+      onAfterClose: () => {
+        pendingAccountId = appliedAccountId;
+      },
+    });
+
+    const savedSheetState = {};
+    const savedSheetController = window.bottomSheetManager?.create({
+      overlay: savedSheetOverlay,
+      sheet: savedBottomSheet,
+      state: savedSheetState,
+      closeDuration: 220,
+      onAfterClose: () => {
+        pendingSavedId = savedSelections.get(activeKey)?.id || '';
+      },
+    });
+
+    const paymentSheetState = {};
+    const paymentSheetController = window.bottomSheetManager?.create({
+      overlay: paymentSheetOverlay,
+      sheet: paymentBottomSheet,
+      state: paymentSheetState,
+      closeDuration: 220,
+    });
+
     function normaliseAccount(account, index) {
       if (!account) return null;
       const id = account.id || account.accountId || account.numberRaw || account.number || `acc-${index}`;
@@ -608,11 +638,15 @@
       }
       renderAccountOptions(pendingAccountId);
       setAccountSheetConfirmState(Boolean(pendingAccountId));
-      accountSheetOverlay.classList.remove('hidden');
-      requestAnimationFrame(() => {
-        accountSheetOverlay.classList.add('opacity-100');
-        accountBottomSheet.classList.remove('translate-y-full');
-      });
+      if (accountSheetController) {
+        accountSheetController.open();
+      } else {
+        accountSheetOverlay.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          accountSheetOverlay.classList.add('opacity-100');
+          accountBottomSheet.classList.remove('translate-y-full');
+        });
+      }
       accountSheetOpen = true;
     }
 
@@ -620,6 +654,10 @@
       if (!accountSheetOverlay || !accountBottomSheet) return;
       const immediate = Boolean(options.immediate);
       accountSheetOpen = false;
+      if (accountSheetController) {
+        accountSheetController.close({ immediate });
+        return;
+      }
       if (immediate) {
         accountSheetOverlay.classList.remove('opacity-100');
         accountSheetOverlay.classList.add('hidden');
@@ -797,11 +835,15 @@
       if (savedSheetList && !savedSheetList.children.length) {
         setSavedSheetConfirmState(false);
       }
-      savedSheetOverlay.classList.remove('hidden');
-      requestAnimationFrame(() => {
-        savedSheetOverlay.classList.add('opacity-100');
-        savedBottomSheet.classList.remove('translate-y-full');
-      });
+      if (savedSheetController) {
+        savedSheetController.open();
+      } else {
+        savedSheetOverlay.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          savedSheetOverlay.classList.add('opacity-100');
+          savedBottomSheet.classList.remove('translate-y-full');
+        });
+      }
       savedSheetOpen = true;
     }
 
@@ -809,6 +851,10 @@
       if (!savedSheetOverlay || !savedBottomSheet) return;
       const immediate = Boolean(options.immediate);
       savedSheetOpen = false;
+      if (savedSheetController) {
+        savedSheetController.close({ immediate });
+        return;
+      }
       if (immediate) {
         savedSheetOverlay.classList.remove('opacity-100');
         savedSheetOverlay.classList.add('hidden');
@@ -1047,6 +1093,10 @@
       resetPaymentOtpState();
       const immediate = Boolean(options.immediate);
       paymentSheetOpen = false;
+      if (paymentSheetController) {
+        paymentSheetController.close({ immediate });
+        return;
+      }
       if (immediate) {
         paymentSheetOverlay.classList.remove('opacity-100');
         paymentSheetOverlay.classList.add('hidden');
@@ -1559,11 +1609,15 @@
         heroSubtitle: displayName,
       };
 
-      paymentSheetOverlay.classList.remove('hidden');
-      requestAnimationFrame(() => {
-        paymentSheetOverlay.classList.add('opacity-100');
-        paymentBottomSheet.classList.remove('translate-y-full');
-      });
+      if (paymentSheetController) {
+        paymentSheetController.open();
+      } else {
+        paymentSheetOverlay.classList.remove('hidden');
+        requestAnimationFrame(() => {
+          paymentSheetOverlay.classList.add('opacity-100');
+          paymentBottomSheet.classList.remove('translate-y-full');
+        });
+      }
       paymentSheetOpen = true;
     }
 

--- a/bottomsheet.js
+++ b/bottomsheet.js
@@ -1,0 +1,223 @@
+(function () {
+  const DEFAULT_DURATION = 200;
+
+  function schedule(callback, delay, state, key) {
+    if (typeof callback !== 'function') {
+      return null;
+    }
+    if (!delay || delay <= 0) {
+      callback();
+      return null;
+    }
+    const id = window.setTimeout(() => {
+      if (state) {
+        state[key] = null;
+      }
+      callback();
+    }, delay);
+    if (state) {
+      state[key] = id;
+    }
+    return id;
+  }
+
+  function clearTimer(state, key) {
+    if (!state || !state[key]) return;
+    window.clearTimeout(state[key]);
+    state[key] = null;
+  }
+
+  function resolveDuration(options, kind) {
+    if (options == null) {
+      return DEFAULT_DURATION;
+    }
+    if (kind === 'open' && typeof options.openDuration === 'number') {
+      return options.openDuration;
+    }
+    if (kind === 'close' && typeof options.closeDuration === 'number') {
+      return options.closeDuration;
+    }
+    if (typeof options.duration === 'number') {
+      return options.duration;
+    }
+    return DEFAULT_DURATION;
+  }
+
+  function createController(config = {}) {
+    const overlay = config.overlay;
+    const sheet = config.sheet;
+    if (!overlay || !sheet) {
+      return null;
+    }
+
+    const state = config.state || {};
+    if (state.overlay && state.overlay !== overlay) {
+      state.overlay = overlay;
+    } else if (!state.overlay) {
+      state.overlay = overlay;
+    }
+
+    if (typeof state.hiddenClass !== 'string') {
+      state.hiddenClass = config.hiddenClass || 'hidden';
+    }
+    if (typeof state.overlayVisibleClass !== 'string') {
+      state.overlayVisibleClass = config.overlayVisibleClass || 'opacity-100';
+    }
+    if (typeof state.overlayHiddenClass !== 'string') {
+      state.overlayHiddenClass = config.overlayHiddenClass || 'opacity-0';
+    }
+    if (!('activeSheet' in state)) {
+      state.activeSheet = null;
+    }
+    state.openTimer = state.openTimer || null;
+    state.closeTimer = state.closeTimer || null;
+
+    const defaults = {
+      sheetHiddenClass: config.sheetHiddenClass || 'translate-y-full',
+      sheetVisibleClass: config.sheetVisibleClass || '',
+      duration: typeof config.duration === 'number' ? config.duration : undefined,
+      openDuration: typeof config.openDuration === 'number' ? config.openDuration : undefined,
+      closeDuration: typeof config.closeDuration === 'number' ? config.closeDuration : undefined,
+      onBeforeOpen: typeof config.onBeforeOpen === 'function' ? config.onBeforeOpen : null,
+      onAfterOpen: typeof config.onAfterOpen === 'function' ? config.onAfterOpen : null,
+      onBeforeClose: typeof config.onBeforeClose === 'function' ? config.onBeforeClose : null,
+      onAfterClose: typeof config.onAfterClose === 'function' ? config.onAfterClose : null,
+    };
+
+    function clearTimers() {
+      clearTimer(state, 'openTimer');
+      clearTimer(state, 'closeTimer');
+    }
+
+    function applyOpenClasses(sheetEl, opts) {
+      const overlayEl = state.overlay;
+      overlayEl.classList.remove(state.overlayHiddenClass);
+      overlayEl.classList.add(state.overlayVisibleClass);
+      sheetEl.classList.remove(opts.sheetHiddenClass);
+      if (opts.sheetVisibleClass) {
+        sheetEl.classList.add(opts.sheetVisibleClass);
+      }
+      state.activeSheet = sheetEl;
+    }
+
+    function open(options = {}) {
+      const opts = {
+        ...defaults,
+        ...options,
+      };
+      const overlayEl = state.overlay;
+      if (!overlayEl) {
+        return;
+      }
+      clearTimers();
+
+      const hiddenClass = state.hiddenClass;
+      const immediate = Boolean(opts.immediate);
+      const sheetHiddenClass = opts.sheetHiddenClass || 'translate-y-full';
+      const sheetVisibleClass = opts.sheetVisibleClass || '';
+
+      opts.onBeforeOpen?.();
+
+      overlayEl.classList.remove(hiddenClass);
+
+      if (!immediate) {
+        overlayEl.classList.remove(state.overlayVisibleClass);
+        overlayEl.classList.add(state.overlayHiddenClass);
+        sheet.classList.add(sheetHiddenClass);
+      }
+
+      if (state.activeSheet && state.activeSheet !== sheet) {
+        state.activeSheet.classList.add(sheetHiddenClass);
+        if (sheetVisibleClass) {
+          state.activeSheet.classList.remove(sheetVisibleClass);
+        }
+      }
+
+      const runOpen = () => applyOpenClasses(sheet, { sheetHiddenClass, sheetVisibleClass });
+
+      if (immediate) {
+        runOpen();
+        opts.onAfterOpen?.();
+      } else {
+        window.requestAnimationFrame(runOpen);
+        schedule(opts.onAfterOpen, resolveDuration(opts, 'open'), state, 'openTimer');
+      }
+      controller.isOpen = true;
+    }
+
+    function finalizeClose(sheetEl, opts) {
+      if (state.activeSheet === sheetEl) {
+        state.activeSheet = null;
+      }
+      if (!state.activeSheet) {
+        state.overlay.classList.add(state.hiddenClass);
+      }
+      opts.onAfterClose?.();
+    }
+
+    function close(options = {}) {
+      const opts = {
+        ...defaults,
+        ...options,
+      };
+      const overlayEl = state.overlay;
+      if (!overlayEl) {
+        return;
+      }
+      clearTimers();
+
+      const sheetHiddenClass = opts.sheetHiddenClass || 'translate-y-full';
+      const sheetVisibleClass = opts.sheetVisibleClass || '';
+      const immediate = Boolean(opts.immediate);
+
+      opts.onBeforeClose?.();
+
+      if (sheetVisibleClass) {
+        sheet.classList.remove(sheetVisibleClass);
+      }
+      sheet.classList.add(sheetHiddenClass);
+      overlayEl.classList.remove(state.overlayVisibleClass);
+      overlayEl.classList.add(state.overlayHiddenClass);
+
+      if (immediate) {
+        finalizeClose(sheet, opts);
+      } else {
+        schedule(() => finalizeClose(sheet, opts), resolveDuration(opts, 'close'), state, 'closeTimer');
+      }
+      controller.isOpen = false;
+    }
+
+    function toggle(options = {}) {
+      if (controller.isOpen) {
+        close(options);
+      } else {
+        open(options);
+      }
+    }
+
+    const controller = {
+      open,
+      close,
+      toggle,
+      get overlay() {
+        return state.overlay;
+      },
+      get sheet() {
+        return sheet;
+      },
+      isOpen: false,
+    };
+
+    if (config.closeOnOverlayClick && state.overlay) {
+      state.overlay.addEventListener('click', () => {
+        close();
+      });
+    }
+
+    return controller;
+  }
+
+  window.bottomSheetManager = {
+    create: createController,
+  };
+})();

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -935,6 +935,7 @@
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="mutasi.js"></script>
   <script src="informasi-rekening.js"></script>
   <script src="sidebar.js"></script>

--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -41,6 +41,7 @@
   let confirmSheetPurposeNode = null;
   let confirmSheetGiroToggleNode = null;
   let confirmSheetGiroContentNode = null;
+  let confirmSheetController = null;
   let otpSectionNode = null;
   let otpInputs = [];
   let otpCountdownNode = null;
@@ -466,18 +467,22 @@
     resetOtpState();
     setConfirmSheetAccordionExpanded(false);
 
-    if (confirmOverlayNode) {
-      confirmOverlayNode.classList.remove('hidden');
-      confirmOverlayNode.classList.remove('opacity-100');
-      confirmOverlayNode.classList.add('opacity-0');
-      requestAnimationFrame(() => {
-        confirmOverlayNode.classList.remove('opacity-0');
-        confirmOverlayNode.classList.add('opacity-100');
-      });
-    }
+    if (confirmSheetController) {
+      confirmSheetController.open();
+    } else {
+      if (confirmOverlayNode) {
+        confirmOverlayNode.classList.remove('hidden');
+        confirmOverlayNode.classList.remove('opacity-100');
+        confirmOverlayNode.classList.add('opacity-0');
+        requestAnimationFrame(() => {
+          confirmOverlayNode.classList.remove('opacity-0');
+          confirmOverlayNode.classList.add('opacity-100');
+        });
+      }
 
-    if (confirmSheetNode) {
-      confirmSheetNode.classList.remove('translate-y-full');
+      if (confirmSheetNode) {
+        confirmSheetNode.classList.remove('translate-y-full');
+      }
     }
 
     if (confirmSheetSubmitButton) {
@@ -493,20 +498,24 @@
 
   function closeConfirmSheet({ resetPending = true, immediate = false } = {}) {
     resetOtpState();
-    if (confirmSheetNode) {
-      confirmSheetNode.classList.add('translate-y-full');
-    }
+    if (confirmSheetController) {
+      confirmSheetController.close({ immediate });
+    } else {
+      if (confirmSheetNode) {
+        confirmSheetNode.classList.add('translate-y-full');
+      }
 
-    if (confirmOverlayNode) {
-      confirmOverlayNode.classList.remove('opacity-100');
-      confirmOverlayNode.classList.add('opacity-0');
-      const hideOverlay = () => {
-        confirmOverlayNode.classList.add('hidden');
-      };
-      if (immediate) {
-        hideOverlay();
-      } else {
-        setTimeout(hideOverlay, CONFIRM_SHEET_TRANSITION_MS);
+      if (confirmOverlayNode) {
+        confirmOverlayNode.classList.remove('opacity-100');
+        confirmOverlayNode.classList.add('opacity-0');
+        const hideOverlay = () => {
+          confirmOverlayNode.classList.add('hidden');
+        };
+        if (immediate) {
+          hideOverlay();
+        } else {
+          setTimeout(hideOverlay, CONFIRM_SHEET_TRANSITION_MS);
+        }
       }
     }
 
@@ -1654,6 +1663,17 @@
     confirmSheetPurposeNode = document.getElementById('addAccountConfirmPurpose');
     confirmSheetGiroToggleNode = document.getElementById('addAccountConfirmGiroToggle');
     confirmSheetGiroContentNode = document.getElementById('addAccountConfirmGiroContent');
+    confirmSheetController = window.bottomSheetManager?.create({
+      overlay: confirmOverlayNode,
+      sheet: confirmSheetNode,
+      closeDuration: CONFIRM_SHEET_TRANSITION_MS,
+      onBeforeOpen: () => {
+        confirmSheetNode?.setAttribute('aria-hidden', 'false');
+      },
+      onAfterClose: () => {
+        confirmSheetNode?.setAttribute('aria-hidden', 'true');
+      },
+    });
     otpSectionNode = document.getElementById('addAccountOtpSection');
     otpInputs = otpSectionNode ? Array.from(otpSectionNode.querySelectorAll('.otp-input')) : [];
     otpCountdownNode = document.getElementById('addAccountOtpCountdown');

--- a/mutasi.html
+++ b/mutasi.html
@@ -508,6 +508,7 @@
   <script src="data/rekening-data.js"></script>
   <script src="data/mutasi-data.js"></script>
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="mutasi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/mutasi.js
+++ b/mutasi.js
@@ -19,6 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const filterGroup = document.querySelector('[data-filter-group="mutasi"]');
   const detailOverlay = document.getElementById('mutasiDetailOverlay');
   const detailSheet = document.getElementById('mutasiDetailSheet');
+  const detailSheetState = {};
+  const detailSheetController = window.bottomSheetManager?.create({
+    overlay: detailOverlay,
+    sheet: detailSheet,
+    state: detailSheetState,
+  });
   const detailContent = document.getElementById('mutasiDetailView');
   const detailCloseButtons = document.querySelectorAll('[data-mutasi-detail-close]');
   const detailElements = {
@@ -443,14 +449,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!detailSheet || !detailOverlay) return;
     fillDetailSheet(transaction || {}, { time: generateMockTime() });
     detailIsOpen = true;
-    detailOverlay.classList.remove('hidden');
     if (detailContent) {
       detailContent.scrollTo({ top: 0, behavior: 'auto' });
     }
-    requestAnimationFrame(() => {
-      detailOverlay.classList.add('opacity-100');
-      detailSheet.classList.remove('translate-y-full');
-    });
+    if (detailSheetController) {
+      detailSheetController.open();
+    } else if (detailOverlay && detailSheet) {
+      detailOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        detailOverlay.classList.add('opacity-100');
+        detailSheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function closeDetailSheet(immediate = false) {
@@ -458,19 +468,21 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!detailIsOpen && !immediate) return;
 
     detailIsOpen = false;
-    detailSheet.classList.add('translate-y-full');
-    detailOverlay.classList.remove('opacity-100');
-
-    if (immediate) {
-      detailOverlay.classList.add('hidden');
-      return;
-    }
-
-    setTimeout(() => {
-      if (!detailIsOpen) {
+    if (detailSheetController) {
+      detailSheetController.close({ immediate });
+    } else if (detailSheet && detailOverlay) {
+      detailSheet.classList.add('translate-y-full');
+      detailOverlay.classList.remove('opacity-100');
+      if (immediate) {
         detailOverlay.classList.add('hidden');
+      } else {
+        setTimeout(() => {
+          if (!detailIsOpen) {
+            detailOverlay.classList.add('hidden');
+          }
+        }, 200);
       }
-    }, 200);
+    }
   }
 
   function showState(state) {

--- a/transfer.html
+++ b/transfer.html
@@ -591,6 +591,7 @@
 
   <script src="data/rekening-data.js"></script>
   <script src="drawer.js"></script>
+  <script src="bottomsheet.js"></script>
   <script src="transfer.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/transfer.js
+++ b/transfer.js
@@ -124,6 +124,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const otpCountdownDefaultMessage = otpCountdownMessage?.textContent?.trim() || 'Sesi akan berakhir dalam';
   const OTP_EXPIRED_MESSAGE = 'Sesi Anda telah berakhir.';
 
+  const sheetState = {};
+  const sourceSheetController = window.bottomSheetManager?.create({
+    overlay: sheetOverlay,
+    sheet,
+    state: sheetState,
+    closeDuration: 200,
+  });
+  const destSheetController = window.bottomSheetManager?.create({
+    overlay: sheetOverlay,
+    sheet: destSheet,
+    state: sheetState,
+    closeDuration: 200,
+  });
+  const confirmSheetController = window.bottomSheetManager?.create({
+    overlay: sheetOverlay,
+    sheet: confirmSheet,
+    state: sheetState,
+    closeDuration: 200,
+  });
+
   // move drawer elements
   const openMoveBtn = document.getElementById('openMoveDrawer');
   const moveCloseBtn = document.getElementById('moveDrawerCloseBtn');
@@ -683,11 +703,15 @@ document.addEventListener('DOMContentLoaded', () => {
     renderList(currentData);
     sheetChoose.disabled = true;
     sheetChoose.classList.add('opacity-50','cursor-not-allowed');
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-    });
+    if (sourceSheetController) {
+      sourceSheetController.open();
+    } else if (sheetOverlay && sheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        sheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function openMoveSourceSheet() {
@@ -699,11 +723,15 @@ document.addEventListener('DOMContentLoaded', () => {
     renderList(currentData);
     sheetChoose.disabled = true;
     sheetChoose.classList.add('opacity-50','cursor-not-allowed');
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-    });
+    if (sourceSheetController) {
+      sourceSheetController.open();
+    } else if (sheetOverlay && sheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        sheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function openMoveDestSheet() {
@@ -721,11 +749,15 @@ document.addEventListener('DOMContentLoaded', () => {
     renderList(currentData);
     sheetChoose.disabled = true;
     sheetChoose.classList.add('opacity-50','cursor-not-allowed');
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-    });
+    if (sourceSheetController) {
+      sourceSheetController.open();
+    } else if (sheetOverlay && sheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        sheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function openMethodSheet() {
@@ -737,19 +769,27 @@ document.addEventListener('DOMContentLoaded', () => {
     renderMethodList(currentData);
     sheetChoose.disabled = true;
     sheetChoose.classList.add('opacity-50','cursor-not-allowed');
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      sheet.classList.remove('translate-y-full');
-    });
+    if (sourceSheetController) {
+      sourceSheetController.open();
+    } else if (sheetOverlay && sheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        sheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function closeSheet() {
-    sheetOverlay.classList.remove('opacity-100');
-    sheet.classList.add('translate-y-full');
-    setTimeout(() => {
-      sheetOverlay.classList.add('hidden');
-    }, 200);
+    if (sourceSheetController) {
+      sourceSheetController.close();
+    } else if (sheetOverlay && sheet) {
+      sheetOverlay.classList.remove('opacity-100');
+      sheet.classList.add('translate-y-full');
+      setTimeout(() => {
+        sheetOverlay.classList.add('hidden');
+      }, 200);
+    }
   }
 
   function resetDestForm() {
@@ -776,19 +816,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function openDestSheet() {
     resetDestForm();
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      destSheet.classList.remove('translate-y-full');
-    });
+    if (destSheetController) {
+      destSheetController.open();
+    } else if (sheetOverlay && destSheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        destSheet.classList.remove('translate-y-full');
+      });
+    }
   }
 
   function closeDestSheet() {
-    destSheet.classList.add('translate-y-full');
-    sheetOverlay.classList.remove('opacity-100');
-    setTimeout(() => {
-      sheetOverlay.classList.add('hidden');
-    }, 200);
+    if (destSheetController) {
+      destSheetController.close();
+    } else if (destSheet && sheetOverlay) {
+      destSheet.classList.add('translate-y-full');
+      sheetOverlay.classList.remove('opacity-100');
+      setTimeout(() => {
+        sheetOverlay.classList.add('hidden');
+      }, 200);
+    }
   }
 
   function setConfirmProceedEnabled(enabled) {
@@ -904,11 +952,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function closeConfirmSheet() {
     resetOtpState();
-    confirmSheet.classList.add('translate-y-full');
-    sheetOverlay.classList.remove('opacity-100');
-    setTimeout(() => {
-      sheetOverlay.classList.add('hidden');
-    }, 200);
+    if (confirmSheetController) {
+      confirmSheetController.close();
+    } else if (confirmSheet && sheetOverlay) {
+      confirmSheet.classList.add('translate-y-full');
+      sheetOverlay.classList.remove('opacity-100');
+      setTimeout(() => {
+        sheetOverlay.classList.add('hidden');
+      }, 200);
+    }
   }
 
   function handleParentMessage(event) {
@@ -1446,11 +1498,15 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     updateConfirmSheetContent('transfer');
     setConfirmProceedEnabled(true);
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      confirmSheet.classList.remove('translate-y-full');
-    });
+    if (confirmSheetController) {
+      confirmSheetController.open();
+    } else if (sheetOverlay && confirmSheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        confirmSheet.classList.remove('translate-y-full');
+      });
+    }
   });
 
   moveConfirmBtn?.addEventListener('click', () => {
@@ -1493,11 +1549,15 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     updateConfirmSheetContent('move');
     setConfirmProceedEnabled(true);
-    sheetOverlay.classList.remove('hidden');
-    requestAnimationFrame(() => {
-      sheetOverlay.classList.add('opacity-100');
-      confirmSheet.classList.remove('translate-y-full');
-    });
+    if (confirmSheetController) {
+      confirmSheetController.open();
+    } else if (sheetOverlay && confirmSheet) {
+      sheetOverlay.classList.remove('hidden');
+      requestAnimationFrame(() => {
+        sheetOverlay.classList.add('opacity-100');
+        confirmSheet.classList.remove('translate-y-full');
+      });
+    }
   });
 
   function restoreSheetSelection() {


### PR DESCRIPTION
## Summary
- add a reusable bottom sheet manager in `bottomsheet.js` to coordinate overlay/sheet transitions
- refactor the bottom sheet logic in the transfer, biller, batas-transaksi, informasi-rekening, mutasi, atur-persetujuan, and drawer scripts to use the shared controller
- load the shared script on pages that display bottom sheets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb74965808330ac72c59c38ba1592