### PR TITLE
Refine transaction approval drawer layout

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -450,48 +450,51 @@
         <h2 class="text-lg font-semibold text-slate-900">Detail Persetujuan</h2>
         <button type="button" id="approvalDrawerClose" data-drawer-close class="text-2xl leading-none text-slate-500 hover:text-slate-700" aria-label="Tutup drawer">&times;</button>
       </div>
-      <div class="flex-1 overflow-hidden">
-        <div id="detailPaneHost" class="h-full overflow-y-auto"></div>
-      </div>
-      <div id="detailPaneMeta" class="border-t border-slate-200 bg-white">
-        <div class="px-6 py-6 space-y-8">
-          <section class="space-y-3">
-            <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-500">Pembuat Permintaan</p>
-            <div class="space-y-3 text-sm">
-              <div class="flex items-start justify-between gap-4">
-                <span class="text-slate-500">Dibuat oleh</span>
-                <span id="detailPaneCreator" class="text-right font-semibold text-slate-900">-</span>
-              </div>
-              <div class="flex items-start justify-between gap-4">
-                <span class="text-slate-500">Tanggal &amp; Waktu</span>
-                <span id="detailPaneDate" class="text-right font-semibold text-slate-900">-</span>
-              </div>
-            </div>
-          </section>
+      <div class="flex-1 overflow-hidden flex flex-col">
+        <div class="flex-1 overflow-y-auto">
+          <div class="px-6 pt-6 pb-4">
+            <div id="detailPaneHost" class="space-y-6"></div>
+          </div>
 
-          <section class="space-y-4">
-            <div class="flex items-center justify-between gap-3">
-              <div class="flex items-center gap-3">
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-cyan-100 text-cyan-700">
-                  <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M9 3H15C16.6569 3 18 4.34315 18 6V7H6V6C6 4.34315 7.34315 3 9 3Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                    <path d="M6 7H18V18C18 19.6569 16.6569 21 15 21H9C7.34315 21 6 19.6569 6 18V7Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                    <path d="M9 11H12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                    <path d="M9 15H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                  </svg>
-                </span>
-                <h3 class="text-base font-semibold text-slate-900">Daftar Persetujuan</h3>
+          <div class="px-6 pb-24 space-y-8">
+            <section class="space-y-3">
+              <p class="text-xs font-semibold uppercase tracking-[.18em] text-slate-500">PEMBUAT PERMINTAAN</p>
+              <div class="space-y-3 text-sm">
+                <div class="flex items-start justify-between gap-4">
+                  <span class="text-slate-500">Dibuat oleh</span>
+                  <span id="detailPaneCreator" class="text-right font-semibold text-slate-900">-</span>
+                </div>
+                <div class="flex items-start justify-between gap-4">
+                  <span class="text-slate-500">Tanggal &amp; Waktu</span>
+                  <span id="detailPaneDate" class="text-right font-semibold text-slate-900">-</span>
+                </div>
               </div>
-              <span id="detailApprovalStatus" class="text-sm font-semibold text-slate-500">0/0 selesai</span>
-            </div>
-            <ul id="detailApprovalList" class="space-y-3"></ul>
-          </section>
+            </section>
+
+            <section class="space-y-4">
+              <div class="flex items-center justify-between gap-3">
+                <div class="flex items-center gap-3">
+                  <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-cyan-100 text-cyan-700">
+                    <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M9 3H15C16.6569 3 18 4.34315 18 6V7H6V6C6 4.34315 7.34315 3 9 3Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M6 7H18V18C18 19.6569 16.6569 21 15 21H9C7.34315 21 6 19.6569 6 18V7Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M9 11H12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M9 15H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </span>
+                  <h3 class="text-base font-semibold text-slate-900">Daftar Persetujuan</h3>
+                </div>
+                <span id="detailApprovalStatus" class="text-sm font-semibold text-slate-500">0/0</span>
+              </div>
+              <ul id="detailApprovalList" class="space-y-3"></ul>
+            </section>
+          </div>
         </div>
 
         <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4">
           <div class="flex items-center justify-between gap-4">
-            <button type="button" class="w-full max-w-[160px] rounded-xl border border-cyan-500 px-4 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50">Tolak</button>
-            <button type="button" class="w-full max-w-[160px] rounded-xl border border-cyan-500 px-4 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50">Setujui</button>
+            <button type="button" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50">Tolak</button>
+            <button type="button" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50">Setujui</button>
           </div>
         </div>
       </div>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -917,7 +917,7 @@ function updateApprovalStatusText(statusElement, completed, total) {
     ? Math.min(Math.max(0, Math.floor(completedNumber)), safeTotal)
     : 0;
 
-  statusElement.textContent = `${safeCompleted}/${safeTotal} selesai`;
+  statusElement.textContent = `${safeCompleted}/${safeTotal}`;
 }
 
 function updateApprovalSection(statusElement, listElement, totalSteps = 2, completedSteps = 0) {


### PR DESCRIPTION
## Summary
- move the requestor details and approval list into the scrollable detail pane layout
- keep action buttons in a sticky footer with matching outlined styling
- adjust the approval status counter copy to display as a simple X/Y value

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dce97a30348330bc2e5374ed847882