### PR TITLE
Adjust approval drawer actions

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -585,8 +585,18 @@
         </div>
 
         <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4 space-y-4">
-          <div class="flex items-center justify-between gap-4">
-            <button type="button" id="approvalOutlineAction" class="rounded-xl border border-cyan-500 px-6 py-2 font-semibold text-cyan-600 transition hover:bg-slate-50 bg-white w-full">Tolak</button>
+          <div class="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              id="approvalOutlineAction"
+              class="rounded-xl border border-cyan-500 px-6 py-3 font-semibold text-cyan-600 transition hover:bg-slate-50 bg-white w-full"
+            >Batalkan</button>
+            <button
+              type="button"
+              id="approvalPrimaryAction"
+              data-variant="outline"
+              class="rounded-xl px-6 py-3 font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 w-full"
+            >Setujui</button>
           </div>
         </div>
       </div>

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -416,7 +416,7 @@ function setApprovalPrimaryEnabled(enabled) {
 
 function setApprovalButtonsToDefault() {
   if (approvalOutlineAction) {
-    approvalOutlineAction.textContent = 'Tolak';
+    approvalOutlineAction.textContent = 'Batalkan';
   }
   if (approvalPrimaryAction) {
     approvalPrimaryAction.textContent = 'Setujui';


### PR DESCRIPTION
## Summary
- add a dedicated primary action button in the approval drawer so both “Batalkan” and “Setujui” actions are visible before the OTP step
- update the drawer button labels to use “Batalkan” before and during the OTP flow while keeping the OTP verification state intact

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de51cd2c3483308a5d353df40178f5