### PR TITLE
Update transaction approval data and add drawer details

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -21,7 +21,10 @@
       safelist: [
         "opacity-0","opacity-100","translate-y-0","translate-y-1",
         "ring-2","ring-cyan-400","bg-cyan-50","border-cyan-300",
-        "text-slate-900","text-slate-400"
+        "text-slate-900","text-slate-400","text-cyan-700",
+        "bg-amber-50","border-amber-200","text-amber-700",
+        "bg-sky-50","border-sky-200","text-sky-800",
+        "bg-emerald-50","border-emerald-200","text-emerald-700"
       ]
     };
   </script>
@@ -152,15 +155,17 @@
         <div class="flex items-center gap-6 border-b border-slate-200 mb-6">
           <button type="button" data-tab="butuh" class="tab-btn relative py-3 font-semibold text-slate-900">
             Butuh Persetujuan
-            <span class="tab-count ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
           <button type="button" data-tab="menunggu" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
             Menunggu Persetujuan
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
           <button type="button" data-tab="selesai" class="tab-btn py-3 text-slate-600 hover:text-slate-900">
             Selesai
+            <span class="tab-count hidden ml-2 text-white text-xs rounded-full bg-red-500 px-2 py-0.5">0</span>
             <span class="tab-indicator hidden absolute bottom-0 left-0 right-0 h-[2px] bg-cyan-500"></span>
           </button>
         </div>
@@ -217,26 +222,22 @@
               </button>
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
                 <div class="flex flex-col gap-2">
-                 <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Transaksi">
-                  <span>Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Manajemen Pengguna">
-                  <span>Manajemen Pengguna</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Batas Transaksi">
-                  <span>Batas Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Atur Persetujuan">
-                  <span>Atur Persetujuan</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Pengaturan Rekening">
-                  <span>Pengaturan Rekening</span>
-                </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Transfer">
+                    <span>Transfer</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Beli Bayar">
+                    <span>Beli &amp; Bayar</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Limit Management">
+                    <span>Limit Management</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Approval Matrix">
+                    <span>Approval Matrix</span>
+                  </label>
                 </div>
                 <div class="flex justify-end gap-2 mt-4">
                   <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
@@ -249,9 +250,9 @@
             <table class="min-w-full">
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
-                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Tanggal Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
-                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="text-left px-4 py-3 font-medium">Detail Permintaan</th>
                   <th class="px-4 py-3"></th>
                 </tr>
               </thead>
@@ -311,26 +312,22 @@
               </button>
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
                 <div class="flex flex-col gap-2">
-                 <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Transaksi">
-                  <span>Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Manajemen Pengguna">
-                  <span>Manajemen Pengguna</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Batas Transaksi">
-                  <span>Batas Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Atur Persetujuan">
-                  <span>Atur Persetujuan</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Pengaturan Rekening">
-                  <span>Pengaturan Rekening</span>
-                </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Transfer">
+                    <span>Transfer</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Beli Bayar">
+                    <span>Beli &amp; Bayar</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Limit Management">
+                    <span>Limit Management</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Approval Matrix">
+                    <span>Approval Matrix</span>
+                  </label>
                 </div>
                 <div class="flex justify-end gap-2 mt-4">
                   <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
@@ -343,9 +340,9 @@
             <table class="min-w-full">
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
-                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Tanggal Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
-                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="text-left px-4 py-3 font-medium">Detail Permintaan</th>
                   <th class="px-4 py-3"></th>
                 </tr>
               </thead>
@@ -406,25 +403,21 @@
               <div class="filter-panel absolute z-10 mt-2 p-4 rounded-xl border border-slate-200 bg-white shadow hidden w-64">
                 <div class="flex flex-col gap-2">
                   <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Transaksi">
