### PR TITLE
Align approval table column widths

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -167,8 +167,8 @@
           <div class="flex items-center justify-between gap-3">
           </div>
 
-          <div class="rounded-2xl border border-slate-200 bg-white overflow-hidden">
-            <div class="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto] items-center gap-4 bg-[#F8F8F8] px-6 py-3 text-sm font-semibold text-slate-700">
+          <div class="approval-table approval-table--with-action rounded-2xl border border-slate-200 bg-white overflow-hidden">
+            <div class="approval-table-row items-center gap-4 bg-[#F8F8F8] px-6 py-3 text-sm font-semibold text-slate-700">
               <span class="text-left">Nominal Transaksi</span>
               <span class="text-center">Jumlah Persetujuan</span>
               <span class="text-right"></span>
@@ -288,8 +288,8 @@
 
               <section class="space-y-4">
                 <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">DAFTAR PERSETUJUAN TRANSFER</p>
-                <div class="rounded-2xl border border-slate-200 overflow-hidden p-4">
-                  <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 bg-slate-50 px-4 py-3 text-xs font-semibold tracking-[.12em] text-slate-500">
+                <div class="approval-table approval-table--two-columns rounded-2xl border border-slate-200 overflow-hidden p-4">
+                  <div class="approval-table-row items-center gap-4 bg-slate-50 px-4 py-3 text-xs font-semibold tracking-[.12em] text-slate-500">
                     <span class="text-left">Nominal Transaksi</span>
                     <span class="text-right">Jumlah Persetujuan</span>
                   </div>
@@ -362,8 +362,8 @@
 
             <section class="space-y-4">
               <p class="font-semibold text-slate-500 uppercase tracking-[.18em] mb-4 bg-slate-100 p-2">DAFTAR PERSETUJUAN TRANSFER</p>
-              <div class="rounded-2xl border border-slate-200 overflow-hidden p-4">
-                <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 bg-slate-50 px-5 py-3 text-[13px] font-semibold tracking-[.16em] text-slate-500">
+              <div class="approval-table approval-table--two-columns rounded-2xl border border-slate-200 overflow-hidden p-4">
+                <div class="approval-table-row items-center gap-4 bg-slate-50 px-5 py-3 text-[13px] font-semibold tracking-[.16em] text-slate-500">
                   <span class="text-left">Nominal Transaksi</span>
                   <span class="text-right">Jumlah Persetujuan</span>
                 </div>

--- a/atur-persetujuan.js
+++ b/atur-persetujuan.js
@@ -278,7 +278,7 @@
 
     state.tableRows.forEach((row) => {
       const container = document.createElement('div');
-      container.className = 'grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto] items-center gap-4 px-6 py-4';
+      container.className = 'approval-table-row items-center gap-4 px-6 py-4';
 
       const range = document.createElement('p');
       range.className = 'text-sm text-slate-700 text-left';
@@ -525,7 +525,7 @@
         const maxLabel = formatCurrency(entry.max);
         const approverLabel = formatApproverLabel(entry.approvers);
         return `
-          <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 min-h-[56px] px-4 py-4 text-sm">
+          <div class="approval-table-row items-center gap-4 min-h-[56px] px-4 py-4 text-sm">
             <span class="font-semibold text-slate-900">${minLabel} – ${maxLabel}</span>
             <span class="text-right text-sm font-semibold text-slate-700">${approverLabel}</span>
           </div>
@@ -551,7 +551,7 @@
         const maxLabel = formatCurrency(entry.max);
         const approverLabel = formatApproverLabel(entry.approvers);
         return `
-          <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 min-h-[56px] px-5 py-4 text-sm">
+          <div class="approval-table-row items-center gap-4 min-h-[56px] px-5 py-4 text-sm">
             <span class="font-semibold text-slate-900">${minLabel} – ${maxLabel}</span>
             <span class="text-right text-sm font-semibold text-slate-700">${approverLabel}</span>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,21 @@
 .sb-item{ height:48px; min-height:48px; align-items:center; position:relative; }
 .sb-item img{ display:block; } /* no baseline jitter */
 
+/* Approval tables shared layout */
+.approval-table{
+  --approval-table-columns:minmax(0,1fr) minmax(0,1fr);
+}
+.approval-table--with-action{
+  --approval-table-columns:minmax(0,1.5fr) minmax(0,1fr) auto;
+}
+.approval-table--two-columns{
+  --approval-table-columns:minmax(0,1.35fr) minmax(0,1fr);
+}
+.approval-table-row{
+  display:grid;
+  grid-template-columns:var(--approval-table-columns);
+}
+
 /* collapse behavior */
 #sidebar{ transition: width .25s ease; overflow:visible; }
 #sidebar.collapsed,


### PR DESCRIPTION
## Summary
- ensure approval tables share consistent column widths on the Atur Persetujuan page
- add shared CSS helpers so header and body rows align across main, confirmation, and pending tables

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e342f98e6883308fedc6bcec3c02b0