### PR TITLE
Allow any OTP value during approval

### DIFF
--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -323,7 +323,6 @@ const APPROVAL_OTP_DURATION_SECONDS = 30;
 const APPROVAL_OTP_DEFAULT_COUNTDOWN_MESSAGE =
   approvalOtpCountdownMessage?.textContent?.trim() || 'Sesi akan berakhir dalam';
 const APPROVAL_OTP_EXPIRED_MESSAGE = 'Kode verifikasi kedaluwarsa. Silakan kirim ulang kode untuk melanjutkan.';
-const APPROVAL_VALID_OTP = '29042404';
 
 const approvalFlowState = {
   currentAction: null,
@@ -592,14 +591,6 @@ function handleApprovalVerify() {
     setApprovalPrimaryEnabled(false);
     return;
   }
-  if (otpValue !== APPROVAL_VALID_OTP) {
-    showApprovalOtpError('Kode verifikasi salah. Silakan coba lagi.');
-    resetApprovalOtpInputs();
-    setApprovalPrimaryEnabled(false);
-    approvalOtpInputs[0]?.focus();
-    return;
-  }
-
   hideApprovalOtpError();
   clearApprovalOtpInterval();
   approvalFlowState.otpActive = false;


### PR DESCRIPTION
## Summary
- remove the fixed OTP constant and its validation check
- allow the approval flow to continue once all OTP inputs are filled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de60eb2778833085e7ae32f7cb1bc4