### PR TITLE
Stop auto focusing add account drawer form

### DIFF
--- a/informasi-rekening.js
+++ b/informasi-rekening.js
@@ -1649,16 +1649,6 @@
     }
     showDrawerPane('addAccount');
     ensureDrawerOpen('addAccount');
-    if (formNode) {
-      const focusTarget = formNode.querySelector('input, textarea, select');
-      if (focusTarget) {
-        try {
-          focusTarget.focus({ preventScroll: true });
-        } catch (err) {
-          focusTarget.focus();
-        }
-      }
-    }
   }
 
   function closeDrawer({ restoreFocus = false } = {}) {


### PR DESCRIPTION
## Summary
- remove the automatic focus on the add account drawer form inputs when opening the drawer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc8f8c908c8330abf2f8991a6b6050