### PR TITLE
Remove approval names from detail approval list

### DIFF
--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -889,12 +889,7 @@ function renderApprovalList(listElement, steps) {
     label.className = 'text-sm font-semibold text-slate-900';
     label.textContent = (step && step.label) || 'Approval';
 
-    const caption = document.createElement('span');
-    caption.className = 'text-xs text-slate-500';
-    caption.textContent = (step && step.approver) || '-';
-
     textWrap.appendChild(label);
-    textWrap.appendChild(caption);
 
     content.appendChild(badge);
     content.appendChild(textWrap);


### PR DESCRIPTION
## Summary
- remove the approver name caption from the detail approval list rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd075a686083308c04272d4a372e24