### PR TITLE
Update transaction approval drawer actions per tab

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -532,7 +532,7 @@
             <div id="detailPaneHost" class="space-y-6"></div>
           </div>
 
-          <div class="px-4 pb-8 space-y-8">
+          <div class="px-6 pb-8 space-y-8">
             <section class="space-y-3">
               <p class=" font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">PEMBUAT PERMINTAAN</p>
               <div class="space-y-3 text-sm">
@@ -584,13 +584,13 @@
           </div>
         </div>
 
-        <div class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4 space-y-4">
+        <section id="approvalActions" class="sticky bottom-0 left-0 right-0 border-t border-slate-200 bg-white px-6 py-4 space-y-4">
           <div class="flex flex-col gap-3 sm:flex-row">
             <button
               type="button"
               id="approvalOutlineAction"
               class="rounded-xl border border-cyan-500 px-6 py-3 font-semibold text-cyan-600 transition hover:bg-slate-50 bg-white w-full"
-            >Batalkan</button>
+            >Tolak</button>
             <button
               type="button"
               id="approvalPrimaryAction"
@@ -598,7 +598,7 @@
               class="rounded-xl px-6 py-3 font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-0 w-full"
             >Setujui</button>
           </div>
-        </div>
+        </section>
       </div>
     </div>
 

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -322,6 +322,7 @@ const successDrawerController =
 
 const approvalOutlineAction = document.getElementById('approvalOutlineAction');
 const approvalPrimaryAction = document.getElementById('approvalPrimaryAction');
+const approvalActionsSection = document.getElementById('approvalActions');
 const approvalOtpSection = document.getElementById('approvalOtpSection');
 const approvalOtpInputs = approvalOtpSection ? Array.from(approvalOtpSection.querySelectorAll('.otp-input')) : [];
 const approvalOtpCountdown = document.getElementById('approvalOtpCountdown');
@@ -426,7 +427,7 @@ function setApprovalPrimaryEnabled(enabled) {
 
 function setApprovalButtonsToDefault() {
   if (approvalOutlineAction) {
-    approvalOutlineAction.textContent = 'Batalkan';
+    approvalOutlineAction.textContent = 'Tolak';
   }
   if (approvalPrimaryAction) {
     approvalPrimaryAction.textContent = 'Setujui';
@@ -628,6 +629,21 @@ async function handleApprovalVerify() {
 function resetApprovalFlowState() {
   resetApprovalOtpState();
   approvalFlowState.resultMode = false;
+}
+
+function updateDrawerActionsVisibility(tab) {
+  if (!approvalActionsSection) {
+    return;
+  }
+
+  const showActions = tab === 'butuh';
+  approvalActionsSection.classList.toggle('hidden', !showActions);
+
+  if (!showActions) {
+    resetApprovalFlowState();
+  } else {
+    setApprovalButtonsToDefault();
+  }
 }
 
 function mutateApprovalDataAfterDecision(itemId, action) {
@@ -863,6 +879,9 @@ if (approvalOtpResend) {
 
 if (approvalOutlineAction) {
   approvalOutlineAction.addEventListener('click', () => {
+    if (approvalActionsSection && approvalActionsSection.classList.contains('hidden')) {
+      return;
+    }
     if (approvalFlowState.resultMode) {
       closeDetailDrawer({ trigger: 'approval-result-back' });
       return;
@@ -877,6 +896,9 @@ if (approvalOutlineAction) {
 
 if (approvalPrimaryAction) {
   approvalPrimaryAction.addEventListener('click', () => {
+    if (approvalActionsSection && approvalActionsSection.classList.contains('hidden')) {
+      return;
+    }
     if (approvalFlowState.resultMode) {
       closeDetailDrawer({ trigger: 'approval-result-close' });
       return;
@@ -1664,6 +1686,8 @@ async function renderDetailPane(item) {
   if (!paneHost) return;
 
   resetApprovalFlowState();
+
+  updateDrawerActionsVisibility(activeTab);
 
   paneHost.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- ensure the drawer content spacing matches the rest of the layout and rename the reject button to “Tolak”
- hide the sticky action section when viewing Menunggu or Selesai items and guard the related event handlers

## Testing
- browser_container.run_playwright_script (capture drawer layout screenshot)
- browser_container.run_playwright_script (verify drawer actions hidden for Menunggu/Selesai)


------
https://chatgpt.com/codex/tasks/task_e_68df542013488330b3690157eb6215a4