### PR TITLE
Use brand name for operasional mutasi account subtitles

### DIFF
--- a/data/mutasi-data.js
+++ b/data/mutasi-data.js
@@ -51,7 +51,7 @@
                 total: 250000000,
                 source: {
                   name: 'Operasional',
-                  subtitle: 'PT ABC Indonesia',
+                  subtitle: companyName,
                   account: 'Amar Indonesia - 000967895483'
                 },
                 destination: {
@@ -77,7 +77,7 @@
                 total: 175000000,
                 source: {
                   name: 'Operasional',
-                  subtitle: 'PT ABC Indonesia',
+                  subtitle: companyName,
                   account: 'BCA - 0987654321'
                 },
                 destination: {


### PR DESCRIPTION
## Summary
- update the mutasi data seed so operasional account subtitles read from the current brand name
- ensure operasional transaction details no longer show the hardcoded "PT ABC Indonesia"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc6a57036083308285de1c2cdfbeb0