### PR TITLE
Add Giro detail drawer to Informasi Rekening page

### DIFF
--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -397,6 +397,157 @@
     </div>
 
     <div
+      id="accountDetailPane"
+      class="hidden h-full flex flex-col bg-white"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="accountDetailTitle"
+      aria-hidden="true"
+    >
+      <div class="sticky top-0 z-20 flex items-center justify-between p-6 pb-4 border-b border-slate-200 bg-white">
+        <h2 id="accountDetailTitle" class="text-lg font-semibold text-slate-900">Detail Rekening</h2>
+        <button
+          type="button"
+          class="w-10 h-10 inline-flex items-center justify-center rounded-full border border-slate-200 text-slate-500 hover:text-slate-700 hover:border-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1"
+          data-account-detail-close
+          data-account-detail-focus
+          aria-label="Tutup detail rekening"
+        >
+          <svg class="w-4 h-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto p-6 space-y-6" data-account-detail-scroll>
+        <section class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6 space-y-6">
+          <div class="flex items-start gap-4">
+            <span
+              id="accountDetailAvatar"
+              class="w-12 h-12 rounded-full grid place-items-center bg-cyan-600 text-white text-lg font-semibold"
+              aria-hidden="true"
+            >
+              O
+            </span>
+            <div class="flex-1 min-w-0">
+              <p id="accountDetailName" class="text-base font-semibold text-slate-900">Operasional</p>
+              <div class="mt-3">
+                <p class="text-xs font-medium uppercase tracking-[0.18em] text-slate-400">Nomor Rekening</p>
+                <div class="mt-1 flex items-center gap-2">
+                  <p id="accountDetailNumber" class="text-sm font-semibold text-slate-900 tracking-wide break-all">0009 6789 5439</p>
+                  <button
+                    type="button"
+                    id="accountDetailCopyBtn"
+                    class="inline-flex items-center justify-center rounded-full border border-slate-200 p-2 text-slate-500 hover:text-cyan-600 hover:border-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1"
+                    aria-label="Salin nomor rekening"
+                  >
+                    <img src="img/icon/copy.svg" alt="" class="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="pt-4 border-t border-slate-200">
+            <div class="flex items-center gap-2 text-sm text-slate-500">
+              <span>Saldo Aktif</span>
+              <span class="inline-flex items-center" title="Saldo yang dapat digunakan">
+                <img src="img/icon/info.svg" alt="Informasi saldo aktif" class="w-4 h-4" />
+              </span>
+            </div>
+            <p id="accountDetailActiveBalance" class="mt-2 text-2xl font-bold text-slate-900 tracking-tight">Rp1.000.000.000.000,00</p>
+          </div>
+
+          <div class="border-t border-slate-200 pt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <div class="flex items-center gap-2 text-sm text-slate-500">
+                <span>Total Saldo Tertahan</span>
+                <span class="inline-flex items-center" title="Saldo yang belum dapat digunakan">
+                  <img src="img/icon/info.svg" alt="Informasi saldo tertahan" class="w-4 h-4" />
+                </span>
+              </div>
+              <p id="accountDetailHeldBalance" class="mt-1 text-base font-semibold text-slate-900">Rp1.000.000,00</p>
+            </div>
+            <div>
+              <div class="flex items-center gap-2 text-sm text-slate-500">
+                <span>Total Saldo</span>
+                <span class="inline-flex items-center" title="Jumlah seluruh saldo">
+                  <img src="img/icon/info.svg" alt="Informasi total saldo" class="w-4 h-4" />
+                </span>
+              </div>
+              <p id="accountDetailTotalBalance" class="mt-1 text-base font-semibold text-slate-900">Rp1.001.000.000,00</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-white">
+          <button
+            type="button"
+            id="accountDetailSpecToggle"
+            class="flex w-full items-center justify-between gap-3 p-6 text-left"
+            aria-expanded="true"
+          >
+            <span class="text-base font-semibold text-slate-900">Spesifikasi GIRO</span>
+            <svg
+              class="h-5 w-5 text-slate-500 transition-transform duration-200"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              data-chevron
+              aria-hidden="true"
+            >
+              <path d="m6 9 6 6 6-6"></path>
+            </svg>
+          </button>
+          <div
+            id="accountDetailSpecContent"
+            class="border-t border-slate-200"
+            data-expanded="true"
+            aria-hidden="false"
+          >
+            <dl id="accountDetailSpecList" class="divide-y divide-slate-200">
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Setoran Awal</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp1.000.000,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Saldo Minimum Mengendap</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp1.000.000,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Admin Bulanan</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp30.000,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Setoran Kliring</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp2.000,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Admin Bulanan di Rekening Pasif</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp500,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Admin Bulanan di Rekening di bawah Saldo Minimum</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp1.000,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Admin 3 Bulan di bawah Saldo Minimum</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp500,-</dd>
+              </div>
+              <div class="flex items-start justify-between gap-6 py-4 px-6">
+                <dt class="text-sm text-slate-500">Biaya Penutupan Rekening</dt>
+                <dd class="text-sm font-semibold text-slate-900">Rp55.000,-</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <div
       id="pendingApprovalPane"
       class="hidden h-full flex flex-col bg-white"
       role="dialog"


### PR DESCRIPTION
## Summary
- add the Detail Rekening drawer markup with account summary, saldo overview, and Giro specification list on informasi-rekening.html
- wire up drawer logic to populate account details, manage accordion state, copy actions, and focus handling in informasi-rekening.js
- replace the card "Lihat Detail" link with a button that opens the drawer and keeps the view in sync when account data changes

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e35eadd06083308ce62374b8db564c