### PR TITLE
Adjust transfer card grid when drawer opens

### DIFF
--- a/transfer.js
+++ b/transfer.js
@@ -17,12 +17,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const initialPaneParam = (document.documentElement.dataset.transferInitialPane || searchParams.get('pane') || '').toLowerCase();
   const embeddedInitialPane = initialPaneParam === 'move' ? 'move' : 'transfer';
 
+  function isDrawerOpen() {
+    if (drawerController && typeof drawerController.isOpen === 'function') {
+      return drawerController.isOpen();
+    }
+    return drawer?.classList.contains('open') || false;
+  }
+
   function updateCardGridLayout() {
-    // Maintain a consistent card layout regardless of drawer state so cards
-    // stay in place when the column configuration would previously change.
     if (!cardGrid) return;
-    cardGrid.classList.add('md:grid-cols-3');
-    cardGrid.classList.remove('md:grid-cols-2');
+    const drawerOpen = isDrawerOpen();
+    cardGrid.classList.toggle('md:grid-cols-2', drawerOpen);
+    cardGrid.classList.toggle('md:grid-cols-3', !drawerOpen);
+  }
+
+  if (drawerController) {
+    drawerController.onOpen(() => updateCardGridLayout());
+    drawerController.onClose(() => updateCardGridLayout());
+  } else if (drawer) {
+    drawer.addEventListener('drawer:open', updateCardGridLayout);
+    drawer.addEventListener('drawer:close', updateCardGridLayout);
   }
 
   updateCardGridLayout();


### PR DESCRIPTION
## Summary
- update the transfer activity card grid to switch between two and three columns based on drawer state
- hook into drawer open and close events so layout stays in sync with manual or managed drawer controls

## Testing
- Manual confirmation in browser

------
https://chatgpt.com/codex/tasks/task_e_68df6c29cc48833092cf98b391cd4e9d