### PR TITLE
Make approval drawer actions use outline style

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -586,8 +586,8 @@
 
         <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4 space-y-4">
           <div class="flex items-center justify-between gap-4">
-            <button type="button" id="approvalOutlineAction" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-slate-50 w-full">Tolak</button>
-            <button type="button" id="approvalPrimaryAction" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-slate-50 w-full">Setujui</button>
+            <button type="button" id="approvalOutlineAction" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-slate-50 bg-white w-full">Tolak</button>
+            <button type="button" id="approvalPrimaryAction" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-slate-50 bg-white w-full">Setujui</button>
           </div>
         </div>
       </div>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -373,11 +373,11 @@ function setApprovalPrimaryEnabled(enabled) {
   approvalPrimaryAction.classList.toggle('cursor-not-allowed', !enabled);
   approvalPrimaryAction.classList.toggle('opacity-50', !enabled);
   if (enabled) {
-    approvalPrimaryAction.classList.add('bg-cyan-500', 'hover:bg-cyan-600', 'text-white');
-    approvalPrimaryAction.classList.remove('bg-slate-200', 'text-slate-400');
+    approvalPrimaryAction.classList.add('border-cyan-500', 'text-cyan-600');
+    approvalPrimaryAction.classList.remove('border-slate-200', 'text-slate-400', 'bg-slate-200', 'text-white', 'bg-cyan-500', 'hover:bg-cyan-600');
   } else {
-    approvalPrimaryAction.classList.remove('bg-cyan-500', 'hover:bg-cyan-600', 'text-white');
-    approvalPrimaryAction.classList.add('bg-slate-200', 'text-slate-400');
+    approvalPrimaryAction.classList.remove('border-cyan-500', 'text-cyan-600', 'bg-cyan-500', 'hover:bg-cyan-600');
+    approvalPrimaryAction.classList.add('border-slate-200', 'text-slate-400');
   }
 }
 


### PR DESCRIPTION
## Summary
- set the sticky approval actions in the detail drawer to use the outline button styling
- update the button state toggling logic so enabling/disabling preserves the outline treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de4637055483309dd60bd740c05182