### PR TITLE
Use dynamic brand name across pages

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -50,9 +50,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -50,9 +50,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/biller.html
+++ b/biller.html
@@ -51,9 +51,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -51,9 +51,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/data/mutasi-data.js
+++ b/data/mutasi-data.js
@@ -1,4 +1,32 @@
 (function () {
+  function readBrandName() {
+    const sessionBrand =
+      typeof window.AMBIS_SESSION === 'object' && typeof window.AMBIS_SESSION.brandName === 'string'
+        ? window.AMBIS_SESSION.brandName.trim()
+        : '';
+    if (sessionBrand) return sessionBrand;
+
+    const datasetBrand =
+      document?.documentElement?.dataset?.ambisBrandName &&
+      document.documentElement.dataset.ambisBrandName.trim();
+    if (datasetBrand) return datasetBrand;
+
+    try {
+      const stored =
+        (localStorage.getItem('ambis:brand-name') || localStorage.getItem('ambis:company-name') || '').trim();
+      if (stored) return stored;
+    } catch (error) {
+      /* Ignore storage errors */
+    }
+
+    const nodeText = document.querySelector('[data-brand-name], #brandName')?.textContent?.trim();
+    if (nodeText) return nodeText;
+
+    return 'Brand Anda';
+  }
+
+  const companyName = readBrandName();
+
   const dataset = {
     utama: {
       status: 'success',
@@ -86,7 +114,7 @@
                 },
                 destination: {
                   name: 'Utama',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895410'
                 }
               }
@@ -118,12 +146,12 @@
                 total: 1000000000000,
                 source: {
                   name: 'Operasional',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895483'
                 },
                 destination: {
                   name: 'Rekening Investasi',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'BCA - 8899001122'
                 }
               }
@@ -144,12 +172,12 @@
                 total: 1000000000000,
                 source: {
                   name: 'Rekening Investasi',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'BCA - 8899001122'
                 },
                 destination: {
                   name: 'Operasional',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895483'
                 }
               }
@@ -176,7 +204,7 @@
                 total: 850000000,
                 source: {
                   name: 'Operasional',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895483'
                 },
                 destination: {
@@ -213,7 +241,7 @@
                 total: 420000000,
                 source: {
                   name: 'Pembayaran Distributor',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895450'
                 },
                 destination: {
@@ -244,7 +272,7 @@
                 },
                 destination: {
                   name: 'Pembayaran Distributor',
-                  subtitle: 'PT Sarana Pancing Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895450'
                 }
               }

--- a/data/rekening-data.js
+++ b/data/rekening-data.js
@@ -1,6 +1,32 @@
 (function () {
+  function readInitialBrandName() {
+    const sessionBrand =
+      typeof window.AMBIS_SESSION === 'object' && typeof window.AMBIS_SESSION.brandName === 'string'
+        ? window.AMBIS_SESSION.brandName.trim()
+        : '';
+    if (sessionBrand) return sessionBrand;
+
+    const datasetBrand =
+      document?.documentElement?.dataset?.ambisBrandName &&
+      document.documentElement.dataset.ambisBrandName.trim();
+    if (datasetBrand) return datasetBrand;
+
+    try {
+      const stored =
+        (localStorage.getItem('ambis:brand-name') || localStorage.getItem('ambis:company-name') || '').trim();
+      if (stored) return stored;
+    } catch (error) {
+      /* Ignore storage errors */
+    }
+
+    const nodeText = document.querySelector('[data-brand-name], #brandName')?.textContent?.trim();
+    if (nodeText) return nodeText;
+
+    return 'Brand Anda';
+  }
+
   const initialData = {
-    brandName: 'PT Sarana Pancing Indonesia',
+    brandName: readInitialBrandName(),
     accounts: [
       {
         id: 'utama',

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -53,9 +53,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/manajemen-pengguna.html
+++ b/manajemen-pengguna.html
@@ -50,9 +50,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/mutasi.html
+++ b/mutasi.html
@@ -51,9 +51,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -51,9 +51,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>

--- a/transfer.html
+++ b/transfer.html
@@ -66,9 +66,7 @@
             id="brandName"
             class="text-slate-400 text-[18px] leading-tight whitespace-normal break-words"
             data-brand-name
-          >
-            PT Sarana Pancing Indonesia
-          </p>
+          ></p>
 
         </div>
       </div>


### PR DESCRIPTION
## Summary
- derive the brand name from the active session/local storage when seeding rekening and mutasi datasets
- remove hard-coded sidebar company labels so they are filled dynamically on every page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc66a94ef08330baf521545d1e4eda