### PR TITLE
Load rekening metadata into persetujuan detail panes

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -470,6 +470,7 @@
   <script src="session.js"></script>
   <script src="filter.js"></script>
   <script src="drawer.js"></script>
+  <script src="data/rekening-data.js"></script>
   <script src="persetujuan-transaksi.js"></script>
   <script src="sidebar.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- include the rekening-data loader on persetujuan-transaksi.html and tag approval records with their sourceAccountKey references
- resolve rekening metadata for transfer and biller panes, formatting source account labels and injecting random meta details
- strip imported pane headers and sticky footers after rendering so the reused templates fit the persetujuan context

## Testing
- node -e "new Function(require('fs').readFileSync('persetujuan-transaksi.js','utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68dcde2f6c80833081433ec34ae8d3d0