-                  <span>Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Manajemen Pengguna">
-                  <span>Manajemen Pengguna</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Batas Transaksi">
-                  <span>Batas Transaksi</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Atur Persetujuan">
-                  <span>Atur Persetujuan</span>
-                </label>
-                <label class="flex items-center gap-2">
-                  <input type="checkbox" value="Pengaturan Rekening">
-                  <span>Pengaturan Rekening</span>
-                </label>
+                    <input type="checkbox" value="Transfer">
+                    <span>Transfer</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Beli Bayar">
+                    <span>Beli &amp; Bayar</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Limit Management">
+                    <span>Limit Management</span>
+                  </label>
+                  <label class="flex items-center gap-2">
+                    <input type="checkbox" value="Approval Matrix">
+                    <span>Approval Matrix</span>
+                  </label>
                 </div>
                 <div class="flex justify-end gap-2 mt-4">
                   <button class="cancel px-3 py-1 rounded-lg border text-slate-600 w-full">Batalkan</button>
@@ -437,9 +430,9 @@
             <table class="min-w-full">
               <thead class="bg-slate-50 text-slate-600">
                 <tr>
-                  <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
+                  <th class="text-left px-4 py-3 font-medium">Tanggal Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
-                  <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="text-left px-4 py-3 font-medium">Detail Permintaan</th>
                   <th class="px-4 py-3"></th>
                 </tr>
               </thead>
@@ -450,11 +443,58 @@
       </div>
     </main>
     <!-- ============ /MAIN ============ -->
+
+    <!-- Drawer -->
+    <div id="drawer" class="relative h-full flex flex-col bg-white flex-shrink-0 border-l border-slate-100" aria-hidden="true">
+      <div class="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-400">Detail Persetujuan</p>
+          <h2 id="approvalDrawerTitle" class="mt-1 text-lg font-semibold text-slate-900">-</h2>
+        </div>
+        <button type="button" id="approvalDrawerClose" data-drawer-close class="text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup drawer">&times;</button>
+      </div>
+      <div class="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+        <section>
+          <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-400 mb-3">Informasi Utama</p>
+          <div class="space-y-3">
+            <div>
+              <p class="text-sm text-slate-500">ID Transaksi</p>
+              <p id="approvalDrawerId" class="text-base font-semibold text-slate-900">-</p>
+            </div>
+            <div>
+              <p class="text-sm text-slate-500">Kategori</p>
+              <p id="approvalDrawerCategory" class="text-base font-semibold text-slate-900">-</p>
+            </div>
+            <div>
+              <p class="text-sm text-slate-500">Status</p>
+              <span id="approvalDrawerStatus" class="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-semibold border bg-slate-100 text-slate-600 border-slate-200">-</span>
+            </div>
+            <div>
+              <p class="text-sm text-slate-500">Tanggal Permintaan</p>
+              <p id="approvalDrawerDate" class="text-base font-semibold text-slate-900">-</p>
+            </div>
+            <div>
+              <p class="text-sm text-slate-500">Sumber</p>
+              <p id="approvalDrawerSourceLabel" class="text-base font-semibold text-slate-900">-</p>
+            </div>
+          </div>
+        </section>
+        <section>
+          <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-400 mb-3">Detail</p>
+          <p id="approvalDrawerDetail" class="text-base leading-relaxed text-slate-700">-</p>
+        </section>
+        <section>
+          <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-400 mb-3">Tindakan</p>
+          <a id="approvalDrawerSourceLink" href="#" class="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-cyan-500 text-cyan-600 font-semibold hover:bg-cyan-50 pointer-events-none opacity-50" aria-disabled="true">Halaman sumber tidak tersedia</a>
+        </section>
+      </div>
+    </div>
   </div>
 
   <script src="https://unpkg.com/air-datepicker@3.4.0/air-datepicker.js"></script>
   <script src="session.js"></script>
   <script src="filter.js"></script>
