### PR TITLE
Reset active account highlight when closing drawer

### DIFF
--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -1676,6 +1676,7 @@
     }
     updateAccountGridLayoutForDrawer(false);
     resetFormState();
+    setActiveAccountCard(null);
 
     let focusTarget = null;
     if (restoreFocus) {


### PR DESCRIPTION
## Summary
- clear the active account card highlight when the drawer closes so cards return to inactive state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc8e32e3d48330a09dc0314d845865