### PR TITLE
Align table headers across approval tabs

### DIFF
--- a/persetujuan-transaksi.html
+++ b/persetujuan-transaksi.html
@@ -285,7 +285,6 @@
                 <tr>
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
-                  <th class="text-left px-4 py-3 font-medium">Status</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
                   <th class="px-4 py-3"></th>
                 </tr>
@@ -403,7 +402,6 @@
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
-                  <th class="text-left px-4 py-3 font-medium">Status</th>
                   <th class="px-4 py-3"></th>
                 </tr>
               </thead>
@@ -520,6 +518,7 @@
                   <th class="text-left px-4 py-3 font-medium">Waktu Permintaan</th>
                   <th class="text-left px-4 py-3 font-medium">Kategori</th>
                   <th class="text-left px-4 py-3 font-medium">Deskripsi</th>
+                  <th class="text-left px-4 py-3 font-medium">Status</th>
                   <th class="px-4 py-3"></th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- remove the status column from the "Butuh Persetujuan" and "Menunggu Persetujuan" tables so their headers match the data shown
- add the missing status column to the "Selesai" table so it displays the status badge provided by the script

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f87abe28bc83309e6cbcb760b20b53