### PR TITLE
Implement OTP verification flow for approval actions

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -559,10 +559,32 @@
           </div>
         </div>
 
-        <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4">
+        <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4 space-y-4">
+          <div id="approvalOtpSection" class="hidden space-y-4">
+            <div class="space-y-1">
+              <h4 class="text-lg font-semibold text-slate-900">Masukkan kode verifikasi</h4>
+              <p class="text-sm text-slate-500">Kode verifikasi dikirim melalui aplikasi Amar Bank Bisnis Anda.</p>
+            </div>
+            <div class="grid grid-cols-8 gap-2">
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+              <input type="text" inputmode="numeric" maxlength="1" class="otp-input w-full h-12 rounded-xl border text-center text-lg font-semibold focus:outline-none focus:ring-2 focus:ring-cyan-400" />
+            </div>
+            <p id="approvalOtpError" class="hidden text-center text-sm text-rose-600"></p>
+            <p id="approvalOtpCountdown" class="text-sm text-slate-500 text-center">
+              <span id="approvalOtpCountdownMessage">Sesi akan berakhir dalam</span>
+              <span id="approvalOtpTimer" class="text-cyan-500 font-semibold">00:30</span>
+            </p>
+            <button id="approvalOtpResend" type="button" class="hidden mx-auto rounded-lg border border-cyan-300 px-4 py-2 text-sm font-medium text-cyan-600 hover:bg-slate-50">Kirim Ulang Kode Verifikasi</button>
+          </div>
           <div class="flex items-center justify-between gap-4">
-            <button type="button" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50 w-full">Tolak</button>
-            <button type="button" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-cyan-50 w-full">Setujui</button>
+            <button type="button" id="approvalOutlineAction" class="rounded-xl border border-slate-200 px-6 py-2 font-semibold text-slate-700 transition hover:bg-slate-50 w-full">Tolak</button>
+            <button type="button" id="approvalPrimaryAction" class="rounded-xl bg-cyan-500 px-6 py-2 font-semibold text-white transition hover:bg-cyan-600 w-full">Setujui</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an OTP entry section and updated button states to the approval detail drawer UI
- implement OTP handling with countdown, resend, and validation tied to approve or reject actions
- surface approval success or rejection results and refresh list data after OTP verification

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de2aeb00fc833081b999f66e0bc5ff