### PR TITLE
Fix approval drawer caption rendering

### DIFF
--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -889,6 +889,10 @@ function renderApprovalList(listElement, steps) {
     label.className = 'text-sm font-semibold text-slate-900';
     label.textContent = (step && step.label) || 'Approval';
 
+    const caption = document.createElement('span');
+    caption.className = 'text-xs text-slate-500';
+    caption.textContent = (step && step.approver) || '-';
+
     textWrap.appendChild(label);
     textWrap.appendChild(caption);
 


### PR DESCRIPTION
## Summary
- add the missing caption element when rendering approval steps so approver names display without throwing a runtime error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd031460cc8330bf49772f8db516f1