### PR TITLE
Remove header user identity block outside dashboard

### DIFF
--- a/atur-persetujuan.html
+++ b/atur-persetujuan.html
@@ -129,10 +129,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Atur Persetujuan</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/batas-transaksi.html
+++ b/batas-transaksi.html
@@ -129,10 +129,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Batas Transaksi</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/biller.html
+++ b/biller.html
@@ -130,10 +130,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Beli &amp; Bayar </h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/informasi-rekening.html
+++ b/informasi-rekening.html
@@ -132,10 +132,10 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Informasi Rekening</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
+            <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
+              <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />
+              <span class="text-slate-700 font-medium">Bantuan</span>
+            </button>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2" data-logout-button>
               <img src="img/dashboard/keluar.svg" alt="Keluar" class="w-5 h-5 object-contain" />
               <span class="text-slate-700 font-medium">Keluar</span>

--- a/manajemen-pengguna.html
+++ b/manajemen-pengguna.html
@@ -129,10 +129,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Manajemen Pengguna</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/mutasi.html
+++ b/mutasi.html
@@ -131,10 +131,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Mutasi Rekening &amp; e-Statement </h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -133,10 +133,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Menunggu Persetujuan</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />

--- a/transfer.html
+++ b/transfer.html
@@ -145,10 +145,6 @@
               <h1 class="text-[24px] leading-none tracking-tight font-semibold">Transfer</h1>
           </div>
           <div class="flex items-center gap-2">
-            <div class="hidden sm:flex items-center gap-2 pr-3 mr-2 border-r border-slate-200">
-              <div class="w-10 h-10 rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold" data-user-initials>RC</div>
-              <span class="font-semibold text-slate-700" data-user-name>Ramero Carlo</span>
-            </div>
             <button class="px-4 py-2 rounded-xl border text-base bg-white hover:bg-slate-50 flex items-center gap-2">
               <!-- bell icon -->
               <img src="img/dashboard/bantuan.svg" alt="Notifikasi" class="w-5 h-5 object-contain" />


### PR DESCRIPTION
## Summary
- remove the user initials/name block from non-dashboard headers
- keep the Bantuan and Keluar actions as the only header controls on those pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37714d5f08330897dd8d805cefa00