### PR TITLE
Align approval detail columns with approval-table layout

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -554,7 +554,14 @@
                 </div>
                 <span id="detailApprovalStatus" class="text-sm font-semibold text-slate-500">0/0</span>
               </div>
-              <ul id="detailApprovalList" class="space-y-3 border rounded-b-xl"></ul>
+              <div class="approval-table approval-table--with-action border border-t-0 border-slate-200 rounded-b-xl overflow-hidden">
+                <div class="approval-table-row items-center gap-4 bg-slate-50 px-6 py-3 text-xs font-semibold tracking-[.12em] text-slate-500 uppercase">
+                  <span class="text-left">Tahap Persetujuan</span>
+                  <span class="text-left">Penyetuju</span>
+                  <span class="text-right">Status</span>
+                </div>
+                <div id="detailApprovalList" class="divide-y divide-slate-100"></div>
+              </div>
             </section>
 
             <section id="approvalOtpSection" class="hidden border-t border-slate-200 p-4 space-y-4">

--- a/persetujuan-transaksi.js
+++ b/persetujuan-transaksi.js
@@ -1425,24 +1425,33 @@ function renderApprovalList(listElement, steps) {
   listElement.innerHTML = '';
 
   if (!Array.isArray(steps) || steps.length === 0) {
-    const emptyItem = document.createElement('li');
-    emptyItem.className = 'text-sm text-slate-500';
-    emptyItem.textContent = 'Belum ada daftar persetujuan.';
-    listElement.appendChild(emptyItem);
+    const emptyState = document.createElement('div');
+    emptyState.className = 'px-6 py-10 text-center text-sm text-slate-500';
+    emptyState.textContent = 'Belum ada daftar persetujuan.';
+    listElement.appendChild(emptyState);
     return;
   }
 
   steps.forEach(step => {
-    const item = document.createElement('li');
-    item.className = 'p-4';
+    const row = document.createElement('div');
+    row.className = 'approval-table-row items-center gap-4 px-6 py-4 text-sm';
 
-    const content = document.createElement('div');
-    content.className = 'flex items-center gap-3';
+    const stageWrap = document.createElement('div');
+    stageWrap.className = 'flex flex-col gap-1';
 
-    const badge = document.createElement('span');
-    badge.className = 'inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700';
-    badge.setAttribute('aria-label', 'Menunggu persetujuan');
-    badge.innerHTML = `
+    const label = document.createElement('span');
+    label.className = 'text-sm font-semibold text-slate-900';
+    label.textContent = (step && step.label) || 'Approval';
+    stageWrap.appendChild(label);
+
+    const approver = document.createElement('span');
+    approver.className = 'text-sm font-semibold text-slate-700';
+    approver.textContent = (step && step.approver) || '-';
+
+    const status = document.createElement('span');
+    status.className = 'inline-flex items-center justify-self-end gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700';
+    status.setAttribute('aria-label', 'Menunggu persetujuan');
+    status.innerHTML = `
       <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <circle cx="10" cy="10" r="7" stroke="#F97316" stroke-width="1.5"></circle>
         <path d="M10 6.5V10.25L12.5 11.75" stroke="#F97316" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
@@ -1450,21 +1459,11 @@ function renderApprovalList(listElement, steps) {
       <span>Menunggu</span>
     `;
 
-    const textWrap = document.createElement('div');
-    textWrap.className = 'flex flex-col';
+    row.appendChild(stageWrap);
+    row.appendChild(approver);
+    row.appendChild(status);
 
-    const label = document.createElement('span');
-    label.className = 'text-sm font-semibold text-slate-900';
-    label.textContent = (step && step.label) || 'Approval';
-
-    textWrap.appendChild(label);
-
-    content.appendChild(badge);
-    content.appendChild(textWrap);
-
-    item.appendChild(content);
-
-    listElement.appendChild(item);
+    listElement.appendChild(row);
   });
 }
 


### PR DESCRIPTION
## Summary
- wrap the approval detail list in an approval-table container with a dedicated header so columns stay aligned
- update the approval list renderer to output grid-based rows that surface the approver name and status badge consistently

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3474bca288330b544c8ae8a67729b