+  <script src="drawer.js"></script>
   <script src="persetujuan-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -1,28 +1,171 @@
 const approvalsData = {
   butuh: [
-    { time: '17 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '19 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp500.000.000 ke Rp250.000.000 - Oleh Bimo Purwoko' },
-    { time: '20 Agu 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan Transaksi - Persetujuan Transfer - Oleh Fajar Satria' },
-    { time: '22 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke Mandiri PT Aman Jaya - Rp100.000.000' },
-    { time: '22 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BNI PT Aman Jaya - Rp190.000.000' },
-    { time: '22 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Aman Jaya - Rp8.000.000' }
+    {
+      id: 'T001',
+      category: 'Transfer',
+      title: 'Transfer Rp100.000.000 ke PT Maju Jaya',
+      date: '2025-09-28',
+      status: 'Butuh Persetujuan',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'B001',
+      category: 'Beli Bayar',
+      title: 'Pembayaran PLN Rp2.000.000',
+      date: '2025-09-29',
+      status: 'Butuh Persetujuan',
+      sourcePage: 'biller.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'T002',
+      category: 'Transfer',
+      title: 'Transfer Rp250.000.000 ke PT Sejahtera',
+      date: '2025-09-27',
+      status: 'Butuh Persetujuan',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'LM001',
+      category: 'Limit Management',
+      title: 'Perubahan Batas Transaksi Rp300.000.000',
+      date: '2025-09-25',
+      status: 'Butuh Persetujuan',
+      sourcePage: 'batas-transaksi.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'T003',
+      category: 'Transfer',
+      title: 'Transfer Rp50.000.000 ke CV Karya Abadi',
+      date: '2025-09-28',
+      status: 'Butuh Persetujuan',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
   ],
   menunggu: [
-    { time: '01 Agu 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp60.000.000' },
-    { time: '20 Agu 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp300.000.000 ke Rp350.000.000 - Oleh Bimo Purwoko' },
-    { time: '05 Sep 2025 • 20:10', category: 'Atur Persetujuan', jenis: 'debit', description: 'Buat Persetujuan - Persetujuan Transfer - Oleh Fajar Satria' }
+    {
+      id: 'T004',
+      category: 'Transfer',
+      title: 'Transfer Rp400.000.000 ke PT Mega Finance',
+      date: '2025-09-26',
+      status: 'Menunggu Persetujuan',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'B002',
+      category: 'Beli Bayar',
+      title: 'Pembayaran Internet Rp1.500.000',
+      date: '2025-09-24',
+      status: 'Menunggu Persetujuan',
+      sourcePage: 'biller.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'T005',
+      category: 'Transfer',
+      title: 'Transfer Rp75.000.000 ke PT Cipta Mandiri',
+      date: '2025-09-23',
+      status: 'Menunggu Persetujuan',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
   ],
   selesai: [
-    { time: '02 Sep 2025 • 20:10', category: 'Transaksi', jenis: 'kredit', description: 'Transfer Saldo - Ke BCA PT Queen Japan - Rp50.000.000' },
-    { time: '04 Sep 2025 • 20:10', category: 'Batas Transaksi', jenis: 'debit', description: 'Ubah Batas Transaksi - Dari Rp350.000.000 ke Rp400.000.000 - Oleh Bimo Purwoko' }
-  ]
+    {
+      id: 'T006',
+      category: 'Transfer',
+      title: 'Transfer Rp500.000.000 ke PT Prima Utama',
+      date: '2025-09-20',
+      status: 'Selesai',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'B003',
+      category: 'Beli Bayar',
+      title: 'Pembayaran PDAM Rp750.000',
+      date: '2025-09-21',
+      status: 'Selesai',
+      sourcePage: 'biller.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'AM001',
+      category: 'Approval Matrix',
+      title: 'Ubah Persetujuan Transfer Rp200.000.000',
+      date: '2025-09-19',
+      status: 'Selesai',
+      sourcePage: 'atur-persetujuan.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+    {
+      id: 'T007',
+      category: 'Transfer',
+      title: 'Transfer Rp150.000.000 ke PT Nusantara',
+      date: '2025-09-18',
+      status: 'Selesai',
+      sourcePage: 'transfer.html',
+      action: { label: 'Detail', type: 'drawer', task: 'pending' },
+    },
+  ],
 };
 
 const tabButtons = document.querySelectorAll('.tab-btn');
 const tabPanels = document.querySelectorAll('[data-tab-panel]');
 let activeTab = 'butuh';
 
-const monthMap = {
+const SOURCE_LABELS = {
+  'transfer.html': 'Halaman Transfer',
+  'biller.html': 'Halaman Beli & Bayar',
+  'batas-transaksi.html': 'Halaman Limit Management',
+  'atur-persetujuan.html': 'Halaman Approval Matrix',
+};
+
+const CATEGORY_CLASS_MAP = {
+  Transfer: 'bg-cyan-50 text-cyan-700 border-cyan-300',
+  'Beli Bayar': 'bg-amber-50 text-amber-700 border-amber-200',
+  'Limit Management': 'bg-sky-50 text-sky-800 border-sky-200',
+  'Approval Matrix': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+};
+
+const STATUS_CLASS_MAP = {
+  'Butuh Persetujuan': 'bg-amber-50 text-amber-700 border-amber-200',
+  'Menunggu Persetujuan': 'bg-sky-50 text-sky-800 border-sky-200',
+  Selesai: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+};
+
+const CATEGORY_BADGE_BASE = 'inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold border';
+const STATUS_BADGE_BASE = 'inline-flex items-center px-3 py-0.5 rounded-full text-xs font-semibold border';
+const LINK_DISABLED_CLASSES = ['pointer-events-none', 'opacity-50'];
+
+const detailState = {
+  currentItemId: null,
+};
+
+const drawer = document.getElementById('drawer');
+const drawerCloseBtn = document.getElementById('approvalDrawerClose');
+const drawerElements = {
+  title: document.getElementById('approvalDrawerTitle'),
+  id: document.getElementById('approvalDrawerId'),
+  category: document.getElementById('approvalDrawerCategory'),
+  status: document.getElementById('approvalDrawerStatus'),
+  date: document.getElementById('approvalDrawerDate'),
+  sourceLabel: document.getElementById('approvalDrawerSourceLabel'),
+  detail: document.getElementById('approvalDrawerDetail'),
+  sourceLink: document.getElementById('approvalDrawerSourceLink'),
+};
+
+const drawerController =
+  drawer && window.drawerManager && typeof window.drawerManager.register === 'function'
+    ? window.drawerManager.register(drawer, { manageAria: true })
+    : null;
+
+const LEGACY_MONTH_MAP = {
   Jan: 0,
   Feb: 1,
   Mar: 2,
@@ -34,16 +177,207 @@ const monthMap = {
   Sep: 8,
   Okt: 9,
   Nov: 10,
-  Des: 11
+  Des: 11,
 };
 
-function parseDate(str) {
-  if (!str) return new Date('1970-01-01');
-  const [datePart, timePart] = str.split('•').map(s => s.trim());
-  const [day, mon, year] = (datePart || '').split(' ');
-  const [hour, min] = (timePart || '').split(':');
-  const monthIdx = monthMap[mon] ?? 0;
-  return new Date(+year || 0, monthIdx, +day || 1, +hour || 0, +min || 0);
+const DATE_FORMAT_SHORT = new Intl.DateTimeFormat('id-ID', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
+const DATE_FORMAT_LONG = new Intl.DateTimeFormat('id-ID', {
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric',
+});
+
+function parseDate(value) {
+  if (!value) return new Date(Number.NaN);
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const [yearStr, monthStr, dayStr] = trimmed.split('-');
+      const year = Number(yearStr) || 0;
+      const month = (Number(monthStr) || 1) - 1;
+      const day = Number(dayStr) || 1;
+      return new Date(year, month, day);
+    }
+
+    if (trimmed.includes('•')) {
+      const [datePart, timePart] = trimmed.split('•').map(part => part.trim());
+      const [dayStr, monthStr, yearStr] = (datePart || '').split(' ');
+      const [hourStr, minuteStr] = (timePart || '').split(':');
+      const monthIdx = LEGACY_MONTH_MAP[monthStr] ?? 0;
+      const day = Number(dayStr) || 1;
+      const year = Number(yearStr) || 0;
+      const hour = Number(hourStr) || 0;
+      const minute = Number(minuteStr) || 0;
+      return new Date(year, monthIdx, day, hour, minute);
+    }
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date(Number.NaN) : parsed;
+}
+
+function formatDateShort(value) {
+  const date = parseDate(value);
+  return Number.isNaN(date.getTime()) ? '-' : DATE_FORMAT_SHORT.format(date);
+}
+
+function formatDateLong(value) {
+  const date = parseDate(value);
+  return Number.isNaN(date.getTime()) ? '-' : DATE_FORMAT_LONG.format(date);
+}
+
+function getItemDateValue(item) {
+  if (!item) return null;
+  return item.date || item.time || null;
+}
+
+function getSourceLabel(sourcePage) {
+  if (!sourcePage) return 'Halaman Sumber';
+  return SOURCE_LABELS[sourcePage] || sourcePage;
+}
+
+function getCategoryClass(category) {
+  return CATEGORY_CLASS_MAP[category] || 'bg-slate-100 text-slate-600 border-slate-200';
+}
+
+function getStatusClass(status) {
+  return STATUS_CLASS_MAP[status] || 'bg-slate-100 text-slate-600 border-slate-200';
+}
+
+function setDrawerLinkState(enabled, label, href) {
+  const link = drawerElements.sourceLink;
+  if (!link) return;
+
+  if (enabled && href) {
+    link.href = href;
+    link.textContent = label || 'Buka halaman sumber';
+    link.setAttribute('target', '_blank');
+    link.setAttribute('rel', 'noopener');
+    link.setAttribute('aria-disabled', 'false');
+    LINK_DISABLED_CLASSES.forEach(cls => link.classList.remove(cls));
+  } else {
+    link.href = '#';
+    link.textContent = label || 'Halaman sumber tidak tersedia';
+    link.removeAttribute('target');
+    link.removeAttribute('rel');
+    link.setAttribute('aria-disabled', 'true');
+    LINK_DISABLED_CLASSES.forEach(cls => link.classList.add(cls));
+  }
+}
+
+function updateDrawerContent(item) {
+  const titleEl = drawerElements.title;
+  const idEl = drawerElements.id;
+  const categoryEl = drawerElements.category;
+  const statusEl = drawerElements.status;
+  const dateEl = drawerElements.date;
+  const sourceLabelEl = drawerElements.sourceLabel;
+  const detailEl = drawerElements.detail;
+
+  if (!item) {
+    if (titleEl) titleEl.textContent = 'Detail Persetujuan';
+    if (idEl) idEl.textContent = '-';
+    if (categoryEl) categoryEl.textContent = '-';
+    if (statusEl) {
+      statusEl.textContent = '-';
+      statusEl.className = `${STATUS_BADGE_BASE} bg-slate-100 text-slate-600 border-slate-200`;
+    }
+    if (dateEl) dateEl.textContent = '-';
+    if (sourceLabelEl) sourceLabelEl.textContent = '-';
+    if (detailEl) detailEl.textContent = '-';
+    setDrawerLinkState(false, 'Halaman sumber tidak tersedia');
+    return;
+  }
+
+  const sourceLabel = getSourceLabel(item.sourcePage);
+  const formattedDate = formatDateLong(getItemDateValue(item));
+  const statusClass = `${STATUS_BADGE_BASE} ${getStatusClass(item.status)}`;
+
+  if (titleEl) titleEl.textContent = item.title || 'Detail Persetujuan';
+  if (idEl) idEl.textContent = item.id || '-';
+  if (categoryEl) categoryEl.textContent = item.category || '-';
+  if (statusEl) {
+    statusEl.textContent = item.status || '-';
+    statusEl.className = statusClass;
+  }
+  if (dateEl) dateEl.textContent = formattedDate;
+  if (sourceLabelEl) sourceLabelEl.textContent = sourceLabel;
+
+  if (detailEl) {
+    const detailParts = [];
+    if (item.title) detailParts.push(item.title);
+    if (item.status) detailParts.push(`Status saat ini: ${item.status}.`);
+    if (sourceLabel) detailParts.push(`Diajukan melalui ${sourceLabel}.`);
+    detailEl.textContent = detailParts.join(' ');
+  }
+
+  const linkLabel = sourceLabel ? `Lihat ${sourceLabel}` : 'Buka halaman sumber';
+  setDrawerLinkState(Boolean(item.sourcePage), linkLabel, item.sourcePage || '#');
+}
+
+function highlightActiveRow(itemId, tab) {
+  const panel = document.querySelector(`[data-tab-panel="${tab}"]`);
+  if (!panel) return;
+  const rows = panel.querySelectorAll('tr[data-item-id]');
+  rows.forEach(row => {
+    const isActive = Boolean(itemId) && row.dataset.itemId === itemId;
+    row.classList.toggle('bg-cyan-50', isActive);
+    row.classList.toggle('hover:bg-cyan-50', isActive);
+    row.classList.toggle('hover:bg-slate-50', !isActive);
+  });
+}
+
+function openDetailDrawer(item) {
+  if (!item || !drawer) return;
+
+  detailState.currentItemId = item.id || null;
+  updateDrawerContent(item);
+  highlightActiveRow(detailState.currentItemId, activeTab);
+
+  if (drawerController) {
+    drawerController.open({ trigger: 'detail' });
+  } else {
+    if (!drawer.classList.contains('open')) {
+      drawer.classList.add('open');
+    }
+    drawer.setAttribute('aria-hidden', 'false');
+  }
+}
+
+function closeDetailDrawer(options = {}) {
+  if (!drawer) return;
+
+  if (drawerController) {
+    drawerController.close(options);
+  } else if (drawer.classList.contains('open')) {
+    drawer.classList.remove('open');
+    drawer.setAttribute('aria-hidden', 'true');
+  }
+
+  detailState.currentItemId = null;
+  highlightActiveRow(null, activeTab);
+}
+
+if (drawerCloseBtn) {
+  drawerCloseBtn.addEventListener('click', () => closeDetailDrawer({ trigger: 'close-button' }));
+}
+
+if (drawer) {
+  drawer.addEventListener('drawer:close', () => {
+    detailState.currentItemId = null;
+    highlightActiveRow(null, activeTab);
+  });
 }
 
 function getFilters(tab) {
@@ -59,47 +393,49 @@ function getFilters(tab) {
 
   return {
     date: read('date'),
-    kategori: kategoriRaw ? kategoriRaw.split(',').filter(Boolean) : []
+    kategori: kategoriRaw ? kategoriRaw.split(',').filter(Boolean) : [],
   };
 }
 
 function filterByDate(list, value) {
   if (!value) return list;
+
   const now = new Date();
   return list.filter(item => {
-    const d = parseDate(item.time);
+    const dateValue = parseDate(getItemDateValue(item));
+    if (Number.isNaN(dateValue.getTime())) return false;
+
     if (value === '7 Hari Terakhir') {
       const weekAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
-      return d >= weekAgo;
+      return dateValue >= weekAgo;
     }
     if (value === '30 Hari Terakhir') {
       const monthAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-      return d >= monthAgo;
+      return dateValue >= monthAgo;
     }
     if (value === '1 Tahun Terakhir') {
       const yearAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 365);
-      return d >= yearAgo;
+      return dateValue >= yearAgo;
     }
     if (value.startsWith('custom:')) {
       const [startStr, endStr] = value.slice(7).split('|');
-      const start = new Date(startStr);
-      const end = new Date(endStr);
-      return d >= start && d <= end;
+      const start = parseDate(startStr);
+      const end = parseDate(endStr);
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return true;
+      return dateValue >= start && dateValue <= end;
     }
+
     return true;
   });
 }
 
 function filterByKategori(list, values) {
   if (!values.length) return list;
+  const valueSet = new Set(values.map(value => value.toLowerCase()));
   return list.filter(item => {
-    if (item.category) {
-      return values.includes(item.category);
-    }
-    if (item.jenis) {
-      return values.includes(item.jenis);
-    }
-    return false;
+    const rawCategory = item.category || item.activity || item.jenis || '';
+    const normalized = rawCategory.toLowerCase();
+    return valueSet.has(normalized);
   });
 }
 
@@ -115,6 +451,13 @@ function render(tab) {
   list = filterByDate(list, filters.date);
   list = filterByKategori(list, filters.kategori);
 
+  if (detailState.currentItemId) {
+    const exists = list.some(item => item.id === detailState.currentItemId);
+    if (!exists) {
+      closeDetailDrawer({ trigger: 'filter-change' });
+    }
+  }
+
   tbody.innerHTML = '';
 
   if (list.length === 0) {
@@ -129,21 +472,51 @@ function render(tab) {
   list.forEach(item => {
     const tr = document.createElement('tr');
     tr.className = 'hover:bg-slate-50';
-    const category = item.category || item.activity || '-';
-    const description = item.description || '';
+    tr.dataset.itemId = item.id || '';
+
+    const displayDate = formatDateShort(getItemDateValue(item));
+    const categoryClass = `${CATEGORY_BADGE_BASE} ${getCategoryClass(item.category)}`;
+    const statusClass = `${STATUS_BADGE_BASE} ${getStatusClass(item.status)}`;
+    const sourceLabel = getSourceLabel(item.sourcePage);
+    const actionLabel = item.action && item.action.label ? item.action.label : 'Detail';
 
     tr.innerHTML = `
-      <td class="px-4 py-3">${item.time || '-'}</td>
-      <td class="px-4 py-3">
-        <span class="font-medium">${category}</span>
+      <td class="px-4 py-3 align-top">
+        <div class="text-sm text-slate-600">${displayDate}</div>
       </td>
-      <td class="px-4 py-3">${description}</td>
-      <td class="px-4 py-3 text-right">
-        <button class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50">Detail</button>
+      <td class="px-4 py-3 align-top">
+        <span class="${categoryClass}">${item.category || '-'}</span>
+      </td>
+      <td class="px-4 py-3">
+        <p class="font-semibold text-slate-900">${item.title || '-'}</p>
+        <div class="mt-2 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+          <span>ID: ${item.id || '-'}</span>
+          <span class="${statusClass}">${item.status || '-'}</span>
+        </div>
+        <p class="mt-2 text-sm text-slate-400">Sumber: ${sourceLabel}</p>
+      </td>
+      <td class="px-4 py-3 text-right align-top">
+        <button type="button" class="px-4 py-1 rounded-lg border border-cyan-500 text-cyan-600 hover:bg-cyan-50" data-role="detail-button">${actionLabel}</button>
       </td>
     `;
+
+    const detailButton = tr.querySelector('[data-role="detail-button"]');
+    if (detailButton) {
+      detailButton.addEventListener('click', () => {
+        if (item.action && item.action.type && item.action.type !== 'drawer') {
+          if (item.sourcePage) {
+            window.location.href = item.sourcePage;
+          }
+          return;
+        }
+        openDetailDrawer(item);
+      });
+    }
+
     tbody.appendChild(tr);
   });
+
+  highlightActiveRow(detailState.currentItemId, tab);
 }
 
 function updateCounts() {
@@ -158,7 +531,12 @@ function updateCounts() {
 }
 
 function setActive(tab) {
+  if (tab === activeTab) return;
+
+  closeDetailDrawer({ trigger: 'tab-change' });
+
   activeTab = tab;
+
   tabButtons.forEach(btn => {
     const isActive = btn.dataset.tab === tab;
     btn.classList.toggle('relative', isActive);
@@ -181,7 +559,7 @@ function setActive(tab) {
 }
 
 updateCounts();
-setActive(activeTab);
+render(activeTab);
 
 tabButtons.forEach(btn => {
   btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- refresh the transaction approval tabs with the new 12-item dataset and matching counts
- align filters, table columns, and tab badges with the updated approval categories and statuses
- add a contextual drawer that surfaces detail metadata and source links when reviewing an item

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcb8fd91b083309cbc58e48994ed54